### PR TITLE
fix: logs flooding by setting recursive log as DEBUG instead of INFO

### DIFF
--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -79,7 +79,7 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
   // fetch the /pointer-changes of the remote server using the last timestamp from the previous step with a grace period of 20 min
   const genesisTimestamp = options.fromTimestamp || 0
   let greatestLocalTimestampProcessed = genesisTimestamp
-  logs.info('Starting to stream entities from Pointer-Changes.', {
+  logs.debug('Starting to stream entities from Pointer-Changes.', {
     contentServer,
     timestamp: new Date(genesisTimestamp).toISOString()
   })


### PR DESCRIPTION
This recursive log is flooding logs from the service using the library. Setting it as `DEBUG`.