### PR TITLE
feat: make metrics optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ downloads/**/*
 temp
 coverage
 **/.DS_Store
+.vscode

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,7 +19,7 @@ export async function getSnapshots(
 }
 
 export async function* fetchJsonPaginated<T>(
-  components: Pick<SnapshotsFetcherComponents, 'fetcher' | 'metrics'>,
+  components: Pick<SnapshotsFetcherComponents, 'fetcher'> & { metrics?: SnapshotsFetcherComponents['metrics'] },
   url: string,
   selector: (responseBody: any) => T[],
   responseTimeMetric: keyof typeof metricsDefinitions
@@ -28,7 +28,7 @@ export async function* fetchJsonPaginated<T>(
   let currentUrl = url
   while (currentUrl) {
     const metricLabels = contentServerMetricLabels(currentUrl)
-    const { end: stopTimer } = components.metrics.startTimer(responseTimeMetric)
+    const { end: stopTimer } = components.metrics?.startTimer(responseTimeMetric) || { end: () => {} }
     const partialHistory: any = await fetchJson(currentUrl, components.fetcher)
     stopTimer({ ...metricLabels })
 
@@ -47,7 +47,7 @@ export async function* fetchJsonPaginated<T>(
 }
 
 export async function* fetchPointerChanges(
-  components: Pick<SnapshotsFetcherComponents, 'fetcher' | 'metrics'>,
+  components: Pick<SnapshotsFetcherComponents, 'fetcher'> & { metrics?: SnapshotsFetcherComponents['metrics'] },
   server: string,
   fromTimestamp: number,
   logger: ILoggerComponent.ILogger
@@ -73,7 +73,7 @@ export async function* fetchPointerChanges(
 }
 
 export async function saveContentFileToDisk(
-  components: Pick<SnapshotsFetcherComponents, 'metrics' | 'storage'>,
+  components: Pick<SnapshotsFetcherComponents, 'storage'> & { metrics?: SnapshotsFetcherComponents['metrics'] },
   server: string,
   hash: string,
   destinationFilename: string

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -6,7 +6,7 @@ import { pickLeastRecentlyUsedServer, sleep } from './utils'
 const downloadFileJobsMap = new Map<Path, ReturnType<typeof downloadFileWithRetries>>()
 
 async function downloadJob(
-  components: Pick<SnapshotsFetcherComponents, 'metrics' | 'storage'>,
+  components: Pick<SnapshotsFetcherComponents, 'storage'> & { metrics?: SnapshotsFetcherComponents['metrics'] },
   hashToDownload: string,
   finalFileName: string,
   presentInServers: string[],
@@ -23,9 +23,9 @@ async function downloadJob(
     retries++
     const serverToUse = pickLeastRecentlyUsedServer(serversToPickFrom)
     try {
-      components.metrics.observe('dcl_available_servers_histogram', {}, presentInServers.length)
+      components.metrics?.observe('dcl_available_servers_histogram', {}, presentInServers.length)
       await downloadContentFile(components, hashToDownload, finalFileName, serverToUse)
-      components.metrics.observe('dcl_content_download_job_succeed_retries', {}, retries)
+      components.metrics?.observe('dcl_content_download_job_succeed_retries', {}, retries)
 
       return
     } catch (e: any) {
@@ -48,7 +48,7 @@ async function downloadJob(
  * being downloaded
  */
 export async function downloadFileWithRetries(
-  components: Pick<SnapshotsFetcherComponents, 'metrics' | 'storage'>,
+  components: Pick<SnapshotsFetcherComponents, 'storage'> & { metrics?: SnapshotsFetcherComponents['metrics'] },
   hashToDownload: string,
   targetTempFolder: string,
   presentInServers: string[],
@@ -81,7 +81,7 @@ export async function downloadFileWithRetries(
 }
 
 async function downloadContentFile(
-  components: Pick<SnapshotsFetcherComponents, 'metrics' | 'storage'>,
+  components: Pick<SnapshotsFetcherComponents, 'storage'> & { metrics?: SnapshotsFetcherComponents['metrics'] },
   hash: string,
   finalFileName: string,
   serverToUse: string

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -18,7 +18,9 @@ export { IDeployerComponent, SynchronizerComponent } from './types'
  * @public
  */
 export async function* getDeployedEntitiesStreamFromSnapshot(
-  components: Pick<SnapshotsFetcherComponents, 'logs' | 'metrics' | 'storage'>,
+  components: Pick<SnapshotsFetcherComponents, 'logs' | 'storage'> & {
+    metrics?: SnapshotsFetcherComponents['metrics']
+  },
   options: SnapshotDeployedEntityStreamOptions,
   snapshotHash: string,
   servers: Set<string>
@@ -42,7 +44,7 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
     const deploymentsInFile = processDeploymentsInFile(snapshotHash, components, logs)
     for await (const deployment of deploymentsInFile) {
       if (deployment.entityTimestamp >= genesisTimestamp) {
-        components.metrics.increment('dcl_entities_deployments_streamed_total', { source: 'snapshots' })
+        components.metrics?.increment('dcl_entities_deployments_streamed_total', { source: 'snapshots' })
         yield {
           ...deployment,
           snapshotHash,
@@ -67,7 +69,9 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
  * @public
  */
 export async function* getDeployedEntitiesStreamFromPointerChanges(
-  components: Pick<SnapshotsFetcherComponents, 'logs' | 'metrics' | 'fetcher'>,
+  components: Pick<SnapshotsFetcherComponents, 'logs' | 'fetcher'> & {
+    metrics?: SnapshotsFetcherComponents['metrics']
+  },
   options: PointerChangesDeployedEntityStreamOptions,
   contentServer: string
 ) {
@@ -85,7 +89,7 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
     for await (const deployment of pointerChanges) {
       // selectively ignore deployments by localTimestamp
       if (deployment.localTimestamp >= genesisTimestamp) {
-        components.metrics.increment('dcl_entities_deployments_streamed_total', { source: 'pointer-changes' })
+        components.metrics?.increment('dcl_entities_deployments_streamed_total', { source: 'pointer-changes' })
         yield deployment
       }
 


### PR DESCRIPTION
This PR makes the metrics component optional. There are some use cases where we use this fetcher as a one-off execution to quickly warm data with Catalyst entities. In these cases, we are not interested in reporting metrics about snapshot fetching since we do not completely rely on it, but it is used to quickly warm up the service.