### PR TITLE
feat: fetch new snapshots

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
 
 name: Release and publish NPM package
 jobs:

--- a/etc/snapshots-fetcher.api.md
+++ b/etc/snapshots-fetcher.api.md
@@ -20,6 +20,11 @@ export function createCatalystDeploymentStream(components: SnapshotsFetcherCompo
     deployer: IDeployerComponent;
 }, options: CatalystDeploymentStreamOptions): IJobWithLifecycle & CatalystDeploymentStreamComponent;
 
+// Warning: (ae-forgotten-export) The symbol "IProcessedSnapshotsComponent" needs to be exported by the entry point index.d.ts
+//
+// @public
+export function createProcessedSnapshotsComponent(components: Pick<SnapshotsFetcherComponents, 'processedSnapshotStorage' | 'logs'>): IProcessedSnapshotsComponent;
+
 // Warning: (ae-forgotten-export) The symbol "EntityHash" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "Server" needs to be exported by the entry point index.d.ts
 //
@@ -29,11 +34,15 @@ export function downloadEntityAndContentFiles(components: Pick<SnapshotsFetcherC
 // Warning: (ae-forgotten-export) The symbol "DeployedEntityStreamOptions" needs to be exported by the entry point index.d.ts
 //
 // @public
-export function getDeployedEntitiesStream(components: SnapshotsFetcherComponents, options: DeployedEntityStreamOptions): AsyncIterable<DeploymentWithAuthChain>;
+export function getDeployedEntitiesStream(components: SnapshotsFetcherComponents, options: DeployedEntityStreamOptions): AsyncIterable<DeploymentWithAuthChain & {
+    snapshotHash?: string;
+}>;
 
 // @public
 export type IDeployerComponent = {
-    deployEntity(entity: DeploymentWithAuthChain, contentServers: string[]): Promise<void>;
+    deployEntity(entity: DeploymentWithAuthChain & {
+        snapshotHash?: string;
+    }, contentServers: string[]): Promise<void>;
     onIdle(): Promise<void>;
 };
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,15 +14,15 @@ export async function getSnapshots(components: SnapshotsFetcherComponents, serve
     // TODO: validate response
     const newSnapshots: {
       hash: string,
-      timeRange: { initTimestampSecs: number, endTimestampSecs: number },
+      timeRange: { initTimestamp: number, endTimestamp: number },
       replacedSnapshotHashes?: string[]
     }[] = await components.downloadQueue.scheduleJobWithRetries(() => fetchJson(incrementalSnapshotsUrl, components.fetcher), 1)
     return newSnapshots
       // newest first
-      .sort((s1, s2) => s2.timeRange.endTimestampSecs - s1.timeRange.endTimestampSecs)
+      .sort((s1, s2) => s2.timeRange.endTimestamp - s1.timeRange.endTimestamp)
       .map(newSnapshot => ({
         hash: newSnapshot.hash,
-        lastIncludedDeploymentTimestamp: newSnapshot.timeRange.endTimestampSecs,
+        lastIncludedDeploymentTimestamp: newSnapshot.timeRange.endTimestamp,
         replacedSnapshotHashes: newSnapshot.replacedSnapshotHashes
       }))
   } catch {

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,7 @@ import { metricsDefinitions } from './metrics'
 import { SnapshotsFetcherComponents } from './types'
 import { contentServerMetricLabels, fetchJson, saveContentFileToDisk as saveContentFile } from './utils'
 
-export async function getGlobalSnapshot(components: SnapshotsFetcherComponents, server: string, retries: number):
+export async function getGlobalSnapshots(components: SnapshotsFetcherComponents, server: string, retries: number):
   Promise<{
     hash: string,
     lastIncludedDeploymentTimestamp: number

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,9 +25,9 @@ export async function getSnapshots(components: SnapshotsFetcherComponents, serve
         lastIncludedDeploymentTimestamp: newSnapshot.timeRange.endTimestamp,
         replacedSnapshotHashes: newSnapshot.replacedSnapshotHashes
       }))
-  } catch {
+  } catch (error) {
     components.logs.getLogger('snapshots-fetcher')
-      .info(`Error fetching new snapshots from ${server}. Will continue to fetch old one.`)
+      .info(`Error fetching new snapshots from ${server}. Will continue to fetch old one. Error: ${error}`)
   }
 
   const globalSnapshotUrl = new URL(`${server}/snapshot`).toString()

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,7 @@ export async function* getDeployedEntitiesStream(
       ? lastIncludedDeploymentTimestamp : greatestProcessedTimestamp
   }
 
-  logs.info(`End processing snapshots. Greatest processed timestamp: ${greatestProcessedTimestamp}`)
+  logs.info(`End processing snapshots.`, { greatestProcessedTimestamp })
   // 3. fetch the /pointer-changes of the remote server using the last timestamp from the previous step
   do {
     // 3.1. download pointer changes and yield

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,8 +195,11 @@ export async function* getDeployedEntitiesStream(
         }
       }
     }
+    console.log(`lastIncludedDeploymentTimestamp: ${lastIncludedDeploymentTimestamp}`)
+    console.log(`greatestProcessedTimestamp: ${greatestProcessedTimestamp}`)
     greatestProcessedTimestamp = lastIncludedDeploymentTimestamp > greatestProcessedTimestamp
       ? lastIncludedDeploymentTimestamp : greatestProcessedTimestamp
+    console.log(`greatestProcessedTimestamp: ${greatestProcessedTimestamp}`)
   }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ export async function* getDeployedEntitiesStream(
 
   for (const snapshot of snapshots) {
     const { hash, lastIncludedDeploymentTimestamp, replacedSnapshotHashes } = snapshot
-    logs.debug(`Processing snapshot: ${snapshot.hash} from ${options.contentServer}`)
+    logs.debug(`Processing snapshot`, { contentServer: options.contentServer, hash: snapshot.hash })
     // 2. for each snapshot, download the snapshot file if it contains deployments
     //    in the range we are interested (>= genesisTimestamp)
     if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,12 +150,12 @@ export async function* getDeployedEntitiesStream(
   )
 
   for (const snapshot of snapshots) {
-    const { hash, lastIncludedDeploymentTimestamp } = snapshot
+    const { hash, lastIncludedDeploymentTimestamp, replacedSnapshotHashes } = snapshot
     // 2. for each snapshot, download the snapshot file if it contains deployments
     //    in the range we are interested (>= genesisTimestamp)
     if (
       hash && lastIncludedDeploymentTimestamp && lastIncludedDeploymentTimestamp > genesisTimestamp &&
-      !(await components.processedSnapshotStorage.wasSnapshotProcessed(hash))) {
+      !(await components.processedSnapshotStorage.wasSnapshotProcessed(hash, replacedSnapshotHashes))) {
       try {
         // 2.1. download the snapshot file if needed
         await downloadFileWithRetries(

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,7 @@ export async function* getDeployedEntitiesStream(
             greatestProcessedTimestamp = deployment.localTimestamp
           }
         }
+        await components.snapshotProcessEndTask.onSnapshotSuccessfullyProcessed(hash)
       } finally {
         if (options.deleteSnapshotAfterUsage !== false) {
           try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,9 +154,13 @@ export async function* getDeployedEntitiesStream(
     logs.debug(`Processing snapshot`, { contentServer: options.contentServer, hash: snapshot.hash })
     // 2. for each snapshot, download the snapshot file if it contains deployments
     //    in the range we are interested (>= genesisTimestamp)
-    if (
-      hash && lastIncludedDeploymentTimestamp && lastIncludedDeploymentTimestamp > genesisTimestamp &&
-      !(await components.processedSnapshotStorage.wasSnapshotProcessed(hash, replacedSnapshotHashes))) {
+    const snapshotShouldBeProcessed =
+      hash &&
+      lastIncludedDeploymentTimestamp &&
+      lastIncludedDeploymentTimestamp > genesisTimestamp &&
+      !(await components.processedSnapshotStorage.wasSnapshotProcessed(hash, replacedSnapshotHashes))
+
+    if (snapshotShouldBeProcessed) {
       try {
         // 2.1. download the snapshot file if needed
         await downloadFileWithRetries(

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,7 @@ export async function* getDeployedEntitiesStream(
   )
 
   for (const snapshot of snapshots) {
+    console.log(`processing snapshot: ${JSON.stringify(snapshot)}`)
     const { hash, lastIncludedDeploymentTimestamp, replacedSnapshotHashes } = snapshot
     // 2. for each snapshot, download the snapshot file if it contains deployments
     //    in the range we are interested (>= genesisTimestamp)
@@ -200,6 +201,7 @@ export async function* getDeployedEntitiesStream(
   // 3. fetch the /pointer-changes of the remote server using the last timestamp from the previous step
   do {
     // 3.1. download pointer changes and yield
+    console.log(`asking pointer changes to ${options.contentServer} after timestap: ${greatestProcessedTimestamp}`)
     const pointerChanges = fetchPointerChanges(components, options.contentServer, greatestProcessedTimestamp)
     for await (const rawDeployment of pointerChanges) {
       const deployment = coerceEntityDeployment(rawDeployment)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { DeploymentWithAuthChain } from '@dcl/schemas'
-import { fetchPointerChanges, getGlobalSnapshots } from './client'
+import { fetchPointerChanges, getSnapshots } from './client'
 import { downloadFileWithRetries } from './downloader'
 import { createExponentialFallofRetry } from './exponential-fallof-retry'
 import { processDeploymentsInFile } from './file-processor'
@@ -143,7 +143,7 @@ export async function* getDeployedEntitiesStream(
   const metricLabels = contentServerMetricLabels(options.contentServer)
 
   // 1. get the hashes of the latest snapshots in the remote server, retry 10 times
-  const snapshots = await getGlobalSnapshots(
+  const snapshots = await getSnapshots(
     components,
     options.contentServer,
     options.requestMaxRetries

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,8 +150,8 @@ export async function* getDeployedEntitiesStream(
   )
 
   for (const snapshot of snapshots) {
-    console.log(`processing snapshot: ${JSON.stringify(snapshot)}`)
     const { hash, lastIncludedDeploymentTimestamp, replacedSnapshotHashes } = snapshot
+    logs.debug(`Processing snapshot: ${snapshot.hash} from ${options.contentServer}`)
     // 2. for each snapshot, download the snapshot file if it contains deployments
     //    in the range we are interested (>= genesisTimestamp)
     if (
@@ -195,18 +195,14 @@ export async function* getDeployedEntitiesStream(
         }
       }
     }
-    console.log(`lastIncludedDeploymentTimestamp: ${lastIncludedDeploymentTimestamp}`)
-    console.log(`greatestProcessedTimestamp: ${greatestProcessedTimestamp}`)
     greatestProcessedTimestamp = lastIncludedDeploymentTimestamp > greatestProcessedTimestamp
       ? lastIncludedDeploymentTimestamp : greatestProcessedTimestamp
-    console.log(`greatestProcessedTimestamp: ${greatestProcessedTimestamp}`)
   }
 
-
+  logs.info(`End processing snapshots. Greatest processed timestamp: ${greatestProcessedTimestamp}`)
   // 3. fetch the /pointer-changes of the remote server using the last timestamp from the previous step
   do {
     // 3.1. download pointer changes and yield
-    console.log(`asking pointer changes to ${options.contentServer} after timestap: ${greatestProcessedTimestamp}`)
     const pointerChanges = fetchPointerChanges(components, options.contentServer, greatestProcessedTimestamp)
     for await (const rawDeployment of pointerChanges) {
       const deployment = coerceEntityDeployment(rawDeployment)

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,8 @@ export async function* getDeployedEntitiesStream(
         }
       }
     }
+    greatestProcessedTimestamp = lastIncludedDeploymentTimestamp > greatestProcessedTimestamp
+      ? lastIncludedDeploymentTimestamp : greatestProcessedTimestamp
   }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { DeploymentWithAuthChain } from '@dcl/schemas'
-import { fetchPointerChanges, getGlobalSnapshot } from './client'
+import { fetchPointerChanges, getGlobalSnapshots } from './client'
 import { downloadFileWithRetries } from './downloader'
 import { createExponentialFallofRetry } from './exponential-fallof-retry'
 import { processDeploymentsInFile } from './file-processor'
@@ -143,7 +143,7 @@ export async function* getDeployedEntitiesStream(
   const metricLabels = contentServerMetricLabels(options.contentServer)
 
   // 1. get the hashes of the latest snapshots in the remote server, retry 10 times
-  const snapshots = await getGlobalSnapshot(
+  const snapshots = await getGlobalSnapshots(
     components,
     options.contentServer,
     options.requestMaxRetries

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ export async function* getDeployedEntitiesStream(
     //    in the range we are interested (>= genesisTimestamp)
     if (
       hash && lastIncludedDeploymentTimestamp && lastIncludedDeploymentTimestamp > genesisTimestamp &&
-      !(await components.snapshotProcessEndTask.wasSnapshotProcessed(hash))) {
+      !(await components.processedSnapshotStorage.wasSnapshotProcessed(hash))) {
       try {
         // 2.1. download the snapshot file if needed
         await downloadFileWithRetries(
@@ -183,7 +183,7 @@ export async function* getDeployedEntitiesStream(
             greatestProcessedTimestamp = deployment.localTimestamp
           }
         }
-        await components.snapshotProcessEndTask.markSnapshotProcessed(hash)
+        await components.processedSnapshotStorage.markSnapshotProcessed(hash)
       } finally {
         if (options.deleteSnapshotAfterUsage !== false) {
           try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,7 +183,7 @@ export async function* getDeployedEntitiesStream(
             greatestProcessedTimestamp = deployment.localTimestamp
           }
         }
-        await components.processedSnapshotStorage.markSnapshotProcessed(hash)
+        await components.processedSnapshotStorage.markSnapshotProcessed(hash, replacedSnapshotHashes)
       } finally {
         if (options.deleteSnapshotAfterUsage !== false) {
           try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { coerceEntityDeployment, contentServerMetricLabels, sleep, streamToBuffe
 
 export { metricsDefinitions } from './metrics'
 export { IDeployerComponent } from './types'
+export { createProcessedSnapshotsComponent } from './processed-snapshots'
 
 if (parseInt(process.version.split('.')[0]) < 16) {
   const { name } = require('../package.json')
@@ -158,7 +159,7 @@ export async function downloadEntityAndContentFiles(
 export async function* getDeployedEntitiesStream(
   components: SnapshotsFetcherComponents,
   options: DeployedEntityStreamOptions
-): AsyncIterable<DeploymentWithAuthChain> {
+): AsyncIterable<DeploymentWithAuthChain & { snapshotHash?: string }> {
   const logs = components.logs.getLogger(`getDeployedEntitiesStream(${options.contentServer})`)
   // the minimum timestamp we are looking for
   const genesisTimestamp = options.fromTimestamp || 0
@@ -177,16 +178,16 @@ export async function* getDeployedEntitiesStream(
 
   for (const snapshot of snapshots) {
     const { hash, lastIncludedDeploymentTimestamp, replacedSnapshotHashes } = snapshot
-    logs.debug(`Processing snapshot`, { contentServer: options.contentServer, hash: snapshot.hash })
+    logs.debug('Snapshot found.', { contentServer: options.contentServer, hash: snapshot.hash })
     // 2. for each snapshot, download the snapshot file if it contains deployments
     //    in the range we are interested (>= genesisTimestamp)
-    const snapshotShouldBeProcessed =
+    const shouldStreamSnapshot =
       hash &&
       lastIncludedDeploymentTimestamp &&
       lastIncludedDeploymentTimestamp > genesisTimestamp &&
-      !(await components.processedSnapshotStorage.wasSnapshotProcessed(hash, replacedSnapshotHashes))
+      await components.processedSnapshots.shouldStream(hash, replacedSnapshotHashes)
 
-    if (snapshotShouldBeProcessed) {
+    if (shouldStreamSnapshot) {
       try {
         // 2.1. download the snapshot file if needed
         await downloadFileWithRetries(
@@ -201,20 +202,26 @@ export async function* getDeployedEntitiesStream(
 
         // 2.2. open the snapshot file and process line by line
         const deploymentsInFile = processDeploymentsInFile(hash, components)
+        components.processedSnapshots.startStreamOf(hash)
+        let numberOfStreamedEntities = 0
         for await (const rawDeployment of deploymentsInFile) {
           const deployment = coerceEntityDeployment(rawDeployment)
           if (!deployment) continue
           // selectively ignore deployments by localTimestamp
           if (deployment.localTimestamp >= genesisTimestamp) {
             components.metrics.increment('dcl_entities_deployments_processed_total', metricLabels)
-            yield deployment
+            numberOfStreamedEntities++
+            yield {
+              ...deployment,
+              snapshotHash: hash
+            }
           }
           // update greatest processed timestamp
           if (deployment.localTimestamp > greatestProcessedTimestamp) {
             greatestProcessedTimestamp = deployment.localTimestamp
           }
         }
-        await components.processedSnapshotStorage.markSnapshotProcessed(hash, replacedSnapshotHashes)
+        components.processedSnapshots.endStreamOf(hash, numberOfStreamedEntities)
       } finally {
         if (options.deleteSnapshotAfterUsage !== false) {
           try {
@@ -229,7 +236,7 @@ export async function* getDeployedEntitiesStream(
       ? lastIncludedDeploymentTimestamp : greatestProcessedTimestamp
   }
 
-  logs.info(`End processing snapshots.`, { greatestProcessedTimestamp })
+  logs.info('End streaming snapshots.', { greatestProcessedTimestamp })
   // 3. fetch the /pointer-changes of the remote server using the last timestamp from the previous step
   do {
     // 3.1. download pointer changes and yield

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,9 @@ export async function* getDeployedEntitiesStream(
     const { hash, lastIncludedDeploymentTimestamp } = snapshot
     // 2. for each snapshot, download the snapshot file if it contains deployments
     //    in the range we are interested (>= genesisTimestamp)
-    if (hash && lastIncludedDeploymentTimestamp && lastIncludedDeploymentTimestamp > genesisTimestamp) {
+    if (
+      hash && lastIncludedDeploymentTimestamp && lastIncludedDeploymentTimestamp > genesisTimestamp &&
+      !(await components.snapshotProcessEndTask.wasSnapshotProcessed(hash))) {
       try {
         // 2.1. download the snapshot file if needed
         await downloadFileWithRetries(
@@ -181,7 +183,7 @@ export async function* getDeployedEntitiesStream(
             greatestProcessedTimestamp = deployment.localTimestamp
           }
         }
-        await components.snapshotProcessEndTask.onSnapshotSuccessfullyProcessed(hash)
+        await components.snapshotProcessEndTask.markSnapshotProcessed(hash)
       } finally {
         if (options.deleteSnapshotAfterUsage !== false) {
           try {

--- a/src/processed-snapshots.ts
+++ b/src/processed-snapshots.ts
@@ -1,0 +1,52 @@
+import { IProcessedSnapshotsComponent, SnapshotsFetcherComponents } from "./types"
+
+/**
+ * Creates the component that signals the streaming and processing of a snapshot.
+ *
+ * @public
+ */
+export function createProcessedSnapshotsComponent(components: Pick<SnapshotsFetcherComponents, 'processedSnapshotStorage' | 'logs'>): IProcessedSnapshotsComponent {
+  const logger = components.logs.getLogger('processed-snapshots-logic')
+  const snapshotsBeingStreamed = new Set()
+  const snapshotsCompletelyStreamed = new Set()
+  const numberOfProcessedEntitiesBySnapshot: Map<string, number> = new Map()
+
+  return {
+    async shouldStream(snapshotHash: string, replacedSnapshotHashes?: string[]) {
+      const isBeingStreamed = snapshotsBeingStreamed.has(snapshotHash)
+      const wasStreamed = snapshotsCompletelyStreamed.has(snapshotHash)
+      const replacedHashes = replacedSnapshotHashes ?? []
+      const processedSnapshotHashes = await components.processedSnapshotStorage.processedFrom([snapshotHash, ...replacedHashes])
+      const snapshotWasAlreadyProcessed = processedSnapshotHashes.has(snapshotHash)
+      const replacedHashesWereAlreadyProcessed = replacedHashes.length > 0 && replacedHashes.every((h) => processedSnapshotHashes.has(h))
+
+      if (!snapshotWasAlreadyProcessed && replacedHashesWereAlreadyProcessed) {
+        await components.processedSnapshotStorage.saveProcessed(snapshotHash)
+      }
+
+      return !isBeingStreamed && !wasStreamed && !(snapshotWasAlreadyProcessed || replacedHashesWereAlreadyProcessed)
+    },
+    startStreamOf(snapshotHash: string) {
+      snapshotsBeingStreamed.add(snapshotHash)
+      logger.info('Starting stream...', { snapshotHash })
+    },
+    async endStreamOf(snapshotHash: string, numberOfStreamedEntities: number) {
+      snapshotsCompletelyStreamed.add(snapshotHash)
+      let numberOfEntities = numberOfProcessedEntitiesBySnapshot.get(snapshotHash) ?? 0
+      numberOfEntities = numberOfEntities - numberOfStreamedEntities
+      numberOfProcessedEntitiesBySnapshot.set(snapshotHash, numberOfEntities)
+      logger.info('Stream ended.', { snapshotHash })
+      if (numberOfEntities == 0) {
+        await components.processedSnapshotStorage.saveProcessed(snapshotHash)
+      }
+    },
+    async entityProcessedFrom(snapshotHash: string) {
+      let numberOfEntities = numberOfProcessedEntitiesBySnapshot.get(snapshotHash) ?? 0
+      numberOfEntities = numberOfEntities + 1
+      numberOfProcessedEntitiesBySnapshot.set(snapshotHash, numberOfEntities)
+      if (snapshotsCompletelyStreamed.has(snapshotHash) && numberOfEntities == 0) {
+        await components.processedSnapshotStorage.saveProcessed(snapshotHash)
+      }
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,6 @@ export type CatalystDeploymentStreamOptions = DeployedEntityStreamOptions & {
 }
 
 export type IProcessedSnapshotStorageComponent = {
-  wasSnapshotProcessed(hash: string): Promise<boolean>
+  wasSnapshotProcessed(hash: string, replacedSnapshotHashes?: string[]): Promise<boolean>
   markSnapshotProcessed(hash: string): Promise<void>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,7 @@ export type SnapshotsFetcherComponents = {
   downloadQueue: IJobQueue
   logs: ILoggerComponent
   storage: IContentStorageComponent
-  snapshotProcessEndTask: IProcessedSnapshotStorageComponent
+  processedSnapshotStorage: IProcessedSnapshotStorageComponent
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,7 @@ export type SnapshotsFetcherComponents = {
   downloadQueue: IJobQueue
   logs: ILoggerComponent
   storage: IContentStorageComponent
-  snapshotProcessEndTask: ISnapshotProcessEndTaskComponent
+  snapshotProcessEndTask: IProcessedSnapshotStorageComponent
 }
 
 /**
@@ -120,6 +120,7 @@ export type CatalystDeploymentStreamOptions = DeployedEntityStreamOptions & {
   maxReconnectionTime?: number
 }
 
-export type ISnapshotProcessEndTaskComponent = {
-  onSnapshotSuccessfullyProcessed(hash: string): Promise<void>
+export type IProcessedSnapshotStorageComponent = {
+  wasSnapshotProcessed(hash: string): Promise<boolean>
+  markSnapshotProcessed(hash: string): Promise<void>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export type SnapshotsFetcherComponents = {
   downloadQueue: IJobQueue
   logs: ILoggerComponent
   storage: IContentStorageComponent
+  snapshotProcessEndTask: ISnapshotProcessEndTaskComponent
 }
 
 /**
@@ -119,6 +120,6 @@ export type CatalystDeploymentStreamOptions = DeployedEntityStreamOptions & {
   maxReconnectionTime?: number
 }
 
-export type ISnapshotProcessTearDownComponent = {
-  onSnapshotProcessed(hash: string): Promise<void>
+export type ISnapshotProcessEndTaskComponent = {
+  onSnapshotSuccessfullyProcessed(hash: string): Promise<void>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export type SnapshotsFetcherComponents = {
   logs: ILoggerComponent
   storage: IContentStorageComponent
   processedSnapshotStorage: IProcessedSnapshotStorageComponent
+  processedSnapshots: IProcessedSnapshotsComponent
 }
 
 /**
@@ -45,7 +46,7 @@ export type SnapshotsFetcherComponents = {
  * @public
  */
 export type IDeployerComponent = {
-  deployEntity(entity: DeploymentWithAuthChain, contentServers: string[]): Promise<void>
+  deployEntity(entity: DeploymentWithAuthChain & { snapshotHash?: string }, contentServers: string[]): Promise<void>
   /**
    * onIdle returns a promise that should be resolved once every deployEntity(...) job has
    * finished and there are no more queued jobs.
@@ -121,6 +122,13 @@ export type CatalystDeploymentStreamOptions = DeployedEntityStreamOptions & {
 }
 
 export type IProcessedSnapshotStorageComponent = {
-  wasSnapshotProcessed(hash: string, replacedSnapshotHashes?: string[]): Promise<boolean>
-  markSnapshotProcessed(hash: string, replacedSnapshotHashes?: string[]): Promise<void>
+  processedFrom(snapshotHashes: string[]): Promise<Set<string>>
+  saveProcessed(snapshotHash: string): Promise<void>
+}
+
+export type IProcessedSnapshotsComponent = {
+  shouldStream(snapshotHash: string, replacedSnapshotHashes?: string[]): Promise<boolean>
+  startStreamOf(snapshotHash: string): void
+  endStreamOf(snapshotHash: string, numberOfEntitiesStreamed: number): Promise<void>
+  entityProcessedFrom(snapshotHash: string): Promise<void>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,5 +122,5 @@ export type CatalystDeploymentStreamOptions = DeployedEntityStreamOptions & {
 
 export type IProcessedSnapshotStorageComponent = {
   wasSnapshotProcessed(hash: string, replacedSnapshotHashes?: string[]): Promise<boolean>
-  markSnapshotProcessed(hash: string): Promise<void>
+  markSnapshotProcessed(hash: string, replacedSnapshotHashes?: string[]): Promise<void>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,3 +118,7 @@ export type CatalystDeploymentStreamOptions = DeployedEntityStreamOptions & {
    */
   maxReconnectionTime?: number
 }
+
+export type ISnapshotProcessTearDownComponent = {
+  onSnapshotProcessed(hash: string): Promise<void>
+}

--- a/test/components.ts
+++ b/test/components.ts
@@ -3,6 +3,7 @@
 
 import { createRunner } from '@well-known-components/test-helpers'
 import { createJobQueue } from '../src/job-queue-port'
+import { createProcessedSnapshotsComponent } from '../src/processed-snapshots'
 import { SnapshotsFetcherComponents } from '../src/types'
 import { createFetchComponent, createProcessedSnapshotStorageComponent, createStorageComponent } from './test-component'
 
@@ -45,6 +46,7 @@ export const test = createRunner<TestComponents>({
     const testServerComponents = await initTestServerComponents()
     const storage = await createStorageComponent()
     const processedSnapshotStorage = createProcessedSnapshotStorageComponent()
+    const processedSnapshots = createProcessedSnapshotsComponent({ processedSnapshotStorage, logs })
 
     return {
       ...testServerComponents,
@@ -53,7 +55,8 @@ export const test = createRunner<TestComponents>({
       downloadQueue,
       fetcher,
       storage,
-      processedSnapshotStorage
+      processedSnapshotStorage,
+      processedSnapshots
     }
   },
 })

--- a/test/components.ts
+++ b/test/components.ts
@@ -4,7 +4,7 @@
 import { createRunner } from '@well-known-components/test-helpers'
 import { createJobQueue } from '../src/job-queue-port'
 import { SnapshotsFetcherComponents } from '../src/types'
-import { createFetchComponent, createStorageComponent } from './test-component'
+import { createFetchComponent, createSnapshotProcessEndTaskComponent, createStorageComponent } from './test-component'
 
 import {
   initTestServerComponents,
@@ -14,8 +14,8 @@ import {
 import { createLogComponent } from '@well-known-components/logger'
 import { createTestMetricsComponent } from '@well-known-components/metrics'
 import { metricsDefinitions } from '../src'
-import {IConfigComponent} from "@well-known-components/interfaces";
-import {createConfigComponent} from "@well-known-components/env-config-provider";
+import { IConfigComponent } from "@well-known-components/interfaces"
+import { createConfigComponent } from "@well-known-components/env-config-provider"
 
 // Record of components
 export type TestComponents = SnapshotsFetcherComponents & TestServerComponents<SnapshotsFetcherComponents>
@@ -44,6 +44,7 @@ export const test = createRunner<TestComponents>({
     const metrics = createTestMetricsComponent(metricsDefinitions)
     const testServerComponents = await initTestServerComponents()
     const storage = await createStorageComponent()
+    const snapshotProcessEndTask = createSnapshotProcessEndTaskComponent({ logs })
 
     return {
       ...testServerComponents,
@@ -52,6 +53,7 @@ export const test = createRunner<TestComponents>({
       downloadQueue,
       fetcher,
       storage,
+      snapshotProcessEndTask
     }
   },
 })

--- a/test/components.ts
+++ b/test/components.ts
@@ -4,7 +4,7 @@
 import { createRunner } from '@well-known-components/test-helpers'
 import { createJobQueue } from '../src/job-queue-port'
 import { SnapshotsFetcherComponents } from '../src/types'
-import { createFetchComponent, createSnapshotProcessEndTaskComponent, createStorageComponent } from './test-component'
+import { createFetchComponent, createProcessedSnapshotStorageComponent, createStorageComponent } from './test-component'
 
 import {
   initTestServerComponents,
@@ -44,7 +44,7 @@ export const test = createRunner<TestComponents>({
     const metrics = createTestMetricsComponent(metricsDefinitions)
     const testServerComponents = await initTestServerComponents()
     const storage = await createStorageComponent()
-    const snapshotProcessEndTask = createSnapshotProcessEndTaskComponent({ logs })
+    const snapshotProcessEndTask = createProcessedSnapshotStorageComponent()
 
     return {
       ...testServerComponents,

--- a/test/components.ts
+++ b/test/components.ts
@@ -44,7 +44,7 @@ export const test = createRunner<TestComponents>({
     const metrics = createTestMetricsComponent(metricsDefinitions)
     const testServerComponents = await initTestServerComponents()
     const storage = await createStorageComponent()
-    const snapshotProcessEndTask = createProcessedSnapshotStorageComponent()
+    const processedSnapshotStorage = createProcessedSnapshotStorageComponent()
 
     return {
       ...testServerComponents,
@@ -53,7 +53,7 @@ export const test = createRunner<TestComponents>({
       downloadQueue,
       fetcher,
       storage,
-      snapshotProcessEndTask
+      processedSnapshotStorage
     }
   },
 })

--- a/test/createCatalystDeploymentStream.spec.ts
+++ b/test/createCatalystDeploymentStream.spec.ts
@@ -4,7 +4,7 @@ import { createReadStream, unlinkSync } from 'fs'
 import { resolve } from 'path'
 import { sleep } from '../src/utils'
 import future from 'fp-future'
-import { IDeployerComponent } from '../src/types'
+import { IDeployerComponent, ISnapshotProcessEndTaskComponent } from '../src/types'
 import { AuthLinkType } from '@dcl/schemas'
 
 test('createCatalystDeploymentStream', ({ components, stubComponents }) => {
@@ -97,7 +97,7 @@ test('createCatalystDeploymentStream', ({ components, stubComponents }) => {
 
     try {
       unlinkSync(resolve(contentFolder, downloadedSnapshotFile))
-    } catch {}
+    } catch { }
   })
 
   it('fetches a stream', async () => {
@@ -125,6 +125,7 @@ test('createCatalystDeploymentStream', ({ components, stubComponents }) => {
         deployer,
         metrics: components.metrics,
         storage: components.storage,
+        snapshotProcessEndTask: components.snapshotProcessEndTask
       },
       {
         contentServer: await components.getBaseUrl(),

--- a/test/createCatalystDeploymentStream.spec.ts
+++ b/test/createCatalystDeploymentStream.spec.ts
@@ -4,7 +4,7 @@ import { createReadStream, unlinkSync } from 'fs'
 import { resolve } from 'path'
 import { sleep } from '../src/utils'
 import future from 'fp-future'
-import { IDeployerComponent, ISnapshotProcessEndTaskComponent } from '../src/types'
+import { IDeployerComponent, IProcessedSnapshotStorageComponent } from '../src/types'
 import { AuthLinkType } from '@dcl/schemas'
 
 test('createCatalystDeploymentStream', ({ components, stubComponents }) => {

--- a/test/createCatalystDeploymentStream.spec.ts
+++ b/test/createCatalystDeploymentStream.spec.ts
@@ -125,7 +125,7 @@ test('createCatalystDeploymentStream', ({ components, stubComponents }) => {
         deployer,
         metrics: components.metrics,
         storage: components.storage,
-        snapshotProcessEndTask: components.snapshotProcessEndTask
+        processedSnapshotStorage: components.processedSnapshotStorage
       },
       {
         contentServer: await components.getBaseUrl(),

--- a/test/createCatalystDeploymentStream.spec.ts
+++ b/test/createCatalystDeploymentStream.spec.ts
@@ -4,7 +4,7 @@ import { createReadStream, unlinkSync } from 'fs'
 import { resolve } from 'path'
 import { sleep } from '../src/utils'
 import future from 'fp-future'
-import { IDeployerComponent, IProcessedSnapshotStorageComponent } from '../src/types'
+import { IDeployerComponent } from '../src/types'
 import { AuthLinkType } from '@dcl/schemas'
 
 test('createCatalystDeploymentStream', ({ components, stubComponents }) => {
@@ -125,7 +125,8 @@ test('createCatalystDeploymentStream', ({ components, stubComponents }) => {
         deployer,
         metrics: components.metrics,
         storage: components.storage,
-        processedSnapshotStorage: components.processedSnapshotStorage
+        processedSnapshotStorage: components.processedSnapshotStorage,
+        processedSnapshots: components.processedSnapshots
       },
       {
         contentServer: await components.getBaseUrl(),
@@ -155,15 +156,15 @@ test('createCatalystDeploymentStream', ({ components, stubComponents }) => {
     expect(stream.isStopped()).toEqual(true)
 
     expect(r).toEqual([
-      { entityType: 'profile', entityId: 'Qm000001', localTimestamp: 1, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000002', localTimestamp: 2, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000003', localTimestamp: 3, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000004', localTimestamp: 4, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000005', localTimestamp: 5, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000006', localTimestamp: 6, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000007', localTimestamp: 7, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000008', localTimestamp: 8, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000009', localTimestamp: 9, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000001', localTimestamp: 1, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000002', localTimestamp: 2, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000003', localTimestamp: 3, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000004', localTimestamp: 4, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000005', localTimestamp: 5, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000006', localTimestamp: 6, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000007', localTimestamp: 7, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000008', localTimestamp: 8, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000009', localTimestamp: 9, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
       { entityType: 'profile', entityId: 'Qm000010', localTimestamp: 10, authChain, pointers: ['0x1'] },
       { entityType: 'profile', entityId: 'Qm000011', localTimestamp: 11, authChain, pointers: ['0x1'] },
       { entityType: 'profile', entityId: 'Qm000012', localTimestamp: 12, authChain, pointers: ['0x1'] },

--- a/test/fixtures/bafkreig6sfhegnp4okzecgx3v6gj6pohh5qzw6zjtrdqtggx64743rkmz4
+++ b/test/fixtures/bafkreig6sfhegnp4okzecgx3v6gj6pohh5qzw6zjtrdqtggx64743rkmz4
@@ -1,0 +1,1 @@
+### Decentraland json snapshot

--- a/test/getDeployedEntitiesStream.spec.ts
+++ b/test/getDeployedEntitiesStream.spec.ts
@@ -18,11 +18,13 @@ test('getDeployedEntitiesStream', ({ components, stubComponents }) => {
   ]
   it('prepares the endpoints', () => {
     // serve the snapshots
-    components.router.get('/snapshot', async () => ({
-      body: {
+    components.router.get('/snapshots', async () => ({
+      body: [{
         hash: downloadedSnapshotFile,
-        lastIncludedDeploymentTimestamp: 8,
-      },
+        timeRange: {
+          initTimestampSecs: 0, endTimestampSecs: 8
+        }
+      }],
     }))
 
     // serve the snapshot file
@@ -73,7 +75,7 @@ test('getDeployedEntitiesStream', ({ components, stubComponents }) => {
 
     try {
       unlinkSync(resolve(contentFolder, downloadedSnapshotFile))
-    } catch {}
+    } catch { }
   })
 
   it('fetches a stream', async () => {
@@ -127,6 +129,15 @@ test('getDeployedEntitiesStream', ({ components, stubComponents }) => {
   })
 
   it('fetches a stream without deleting the downloaded file', async () => {
+    components.router.get('/snapshots', async () => {
+      throw new Error('i am an error')
+    })
+    components.router.get('/snapshot', async () => ({
+      body: {
+        hash: downloadedSnapshotFile,
+        lastIncludedDeploymentTimestamp: 8,
+      },
+    }))
     const { storage } = stubComponents
 
     storage.storeStream.callThrough()
@@ -161,6 +172,181 @@ test('getDeployedEntitiesStream', ({ components, stubComponents }) => {
     Sinon.assert.callCount(storage.delete, 0)
 
     expect(r.length).toBeGreaterThan(0)
+  })
+
+  it('fetches stream from old snapshot if new /snapshots endpoint fails', async () => {
+    const { storage } = stubComponents
+
+    storage.storeStream.callThrough()
+    storage.retrieve.callThrough()
+
+    const r = []
+    const stream = getDeployedEntitiesStream(
+      {
+        fetcher: components.fetcher,
+        downloadQueue: components.downloadQueue,
+        logs: components.logs,
+        metrics: components.metrics,
+        storage: components.storage,
+      },
+      {
+        contentServer: await components.getBaseUrl(),
+        tmpDownloadFolder: contentFolder,
+        pointerChangesWaitTime: 0,
+        requestRetryWaitTime: 0,
+        requestMaxRetries: 10,
+      }
+    )
+
+    Sinon.assert.callCount(storage.delete, 0)
+
+    for await (const deployment of stream) {
+      r.push(deployment)
+    }
+
+    // the downloaded file must be deleted
+    Sinon.assert.calledOnce(storage.delete)
+
+    expect(r).toEqual([
+      { entityType: 'profile', entityId: 'Qm000001', localTimestamp: 1, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000002', localTimestamp: 2, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000003', localTimestamp: 3, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000004', localTimestamp: 4, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000005', localTimestamp: 5, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000006', localTimestamp: 6, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000007', localTimestamp: 7, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000008', localTimestamp: 8, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000009', localTimestamp: 9, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000010', localTimestamp: 10, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000011', localTimestamp: 11, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000012', localTimestamp: 12, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000013', localTimestamp: 13, authChain, pointers: ['0x1'] },
+    ])
+  })
+})
+
+test('getDeployedEntitiesStream from old snapshot endpoint', ({ components, stubComponents }) => {
+  const contentFolder = resolve('downloads')
+  const downloadedSnapshotFile = 'bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha'
+  const authChain = [
+    {
+      type: AuthLinkType.SIGNER,
+      payload: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5',
+      signature: '',
+    },
+  ]
+  it('prepares the endpoints', () => {
+    // serve the snapshots
+    components.router.get('/snapshot', async () => ({
+      body: {
+        hash: downloadedSnapshotFile,
+        lastIncludedDeploymentTimestamp: 8,
+      },
+    }))
+
+    components.router.get('/snapshots', async () => {
+      throw new Error('i am an error')
+    })
+
+    // serve the snapshot file
+    let downloadAttempts = 0
+    components.router.get(`/contents/${downloadedSnapshotFile}`, async () => {
+      if (downloadAttempts == 0) {
+        await sleep(100)
+        downloadAttempts++
+        return { status: 503 }
+      }
+
+      return {
+        body: createReadStream('test/fixtures/bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha'),
+      }
+    })
+
+    components.router.get('/pointer-changes', async (ctx) => {
+      if (!ctx.url.searchParams.has('from')) throw new Error('pointer-changes called without ?from')
+
+      if (ctx.url.searchParams.get('from') == '9') {
+        return {
+          body: {
+            deltas: [
+              { entityType: 'profile', entityId: 'Qm000010', localTimestamp: 10, authChain, pointers: ['0x1'] },
+              { entityType: 'profile', entityId: 'Qm000011', localTimestamp: 11, authChain, pointers: ['0x1'] },
+            ],
+            pagination: {
+              next: '?from=11&entityId=Qm000011',
+            },
+          },
+        }
+      }
+
+      if (ctx.url.searchParams.get('from') != '11' && ctx.url.searchParams.get('entityId') != 'Qm000011') {
+        throw new Error('pagination is not working properly')
+      }
+
+      return {
+        body: {
+          deltas: [
+            { entityType: 'profile', entityId: 'Qm000012', localTimestamp: 12, authChain, pointers: ['0x1'] },
+            { entityType: 'profile', entityId: 'Qm000013', localTimestamp: 13, authChain, pointers: ['0x1'] },
+          ],
+          pagination: {},
+        },
+      }
+    })
+
+    try {
+      unlinkSync(resolve(contentFolder, downloadedSnapshotFile))
+    } catch { }
+  })
+
+  it('fetches stream from old snapshot if new /snapshots endpoint fails', async () => {
+    const { storage } = stubComponents
+
+    storage.storeStream.callThrough()
+    storage.retrieve.callThrough()
+
+    const r = []
+    const stream = getDeployedEntitiesStream(
+      {
+        fetcher: components.fetcher,
+        downloadQueue: components.downloadQueue,
+        logs: components.logs,
+        metrics: components.metrics,
+        storage: components.storage,
+      },
+      {
+        contentServer: await components.getBaseUrl(),
+        tmpDownloadFolder: contentFolder,
+        pointerChangesWaitTime: 0,
+        requestRetryWaitTime: 0,
+        requestMaxRetries: 10,
+      }
+    )
+
+    Sinon.assert.callCount(storage.delete, 0)
+
+    for await (const deployment of stream) {
+      r.push(deployment)
+    }
+
+    // the downloaded file must be deleted
+    Sinon.assert.calledOnce(storage.delete)
+
+    expect(r).toEqual([
+      { entityType: 'profile', entityId: 'Qm000001', localTimestamp: 1, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000002', localTimestamp: 2, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000003', localTimestamp: 3, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000004', localTimestamp: 4, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000005', localTimestamp: 5, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000006', localTimestamp: 6, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000007', localTimestamp: 7, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000008', localTimestamp: 8, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000009', localTimestamp: 9, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000010', localTimestamp: 10, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000011', localTimestamp: 11, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000012', localTimestamp: 12, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000013', localTimestamp: 13, authChain, pointers: ['0x1'] },
+    ])
   })
 })
 

--- a/test/getDeployedEntitiesStream.spec.ts
+++ b/test/getDeployedEntitiesStream.spec.ts
@@ -5,8 +5,9 @@ import { resolve } from 'path'
 import { sleep } from '../src/utils'
 import Sinon from 'sinon'
 import { AuthLinkType } from '@dcl/schemas'
+import { ISnapshotProcessEndTaskComponent } from '../src/types'
 
-test('getDeployedEntitiesStream', ({ components, stubComponents }) => {
+test('getDeployedEntitiesStream from /snapshots endpoint', ({ components, stubComponents }) => {
   const contentFolder = resolve('downloads')
   const downloadedSnapshotFile = 'bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha'
   const authChain = [
@@ -92,6 +93,7 @@ test('getDeployedEntitiesStream', ({ components, stubComponents }) => {
         logs: components.logs,
         metrics: components.metrics,
         storage: components.storage,
+        snapshotProcessEndTask: components.snapshotProcessEndTask
       },
       {
         contentServer: await components.getBaseUrl(),
@@ -129,15 +131,6 @@ test('getDeployedEntitiesStream', ({ components, stubComponents }) => {
   })
 
   it('fetches a stream without deleting the downloaded file', async () => {
-    components.router.get('/snapshots', async () => {
-      throw new Error('i am an error')
-    })
-    components.router.get('/snapshot', async () => ({
-      body: {
-        hash: downloadedSnapshotFile,
-        lastIncludedDeploymentTimestamp: 8,
-      },
-    }))
     const { storage } = stubComponents
 
     storage.storeStream.callThrough()
@@ -151,6 +144,7 @@ test('getDeployedEntitiesStream', ({ components, stubComponents }) => {
         logs: components.logs,
         metrics: components.metrics,
         storage: components.storage,
+        snapshotProcessEndTask: components.snapshotProcessEndTask
       },
       {
         contentServer: await components.getBaseUrl(),
@@ -173,9 +167,204 @@ test('getDeployedEntitiesStream', ({ components, stubComponents }) => {
 
     expect(r.length).toBeGreaterThan(0)
   })
+})
 
-  it('fetches stream from old snapshot if new /snapshots endpoint fails', async () => {
+test('when successfully process all snapshot files', ({ components, stubComponents }) => {
+  const contentFolder = resolve('downloads')
+  const downloadedSnapshotFile = 'bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha'
+  const authChain = [
+    {
+      type: AuthLinkType.SIGNER,
+      payload: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5',
+      signature: '',
+    },
+  ]
+  it('prepares the endpoints', () => {
+    // serve the snapshots
+    components.router.get('/snapshots', async () => ({
+      body: [{
+        hash: downloadedSnapshotFile,
+        timeRange: {
+          initTimestampSecs: 0, endTimestampSecs: 8
+        }
+      },
+      {
+        hash: downloadedSnapshotFile,
+        timeRange: {
+          initTimestampSecs: 8, endTimestampSecs: 16
+        }
+      }],
+    }))
+
+    // serve the snapshot file
+    let downloadAttempts = 0
+    components.router.get(`/contents/${downloadedSnapshotFile}`, async () => {
+      if (downloadAttempts == 0) {
+        await sleep(100)
+        downloadAttempts++
+        return { status: 503 }
+      }
+
+      return {
+        body: createReadStream('test/fixtures/bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha'),
+      }
+    })
+
+    components.router.get('/pointer-changes', async (ctx) => {
+      if (!ctx.url.searchParams.has('from')) throw new Error('pointer-changes called without ?from')
+
+      if (ctx.url.searchParams.get('from') == '9') {
+        return {
+          body: {
+            deltas: [
+              { entityType: 'profile', entityId: 'Qm000010', localTimestamp: 10, authChain, pointers: ['0x1'] },
+              { entityType: 'profile', entityId: 'Qm000011', localTimestamp: 11, authChain, pointers: ['0x1'] },
+            ],
+            pagination: {
+              next: '?from=11&entityId=Qm000011',
+            },
+          },
+        }
+      }
+
+      if (ctx.url.searchParams.get('from') != '11' && ctx.url.searchParams.get('entityId') != 'Qm000011') {
+        throw new Error('pagination is not working properly')
+      }
+
+      return {
+        body: {
+          deltas: [
+            { entityType: 'profile', entityId: 'Qm000012', localTimestamp: 12, authChain, pointers: ['0x1'] },
+            { entityType: 'profile', entityId: 'Qm000013', localTimestamp: 13, authChain, pointers: ['0x1'] },
+          ],
+          pagination: {},
+        },
+      }
+    })
+
+    try {
+      unlinkSync(resolve(contentFolder, downloadedSnapshotFile))
+    } catch { }
+  })
+
+  it('runs the end task for each one', async () => {
     const { storage } = stubComponents
+    const snapshotProcessEndTask: ISnapshotProcessEndTaskComponent = {
+      onSnapshotSuccessfullyProcessed: jest.fn()
+    }
+    storage.storeStream.callThrough()
+    storage.retrieve.callThrough()
+
+    const r = []
+    const stream = getDeployedEntitiesStream(
+      {
+        fetcher: components.fetcher,
+        downloadQueue: components.downloadQueue,
+        logs: components.logs,
+        metrics: components.metrics,
+        storage: components.storage,
+        snapshotProcessEndTask: snapshotProcessEndTask
+      },
+      {
+        contentServer: await components.getBaseUrl(),
+        tmpDownloadFolder: contentFolder,
+        pointerChangesWaitTime: 0,
+        requestRetryWaitTime: 0,
+        requestMaxRetries: 10,
+      }
+    )
+
+    for await (const deployment of stream) {
+      r.push(deployment)
+    }
+    expect(snapshotProcessEndTask.onSnapshotSuccessfullyProcessed).toBeCalledTimes(2)
+    expect(snapshotProcessEndTask.onSnapshotSuccessfullyProcessed).toBeCalledWith(downloadedSnapshotFile)
+  })
+})
+
+test('when successfully process a snapshot file and fails to process other', ({ components, stubComponents }) => {
+  const contentFolder = resolve('downloads')
+  const downloadedSnapshotFile = 'bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha'
+  const authChain = [
+    {
+      type: AuthLinkType.SIGNER,
+      payload: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5',
+      signature: '',
+    },
+  ]
+  it('prepares the endpoints', () => {
+    // serve the snapshots
+    components.router.get('/snapshots', async () => ({
+      body: [{
+        hash: downloadedSnapshotFile,
+        timeRange: {
+          initTimestampSecs: 0, endTimestampSecs: 8
+        }
+      },
+      {
+        hash: 'unexistent-hash',
+        timeRange: {
+          initTimestampSecs: 8, endTimestampSecs: 16
+        }
+      }],
+    }))
+
+    // serve the snapshot file
+    let downloadAttempts = 0
+    components.router.get(`/contents/${downloadedSnapshotFile}`, async () => {
+      if (downloadAttempts == 0) {
+        await sleep(100)
+        downloadAttempts++
+        return { status: 503 }
+      }
+
+      return {
+        body: createReadStream('test/fixtures/bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha'),
+      }
+    })
+
+    components.router.get('/pointer-changes', async (ctx) => {
+      if (!ctx.url.searchParams.has('from')) throw new Error('pointer-changes called without ?from')
+
+      if (ctx.url.searchParams.get('from') == '9') {
+        return {
+          body: {
+            deltas: [
+              { entityType: 'profile', entityId: 'Qm000010', localTimestamp: 10, authChain, pointers: ['0x1'] },
+              { entityType: 'profile', entityId: 'Qm000011', localTimestamp: 11, authChain, pointers: ['0x1'] },
+            ],
+            pagination: {
+              next: '?from=11&entityId=Qm000011',
+            },
+          },
+        }
+      }
+
+      if (ctx.url.searchParams.get('from') != '11' && ctx.url.searchParams.get('entityId') != 'Qm000011') {
+        throw new Error('pagination is not working properly')
+      }
+
+      return {
+        body: {
+          deltas: [
+            { entityType: 'profile', entityId: 'Qm000012', localTimestamp: 12, authChain, pointers: ['0x1'] },
+            { entityType: 'profile', entityId: 'Qm000013', localTimestamp: 13, authChain, pointers: ['0x1'] },
+          ],
+          pagination: {},
+        },
+      }
+    })
+
+    try {
+      unlinkSync(resolve(contentFolder, downloadedSnapshotFile))
+    } catch { }
+  })
+
+  it('runs the end task only for the successfully processed one', async () => {
+    const { storage } = stubComponents
+    const snapshotProcessEndTask: ISnapshotProcessEndTaskComponent = {
+      onSnapshotSuccessfullyProcessed: jest.fn()
+    }
 
     storage.storeStream.callThrough()
     storage.retrieve.callThrough()
@@ -188,6 +377,7 @@ test('getDeployedEntitiesStream', ({ components, stubComponents }) => {
         logs: components.logs,
         metrics: components.metrics,
         storage: components.storage,
+        snapshotProcessEndTask
       },
       {
         contentServer: await components.getBaseUrl(),
@@ -198,34 +388,19 @@ test('getDeployedEntitiesStream', ({ components, stubComponents }) => {
       }
     )
 
-    Sinon.assert.callCount(storage.delete, 0)
-
-    for await (const deployment of stream) {
-      r.push(deployment)
+    const iterate = async () => {
+      for await (const deployment of stream) {
+        r.push(deployment)
+      }
     }
-
-    // the downloaded file must be deleted
-    Sinon.assert.calledOnce(storage.delete)
-
-    expect(r).toEqual([
-      { entityType: 'profile', entityId: 'Qm000001', localTimestamp: 1, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000002', localTimestamp: 2, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000003', localTimestamp: 3, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000004', localTimestamp: 4, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000005', localTimestamp: 5, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000006', localTimestamp: 6, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000007', localTimestamp: 7, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000008', localTimestamp: 8, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000009', localTimestamp: 9, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000010', localTimestamp: 10, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000011', localTimestamp: 11, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000012', localTimestamp: 12, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000013', localTimestamp: 13, authChain, pointers: ['0x1'] },
-    ])
+    await expect(iterate()).rejects.toThrow()
+    expect(snapshotProcessEndTask.onSnapshotSuccessfullyProcessed).toBeCalledTimes(1)
+    expect(snapshotProcessEndTask.onSnapshotSuccessfullyProcessed).toBeCalledWith(downloadedSnapshotFile)
   })
 })
 
-test('getDeployedEntitiesStream from old snapshot endpoint', ({ components, stubComponents }) => {
+
+test('getDeployedEntitiesStream from old /snapshot endpoint', ({ components, stubComponents }) => {
   const contentFolder = resolve('downloads')
   const downloadedSnapshotFile = 'bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha'
   const authChain = [
@@ -313,6 +488,7 @@ test('getDeployedEntitiesStream from old snapshot endpoint', ({ components, stub
         logs: components.logs,
         metrics: components.metrics,
         storage: components.storage,
+        snapshotProcessEndTask: components.snapshotProcessEndTask
       },
       {
         contentServer: await components.getBaseUrl(),
@@ -414,6 +590,7 @@ test("getDeployedEntitiesStream does not download snapshot if it doesn't include
         logs: components.logs,
         metrics: components.metrics,
         storage: components.storage,
+        snapshotProcessEndTask: components.snapshotProcessEndTask
       },
       {
         fromTimestamp: 150,

--- a/test/getDeployedEntitiesStream.spec.ts
+++ b/test/getDeployedEntitiesStream.spec.ts
@@ -273,7 +273,7 @@ test('when successfully process all snapshot files', ({ components, stubComponen
     components.router.get('/pointer-changes', async (ctx) => {
       if (!ctx.url.searchParams.has('from')) throw new Error('pointer-changes called without ?from')
 
-      if (ctx.url.searchParams.get('from') == '9') {
+      if (ctx.url.searchParams.get('from') == '16') {
         return {
           body: {
             deltas: [
@@ -281,13 +281,13 @@ test('when successfully process all snapshot files', ({ components, stubComponen
               { entityType: 'profile', entityId: 'Qm000011', localTimestamp: 11, authChain, pointers: ['0x1'] },
             ],
             pagination: {
-              next: '?from=11&entityId=Qm000011',
+              next: '?from=18&entityId=Qm000011',
             },
           },
         }
       }
 
-      if (ctx.url.searchParams.get('from') != '11' && ctx.url.searchParams.get('entityId') != 'Qm000011') {
+      if (ctx.url.searchParams.get('from') != '18' && ctx.url.searchParams.get('entityId') != 'Qm000011') {
         throw new Error('pagination is not working properly')
       }
 

--- a/test/getDeployedEntitiesStream.spec.ts
+++ b/test/getDeployedEntitiesStream.spec.ts
@@ -251,7 +251,8 @@ test('when successfully process all snapshot files', ({ components, stubComponen
         hash: downloadedSnapshotFile,
         timeRange: {
           initTimestampSecs: 8, endTimestampSecs: 16
-        }
+        },
+        replacedSnapshotHashes: ['otherHash1', 'otherHash2']
       }],
     }))
 
@@ -339,6 +340,10 @@ test('when successfully process all snapshot files', ({ components, stubComponen
     }
     expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledTimes(2)
     expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledWith(downloadedSnapshotFile)
+    expect(processedSnapshotStorage.wasSnapshotProcessed)
+      .toBeCalledWith(downloadedSnapshotFile, expect.arrayContaining(['otherHash1', 'otherHash2']))
+    expect(processedSnapshotStorage.wasSnapshotProcessed)
+      .toBeCalledWith(downloadedSnapshotFile, undefined)
   })
 })
 

--- a/test/getDeployedEntitiesStream.spec.ts
+++ b/test/getDeployedEntitiesStream.spec.ts
@@ -5,7 +5,7 @@ import { resolve } from 'path'
 import { sleep } from '../src/utils'
 import Sinon from 'sinon'
 import { AuthLinkType } from '@dcl/schemas'
-import { IProcessedSnapshotStorageComponent } from '../src/types'
+import { IProcessedSnapshotsComponent } from '../src/types'
 
 test('getDeployedEntitiesStream from /snapshots endpoint', ({ components, stubComponents }) => {
   const contentFolder = resolve('downloads')
@@ -107,15 +107,15 @@ test('getDeployedEntitiesStream from /snapshots endpoint', ({ components, stubCo
     Sinon.assert.calledOnce(storage.delete)
 
     expect(r).toEqual([
-      { entityType: 'profile', entityId: 'Qm000001', localTimestamp: 1, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000002', localTimestamp: 2, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000003', localTimestamp: 3, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000004', localTimestamp: 4, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000005', localTimestamp: 5, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000006', localTimestamp: 6, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000007', localTimestamp: 7, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000008', localTimestamp: 8, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000009', localTimestamp: 9, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000001', localTimestamp: 1, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000002', localTimestamp: 2, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000003', localTimestamp: 3, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000004', localTimestamp: 4, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000005', localTimestamp: 5, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000006', localTimestamp: 6, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000007', localTimestamp: 7, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000008', localTimestamp: 8, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000009', localTimestamp: 9, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
       { entityType: 'profile', entityId: 'Qm000010', localTimestamp: 10, authChain, pointers: ['0x1'] },
       { entityType: 'profile', entityId: 'Qm000011', localTimestamp: 11, authChain, pointers: ['0x1'] },
       { entityType: 'profile', entityId: 'Qm000012', localTimestamp: 12, authChain, pointers: ['0x1'] },
@@ -231,6 +231,7 @@ test('fetches a stream without deleting the downloaded file', ({ components, stu
 test('when successfully process all snapshot files', ({ components, stubComponents }) => {
   const contentFolder = resolve('downloads')
   const downloadedSnapshotFile = 'bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha'
+  const anotherSnapshotFile = 'bafkreig6sfhegnp4okzecgx3v6gj6pohh5qzw6zjtrdqtggx64743rkmz4'
   const authChain = [
     {
       type: AuthLinkType.SIGNER,
@@ -248,7 +249,7 @@ test('when successfully process all snapshot files', ({ components, stubComponen
         }
       },
       {
-        hash: downloadedSnapshotFile,
+        hash: anotherSnapshotFile,
         timeRange: {
           initTimestamp: 8, endTimestamp: 16
         },
@@ -267,6 +268,18 @@ test('when successfully process all snapshot files', ({ components, stubComponen
 
       return {
         body: createReadStream('test/fixtures/bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha'),
+      }
+    })
+
+    components.router.get(`/contents/${anotherSnapshotFile}`, async () => {
+      if (downloadAttempts == 0) {
+        await sleep(100)
+        downloadAttempts++
+        return { status: 503 }
+      }
+
+      return {
+        body: createReadStream('test/fixtures/bafkreig6sfhegnp4okzecgx3v6gj6pohh5qzw6zjtrdqtggx64743rkmz4'),
       }
     })
 
@@ -307,25 +320,15 @@ test('when successfully process all snapshot files', ({ components, stubComponen
     } catch { }
   })
 
-  it('should mark all as processed', async () => {
+  it('should call end of stream for all', async () => {
     const { storage } = stubComponents
-    const processedSnapshotStorage: IProcessedSnapshotStorageComponent = {
-      wasSnapshotProcessed: jest.fn(),
-      markSnapshotProcessed: jest.fn()
-    }
+    const endStreamOfSpy = jest.spyOn(components.processedSnapshots, 'endStreamOf')
     storage.storeStream.callThrough()
     storage.retrieve.callThrough()
 
     const r = []
     const stream = getDeployedEntitiesStream(
-      {
-        fetcher: components.fetcher,
-        downloadQueue: components.downloadQueue,
-        logs: components.logs,
-        metrics: components.metrics,
-        storage: components.storage,
-        processedSnapshotStorage
-      },
+      components,
       {
         contentServer: await components.getBaseUrl(),
         tmpDownloadFolder: contentFolder,
@@ -338,15 +341,9 @@ test('when successfully process all snapshot files', ({ components, stubComponen
     for await (const deployment of stream) {
       r.push(deployment)
     }
-    expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledTimes(2)
-    expect(processedSnapshotStorage.markSnapshotProcessed)
-      .toBeCalledWith(downloadedSnapshotFile, undefined)
-    expect(processedSnapshotStorage.markSnapshotProcessed)
-      .toBeCalledWith(downloadedSnapshotFile, expect.arrayContaining(['otherHash1', 'otherHash2']))
-    expect(processedSnapshotStorage.wasSnapshotProcessed)
-      .toBeCalledWith(downloadedSnapshotFile, expect.arrayContaining(['otherHash1', 'otherHash2']))
-    expect(processedSnapshotStorage.wasSnapshotProcessed)
-      .toBeCalledWith(downloadedSnapshotFile, undefined)
+    expect(endStreamOfSpy).toBeCalledTimes(2)
+    expect(endStreamOfSpy).toBeCalledWith(downloadedSnapshotFile, 9)
+    expect(endStreamOfSpy).toBeCalledWith(anotherSnapshotFile, 0)
   })
 })
 
@@ -429,26 +426,17 @@ test('when successfully process a snapshot file and fails to process other', ({ 
     } catch { }
   })
 
-  it('should mark as processed only for the successfully processed one', async () => {
+  it('should start and end stream only for the successfully read one', async () => {
     const { storage } = stubComponents
-    const processedSnapshotStorage: IProcessedSnapshotStorageComponent = {
-      wasSnapshotProcessed: jest.fn(),
-      markSnapshotProcessed: jest.fn()
-    }
+    const startStreamOfSpy = jest.spyOn(components.processedSnapshots, 'startStreamOf')
+    const endStreamOfSpy = jest.spyOn(components.processedSnapshots, 'endStreamOf')
 
     storage.storeStream.callThrough()
     storage.retrieve.callThrough()
 
     const r = []
     const stream = getDeployedEntitiesStream(
-      {
-        fetcher: components.fetcher,
-        downloadQueue: components.downloadQueue,
-        logs: components.logs,
-        metrics: components.metrics,
-        storage: components.storage,
-        processedSnapshotStorage
-      },
+      components,
       {
         contentServer: await components.getBaseUrl(),
         tmpDownloadFolder: contentFolder,
@@ -464,8 +452,10 @@ test('when successfully process a snapshot file and fails to process other', ({ 
       }
     }
     await expect(iterate()).rejects.toThrow()
-    expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledTimes(1)
-    expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledWith(downloadedSnapshotFile, undefined)
+    expect(startStreamOfSpy).toBeCalledWith(downloadedSnapshotFile)
+    expect(startStreamOfSpy).toBeCalledTimes(1)
+    expect(endStreamOfSpy).toBeCalledTimes(1)
+    expect(endStreamOfSpy).toBeCalledWith(downloadedSnapshotFile, 9)
   })
 })
 
@@ -571,15 +561,15 @@ test('getDeployedEntitiesStream from old /snapshot endpoint', ({ components, stu
     Sinon.assert.calledOnce(storage.delete)
 
     expect(r).toEqual([
-      { entityType: 'profile', entityId: 'Qm000001', localTimestamp: 1, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000002', localTimestamp: 2, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000003', localTimestamp: 3, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000004', localTimestamp: 4, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000005', localTimestamp: 5, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000006', localTimestamp: 6, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000007', localTimestamp: 7, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000008', localTimestamp: 8, authChain, pointers: ['0x1'] },
-      { entityType: 'profile', entityId: 'Qm000009', localTimestamp: 9, authChain, pointers: ['0x1'] },
+      { entityType: 'profile', entityId: 'Qm000001', localTimestamp: 1, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000002', localTimestamp: 2, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000003', localTimestamp: 3, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000004', localTimestamp: 4, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000005', localTimestamp: 5, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000006', localTimestamp: 6, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000007', localTimestamp: 7, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000008', localTimestamp: 8, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
+      { entityType: 'profile', entityId: 'Qm000009', localTimestamp: 9, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile },
       { entityType: 'profile', entityId: 'Qm000010', localTimestamp: 10, authChain, pointers: ['0x1'] },
       { entityType: 'profile', entityId: 'Qm000011', localTimestamp: 11, authChain, pointers: ['0x1'] },
       { entityType: 'profile', entityId: 'Qm000012', localTimestamp: 12, authChain, pointers: ['0x1'] },

--- a/test/getDeployedEntitiesStream.spec.ts
+++ b/test/getDeployedEntitiesStream.spec.ts
@@ -399,7 +399,6 @@ test('when successfully process a snapshot file and fails to process other', ({ 
   })
 })
 
-
 test('getDeployedEntitiesStream from old /snapshot endpoint', ({ components, stubComponents }) => {
   const contentFolder = resolve('downloads')
   const downloadedSnapshotFile = 'bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha'

--- a/test/getDeployedEntitiesStream.spec.ts
+++ b/test/getDeployedEntitiesStream.spec.ts
@@ -1,5 +1,5 @@
 import { getDeployedEntitiesStream } from '../src'
-import { test, TestComponents } from './components'
+import { test } from './components'
 import { createReadStream, unlinkSync } from 'fs'
 import { resolve } from 'path'
 import { sleep } from '../src/utils'
@@ -23,7 +23,7 @@ test('getDeployedEntitiesStream from /snapshots endpoint', ({ components, stubCo
       body: [{
         hash: downloadedSnapshotFile,
         timeRange: {
-          initTimestampSecs: 0, endTimestampSecs: 8
+          initTimestamp: 0, endTimestamp: 8
         }
       }],
     }))
@@ -140,7 +140,7 @@ test('fetches a stream without deleting the downloaded file', ({ components, stu
       body: [{
         hash: downloadedSnapshotFile,
         timeRange: {
-          initTimestampSecs: 0, endTimestampSecs: 8
+          initTimestamp: 0, endTimestamp: 8
         }
       }],
     }))
@@ -244,13 +244,13 @@ test('when successfully process all snapshot files', ({ components, stubComponen
       body: [{
         hash: downloadedSnapshotFile,
         timeRange: {
-          initTimestampSecs: 0, endTimestampSecs: 8
+          initTimestamp: 0, endTimestamp: 8
         }
       },
       {
         hash: downloadedSnapshotFile,
         timeRange: {
-          initTimestampSecs: 8, endTimestampSecs: 16
+          initTimestamp: 8, endTimestamp: 16
         },
         replacedSnapshotHashes: ['otherHash1', 'otherHash2']
       }],
@@ -364,13 +364,13 @@ test('when successfully process a snapshot file and fails to process other', ({ 
         // This is processed first because it has greater end timestamp
         hash: downloadedSnapshotFile,
         timeRange: {
-          initTimestampSecs: 10, endTimestampSecs: 20
+          initTimestamp: 10, endTimestamp: 20
         }
       },
       {
         hash: 'unexistent-hash',
         timeRange: {
-          initTimestampSecs: 0, endTimestampSecs: 10
+          initTimestamp: 0, endTimestamp: 10
         }
       }],
     }))

--- a/test/getDeployedEntitiesStream.spec.ts
+++ b/test/getDeployedEntitiesStream.spec.ts
@@ -308,7 +308,7 @@ test('when successfully process all snapshot files', ({ components, stubComponen
 
   it('should mark all as processed', async () => {
     const { storage } = stubComponents
-    const snapshotProcessEndTask: IProcessedSnapshotStorageComponent = {
+    const processedSnapshotStorage: IProcessedSnapshotStorageComponent = {
       wasSnapshotProcessed: jest.fn(),
       markSnapshotProcessed: jest.fn()
     }
@@ -323,7 +323,7 @@ test('when successfully process all snapshot files', ({ components, stubComponen
         logs: components.logs,
         metrics: components.metrics,
         storage: components.storage,
-        snapshotProcessEndTask: snapshotProcessEndTask
+        processedSnapshotStorage
       },
       {
         contentServer: await components.getBaseUrl(),
@@ -337,8 +337,8 @@ test('when successfully process all snapshot files', ({ components, stubComponen
     for await (const deployment of stream) {
       r.push(deployment)
     }
-    expect(snapshotProcessEndTask.markSnapshotProcessed).toBeCalledTimes(2)
-    expect(snapshotProcessEndTask.markSnapshotProcessed).toBeCalledWith(downloadedSnapshotFile)
+    expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledTimes(2)
+    expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledWith(downloadedSnapshotFile)
   })
 })
 
@@ -422,7 +422,7 @@ test('when successfully process a snapshot file and fails to process other', ({ 
 
   it('should mark as processed only for the successfully processed one', async () => {
     const { storage } = stubComponents
-    const snapshotProcessEndTask: IProcessedSnapshotStorageComponent = {
+    const processedSnapshotStorage: IProcessedSnapshotStorageComponent = {
       wasSnapshotProcessed: jest.fn(),
       markSnapshotProcessed: jest.fn()
     }
@@ -438,7 +438,7 @@ test('when successfully process a snapshot file and fails to process other', ({ 
         logs: components.logs,
         metrics: components.metrics,
         storage: components.storage,
-        snapshotProcessEndTask
+        processedSnapshotStorage
       },
       {
         contentServer: await components.getBaseUrl(),
@@ -455,8 +455,8 @@ test('when successfully process a snapshot file and fails to process other', ({ 
       }
     }
     await expect(iterate()).rejects.toThrow()
-    expect(snapshotProcessEndTask.markSnapshotProcessed).toBeCalledTimes(1)
-    expect(snapshotProcessEndTask.markSnapshotProcessed).toBeCalledWith(downloadedSnapshotFile)
+    expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledTimes(1)
+    expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledWith(downloadedSnapshotFile)
   })
 })
 

--- a/test/getDeployedEntitiesStream.spec.ts
+++ b/test/getDeployedEntitiesStream.spec.ts
@@ -339,7 +339,10 @@ test('when successfully process all snapshot files', ({ components, stubComponen
       r.push(deployment)
     }
     expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledTimes(2)
-    expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledWith(downloadedSnapshotFile)
+    expect(processedSnapshotStorage.markSnapshotProcessed)
+      .toBeCalledWith(downloadedSnapshotFile, undefined)
+    expect(processedSnapshotStorage.markSnapshotProcessed)
+      .toBeCalledWith(downloadedSnapshotFile, expect.arrayContaining(['otherHash1', 'otherHash2']))
     expect(processedSnapshotStorage.wasSnapshotProcessed)
       .toBeCalledWith(downloadedSnapshotFile, expect.arrayContaining(['otherHash1', 'otherHash2']))
     expect(processedSnapshotStorage.wasSnapshotProcessed)
@@ -462,7 +465,7 @@ test('when successfully process a snapshot file and fails to process other', ({ 
     }
     await expect(iterate()).rejects.toThrow()
     expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledTimes(1)
-    expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledWith(downloadedSnapshotFile)
+    expect(processedSnapshotStorage.markSnapshotProcessed).toBeCalledWith(downloadedSnapshotFile, undefined)
   })
 })
 

--- a/test/getDeployedEntitiesStream.spec.ts
+++ b/test/getDeployedEntitiesStream.spec.ts
@@ -361,15 +361,16 @@ test('when successfully process a snapshot file and fails to process other', ({ 
     // serve the snapshots
     components.router.get('/snapshots', async () => ({
       body: [{
+        // This is processed first because it has greater end timestamp
         hash: downloadedSnapshotFile,
         timeRange: {
-          initTimestampSecs: 0, endTimestampSecs: 8
+          initTimestampSecs: 10, endTimestampSecs: 20
         }
       },
       {
         hash: 'unexistent-hash',
         timeRange: {
-          initTimestampSecs: 8, endTimestampSecs: 16
+          initTimestampSecs: 0, endTimestampSecs: 10
         }
       }],
     }))

--- a/test/processed-snapshots.spec.ts
+++ b/test/processed-snapshots.spec.ts
@@ -1,0 +1,127 @@
+import { test } from './components'
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { createLogComponent } from '@well-known-components/logger'
+import { createProcessedSnapshotsComponent } from '../src'
+import { IProcessedSnapshotsComponent, IProcessedSnapshotStorageComponent } from '../src/types'
+import { createProcessedSnapshotStorageComponent } from './test-component'
+
+describe('processed snapshots', () => {
+
+  const processedSnapshot = 'someHash'
+  const h1 = 'h1'
+  const h2 = 'h2'
+  const h3 = 'h3'
+
+  let processedSnapshotStorage: IProcessedSnapshotStorageComponent
+  let processedSnapshots: IProcessedSnapshotsComponent
+  let logs: ILoggerComponent
+
+  beforeAll(async () => {
+    logs = await createLogComponent({
+      config: createConfigComponent({
+        LOG_LEVEL: 'INFO'
+      })
+    })
+  })
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    processedSnapshotStorage = createProcessedSnapshotStorageComponent()
+    processedSnapshots = createProcessedSnapshotsComponent({ processedSnapshotStorage, logs })
+  })
+
+  describe('shouldStream', () => {
+    it('should return false when the snapshot was processed', async () => {
+      processedSnapshotStorage.saveProcessed(processedSnapshot)
+      expect(await processedSnapshots.shouldStream(processedSnapshot)).toBeFalsy()
+    })
+
+    it('should return false when the replaced hashes where processed', async () => {
+      processedSnapshotStorage.saveProcessed(h1)
+      processedSnapshotStorage.saveProcessed(h2)
+      processedSnapshotStorage.saveProcessed(h3)
+
+      expect(await processedSnapshots.shouldStream(processedSnapshot, [h1, h2, h3])).toBeFalsy()
+    })
+
+    it('should return false and save the snapshot as processed when the replaced hashes where processed', async () => {
+      processedSnapshotStorage.saveProcessed(h1)
+      processedSnapshotStorage.saveProcessed(h2)
+      processedSnapshotStorage.saveProcessed(h3)
+
+      await processedSnapshots.shouldStream(processedSnapshot, [h1, h2, h3])
+
+      const processedSnapshotsInDB = await processedSnapshotStorage.processedFrom([processedSnapshot])
+      expect(processedSnapshotsInDB.has(processedSnapshot)).toBeTruthy()
+    })
+
+    it('should return false when the snapshot is being streamed', async () => {
+      processedSnapshots.startStreamOf(processedSnapshot)
+      expect(await processedSnapshots.shouldStream(processedSnapshot)).toBeFalsy()
+    })
+
+    it('should return false when the snapshot was completely streamed', async () => {
+      processedSnapshots.startStreamOf(processedSnapshot)
+      processedSnapshots.endStreamOf(processedSnapshot, 1)
+      expect(await processedSnapshots.shouldStream(processedSnapshot)).toBeFalsy()
+    })
+
+    it('should return true when the snapshot and the replaced ones were not processed', async () => {
+      expect(await processedSnapshots.shouldStream(processedSnapshot, [h1, h2, h3])).toBeTruthy()
+    })
+
+  })
+
+  describe('endStreamOf', () => {
+    it('should not save the snapshot as processed when there are still entities to process', async () => {
+      processedSnapshots.startStreamOf(processedSnapshot)
+      processedSnapshots.endStreamOf(processedSnapshot, 1)
+
+      const processedSnapshotsInDB = await processedSnapshotStorage.processedFrom([processedSnapshot])
+      expect(processedSnapshotsInDB.size).toEqual(0)
+    })
+
+    it('should save the snapshot as processed when there are not entities to process', async () => {
+      processedSnapshots.startStreamOf(processedSnapshot)
+      processedSnapshots.entityProcessedFrom(processedSnapshot)
+      processedSnapshots.endStreamOf(processedSnapshot, 1)
+
+      const processedSnapshotsInDB = await processedSnapshotStorage.processedFrom([processedSnapshot])
+      expect(processedSnapshotsInDB.size).toEqual(1)
+    })
+  })
+
+  describe('entityProcessedFrom', () => {
+    it('should not save the snapshot as processed when the stream is not finished yet', async () => {
+      processedSnapshots.startStreamOf(processedSnapshot)
+      processedSnapshots.entityProcessedFrom(processedSnapshot)
+      processedSnapshots.entityProcessedFrom(processedSnapshot)
+
+      const processedSnapshotsInDB = await processedSnapshotStorage.processedFrom([processedSnapshot])
+      expect(processedSnapshotsInDB.size).toEqual(0)
+    })
+
+    it('should not save the snapshot as processed when the stream is finished but there still are entities to process', async () => {
+      processedSnapshots.startStreamOf(processedSnapshot)
+      processedSnapshots.endStreamOf(processedSnapshot, 3)
+      processedSnapshots.entityProcessedFrom(processedSnapshot)
+      processedSnapshots.entityProcessedFrom(processedSnapshot)
+
+
+      const processedSnapshotsInDB = await processedSnapshotStorage.processedFrom([processedSnapshot])
+      expect(processedSnapshotsInDB.size).toEqual(0)
+    })
+
+    it('should save the snapshot as processed when there are not entities to process and the stream is finished', async () => {
+      processedSnapshots.startStreamOf(processedSnapshot)
+      processedSnapshots.entityProcessedFrom(processedSnapshot)
+      processedSnapshots.entityProcessedFrom(processedSnapshot)
+      processedSnapshots.endStreamOf(processedSnapshot, 3)
+      processedSnapshots.entityProcessedFrom(processedSnapshot)
+
+      const processedSnapshotsInDB = await processedSnapshotStorage.processedFrom([processedSnapshot])
+      expect(processedSnapshotsInDB.has(processedSnapshot)).toBeTruthy()
+    })
+  })
+})

--- a/test/saveToDisk.spec.ts
+++ b/test/saveToDisk.spec.ts
@@ -89,7 +89,6 @@ test('saveToDisk', ({ components, stubComponents }) => {
         chunk++
         yield 'a'
         if (chunk == 100) {
-          console.log('Closing stream')
           throw new Error('Closing stream')
         }
       }
@@ -107,7 +106,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'working')
     try {
       unlinkSync(filename)
-    } catch {}
+    } catch { }
 
     await saveContentFileToDisk(
       { metrics, storage: components.storage },
@@ -127,7 +126,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'working')
     try {
       unlinkSync(filename)
-    } catch {}
+    } catch { }
 
     await saveContentFileToDisk(
       { metrics, storage: components.storage },
@@ -147,7 +146,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'working')
     try {
       unlinkSync(filename)
-    } catch {}
+    } catch { }
 
     await saveContentFileToDisk(
       { metrics, storage: components.storage },
@@ -180,7 +179,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'fails')
     try {
       unlinkSync(filename)
-    } catch {}
+    } catch { }
 
     // check file exists and has correct content
     expect(await checkFileExists(filename)).toEqual(false)
@@ -203,7 +202,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'fails404')
     try {
       unlinkSync(filename)
-    } catch {}
+    } catch { }
 
     // check file exists and has correct content
     expect(await checkFileExists(filename)).toEqual(false)
@@ -226,7 +225,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'failsECONNREFUSED')
     try {
       unlinkSync(filename)
-    } catch {}
+    } catch { }
 
     // check file exists and has correct content
     expect(await checkFileExists(filename)).toEqual(false)
@@ -250,7 +249,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'failsTLS')
     try {
       unlinkSync(filename)
-    } catch {}
+    } catch { }
 
     // check file exists and has correct content
     expect(await checkFileExists(filename)).toEqual(false)
@@ -274,7 +273,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'decentraland.org')
     try {
       unlinkSync(filename)
-    } catch {}
+    } catch { }
 
     // check file exists and has correct content
     expect(await checkFileExists(filename)).toEqual(false)
@@ -346,7 +345,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'QmInValidHash')
     try {
       unlinkSync(filename)
-    } catch {}
+    } catch { }
 
     // check file exists and has correct content
     expect(await checkFileExists(filename)).toEqual(false)

--- a/test/test-component.ts
+++ b/test/test-component.ts
@@ -18,7 +18,7 @@ export function createFetchComponent() {
 }
 
 export async function createStorageComponent(): Promise<IContentStorageComponent> {
-  console.log('called')
+
   const rootFixturesDir = 'test/fixtures'
 
   const files = await readdir(rootFixturesDir)

--- a/test/test-component.ts
+++ b/test/test-component.ts
@@ -44,17 +44,13 @@ export async function createStorageComponent(): Promise<IContentStorageComponent
 
 export function createProcessedSnapshotStorageComponent(): IProcessedSnapshotStorageComponent {
   const processedSnapshots = new Set()
+
   return {
-    async wasSnapshotProcessed(hash: string, replacedSnapshotHashes?: string[]) {
-      const replacedSnapshotsWereProcessed =
-        replacedSnapshotHashes
-          ? replacedSnapshotHashes.length > 0 && replacedSnapshotHashes.every(s => processedSnapshots.has(s))
-          : false
-      return replacedSnapshotsWereProcessed || processedSnapshots.has(hash)
+    async processedFrom(snapshotHashes: string[]) {
+      return new Set(snapshotHashes.filter(h => processedSnapshots.has(h)))
     },
-    async markSnapshotProcessed(hash: string) {
-      processedSnapshots.add(hash)
+    async saveProcessed(snapshotHash: string) {
+      processedSnapshots.add(snapshotHash)
     }
   }
-
 }

--- a/test/test-component.ts
+++ b/test/test-component.ts
@@ -45,9 +45,12 @@ export async function createStorageComponent(): Promise<IContentStorageComponent
 export function createProcessedSnapshotStorageComponent(): IProcessedSnapshotStorageComponent {
   const processedSnapshots = new Set()
   return {
-    async wasSnapshotProcessed(hash: string) {
-      return processedSnapshots.has(hash)
-      // return false
+    async wasSnapshotProcessed(hash: string, replacedSnapshotHashes?: string[]) {
+      const replacedSnapshotsWereProcessed =
+        replacedSnapshotHashes
+          ? replacedSnapshotHashes.length > 0 && replacedSnapshotHashes.every(s => processedSnapshots.has(s))
+          : false
+      return replacedSnapshotsWereProcessed || processedSnapshots.has(hash)
     },
     async markSnapshotProcessed(hash: string) {
       processedSnapshots.add(hash)

--- a/test/test-component.ts
+++ b/test/test-component.ts
@@ -5,8 +5,7 @@ import { readdir, stat } from 'fs/promises'
 import { resolve } from 'path'
 import { MockedStorage } from '@dcl/catalyst-storage/dist/MockedStorage'
 import { IContentStorageComponent } from '@dcl/catalyst-storage'
-import { TestComponents } from './components'
-import { ISnapshotProcessEndTaskComponent } from '../src/types'
+import { IProcessedSnapshotStorageComponent } from '../src/types'
 
 export function createFetchComponent() {
   const fetch: IFetchComponent = {
@@ -19,6 +18,7 @@ export function createFetchComponent() {
 }
 
 export async function createStorageComponent(): Promise<IContentStorageComponent> {
+  console.log('called')
   const rootFixturesDir = 'test/fixtures'
 
   const files = await readdir(rootFixturesDir)
@@ -42,11 +42,15 @@ export async function createStorageComponent(): Promise<IContentStorageComponent
   return mockFileSystem
 }
 
-export function createSnapshotProcessEndTaskComponent(components: Pick<TestComponents, 'logs'>): ISnapshotProcessEndTaskComponent {
-  const endTaskLogger = components.logs.getLogger('snapshots-fetcher')
+export function createProcessedSnapshotStorageComponent(): IProcessedSnapshotStorageComponent {
+  const processedSnapshots = new Set()
   return {
-    async onSnapshotSuccessfullyProcessed(hash: string) {
-      endTaskLogger.info(`Finished processing snapshot with hash: ${hash}`)
+    async wasSnapshotProcessed(hash: string) {
+      return processedSnapshots.has(hash)
+      // return false
+    },
+    async markSnapshotProcessed(hash: string) {
+      processedSnapshots.add(hash)
     }
   }
 

--- a/test/test-component.ts
+++ b/test/test-component.ts
@@ -5,6 +5,8 @@ import { readdir, stat } from 'fs/promises'
 import { resolve } from 'path'
 import { MockedStorage } from '@dcl/catalyst-storage/dist/MockedStorage'
 import { IContentStorageComponent } from '@dcl/catalyst-storage'
+import { TestComponents } from './components'
+import { ISnapshotProcessEndTaskComponent } from '../src/types'
 
 export function createFetchComponent() {
   const fetch: IFetchComponent = {
@@ -38,4 +40,14 @@ export async function createStorageComponent(): Promise<IContentStorageComponent
   await reset()
 
   return mockFileSystem
+}
+
+export function createSnapshotProcessEndTaskComponent(components: Pick<TestComponents, 'logs'>): ISnapshotProcessEndTaskComponent {
+  const endTaskLogger = components.logs.getLogger('snapshots-fetcher')
+  return {
+    async onSnapshotSuccessfullyProcessed(hash: string) {
+      endTaskLogger.info(`Finished processing snapshot with hash: ${hash}`)
+    }
+  }
+
 }


### PR DESCRIPTION
This PR adds the functionality of reading snapshots of the new endpoint `/snapshots` that provides the active entities in multiple snapshots instead of a whole big one.
A `synchronizer` was added that is in charge of syncing the specified servers by deploying all the entities from snapshots and pointer-changes. It has mechanisms for retrying when things fail.
Also, with the possibility that a snapshot converges, if there are two servers (or more) with the same snapshot, it is downloaded only from one of them, and the entities inside are fetched from all the servers that have that snapshot as a load balancing mechanism.
The `synchronizer` maintains the servers in 3 states:
1. Bootstrap from snapshots: deploying the entities in the snapshots of that server.
2. Bootstrap from pointer-changes: deploying entities from pointer-changes between the last timestamp of its snapshots and now.
3. Syncing: deploying entities polling from pointer-changes.
When a server finishes the tasks in one state, goes to the next one. Retry mechanisms are done if something fails.

When all the initial servers to sync try to perform at least once with states (1) and (2), the initial bootstrap is considered as done, and the Catalysts startup. Note: if some server fails, it'll retry later but the initial bootstrap will finishes anyway.