### PR TITLE
chore: fix publish notification pipeline to properly check for dependabot PRs

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -47,7 +47,7 @@ jobs:
 
   notify_deployment:
     needs: [check_and_build]
-    if: ${{ github.event.pull_request.number }} && !startsWith(github.head_ref, 'dependabot)
+    if: ${{ github.event.pull_request.number && !startsWith(github.head_ref, 'dependabot/') }}
     runs-on: ubuntu-latest
     name: Deployment Notification
     steps:


### PR DESCRIPTION
This PR avoids running publish notification step from pipeline for dependabot PRs.