### PR TITLE
chore: use @dcl packages instead of @well-known-components

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },
-  testTimeout: 65000,
+  testTimeout: 60000,
   coverageDirectory: 'coverage',
   verbose: true,
   testMatch: ['**/*.spec.(ts)'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },
-  testTimeout: 60000,
+  testTimeout: 65000,
   coverageDirectory: 'coverage',
   verbose: true,
   testMatch: ['**/*.spec.(ts)'],

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@dcl/eslint-config": "^1.1.1",
-    "@dcl/http-server": "^1.0.0",
+    "@dcl/http-server": "^1.0.1",
     "@types/node": "^18.15.11",
     "@well-known-components/env-config-provider": "^1.1.1",
     "@well-known-components/logger": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@dcl/catalyst-storage": "^4.0.0",
     "@dcl/hashing": "^3.0.3",
     "@dcl/schemas": "^9.1.1",
+    "@well-known-components/fetch-component": "^3.0.0",
     "@well-known-components/interfaces": "^1.4.0",
     "@well-known-components/metrics": "^2.0.0",
     "p-queue": "^6.6.2"
@@ -39,9 +40,9 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@dcl/eslint-config": "^1.1.1",
+    "@dcl/http-server": "^1.0.0",
     "@types/node": "^18.15.11",
     "@well-known-components/env-config-provider": "^1.1.1",
-    "@well-known-components/http-server": "^2.0.0",
     "@well-known-components/logger": "^3.0.0",
     "@well-known-components/test-helpers": "^1.2.1",
     "babel-plugin-module-resolver": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "dependencies": {
     "@dcl/catalyst-storage": "^4.0.0",
     "@dcl/hashing": "^3.0.3",
+    "@dcl/metrics": "^1.0.0",
     "@dcl/schemas": "^9.1.1",
     "@well-known-components/fetch-component": "^3.0.0",
     "@well-known-components/interfaces": "^1.4.0",
-    "@well-known-components/metrics": "^2.0.0",
     "p-queue": "^6.6.2"
   },
   "engines": {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,4 +1,4 @@
-import { validateMetricsDeclaration } from '@well-known-components/metrics'
+import { validateMetricsDeclaration } from '@dcl/metrics'
 
 type ContentServerMetricLabelNames = 'remote_server'
 export type ContentServerMetricLabels = Record<ContentServerMetricLabelNames, string>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,6 @@
 import { IContentStorageComponent } from '@dcl/catalyst-storage'
 import { SyncDeployment } from '@dcl/schemas'
-import { IFetchComponent } from '@well-known-components/http-server'
-import { IBaseComponent, ILoggerComponent, IMetricsComponent } from '@well-known-components/interfaces'
+import { IBaseComponent, IFetchComponent, ILoggerComponent, IMetricsComponent } from '@well-known-components/interfaces'
 import { ExponentialFallofRetryComponent } from './exponential-fallof-retry'
 import { IJobQueue } from './job-queue-port'
 import { metricsDefinitions } from './metrics'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { hashV0, hashV1 } from '@dcl/hashing'
-import { IFetchComponent } from '@well-known-components/http-server'
+import { IFetchComponent } from '@well-known-components/interfaces'
 import * as crypto from 'crypto'
 import * as fs from 'fs'
 import * as http from 'http'

--- a/test/components.ts
+++ b/test/components.ts
@@ -6,16 +6,16 @@ import { createJobQueue } from '../src/job-queue-port'
 import { SnapshotsFetcherComponents } from '../src/types'
 import { createFetchComponent, createProcessedSnapshotStorageComponent, createStorageComponent } from './test-component'
 
+import { createTestMetricsComponent } from '@dcl/metrics'
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+import { IConfigComponent } from '@well-known-components/interfaces'
+import { createLogComponent } from '@well-known-components/logger'
+import { metricsDefinitions } from '../src'
 import {
   initTestServerComponents,
   TestServerComponents,
-  wireTestServerComponents,
+  wireTestServerComponents
 } from './functions-for-wkc-test-helpers'
-import { createLogComponent } from '@well-known-components/logger'
-import { createTestMetricsComponent } from '@well-known-components/metrics'
-import { metricsDefinitions } from '../src'
-import { IConfigComponent } from "@well-known-components/interfaces"
-import { createConfigComponent } from "@well-known-components/env-config-provider"
 
 // Record of components
 export type TestComponents = SnapshotsFetcherComponents & TestServerComponents<SnapshotsFetcherComponents>
@@ -37,9 +37,9 @@ export const test = createRunner<TestComponents>({
     const downloadQueue = createJobQueue({
       autoStart: true,
       concurrency: 1,
-      timeout: 100000,
+      timeout: 100000
     })
-    const config: IConfigComponent = createConfigComponent({ ...process.env, LOG_LEVEL: "INFO" })
+    const config: IConfigComponent = createConfigComponent({ ...process.env, LOG_LEVEL: 'INFO' })
     const logs = await createLogComponent({ config })
     const metrics = createTestMetricsComponent(metricsDefinitions)
     const testServerComponents = await initTestServerComponents()
@@ -61,5 +61,5 @@ export const test = createRunner<TestComponents>({
       processedSnapshotStorage,
       snapshotStorage
     }
-  },
+  }
 })

--- a/test/functions-for-wkc-test-helpers.ts
+++ b/test/functions-for-wkc-test-helpers.ts
@@ -1,7 +1,7 @@
 // The functions in this file may be migrated to http-server test helpers
 
+import { createServerComponent, Router } from '@dcl/http-server'
 import { createConfigComponent } from '@well-known-components/env-config-provider'
-import { createServerComponent, Router } from '@well-known-components/http-server'
 import { IConfigComponent, IHttpServerComponent, ILoggerComponent } from '@well-known-components/interfaces'
 import { createLogComponent } from '@well-known-components/logger'
 import { defaultServerConfig } from '@well-known-components/test-helpers'
@@ -73,8 +73,7 @@ export async function wireTestServerComponents<T>(context: TestServerAppContext<
  * Creates a test server and returns all the components and helpers
  */
 export async function initTestServerComponents(): Promise<TestServerComponents<any>> {
-
-  const config = createConfigComponent({...defaultServerConfig(), LOG_LEVEL: "INFO"})
+  const config = createConfigComponent({ ...defaultServerConfig(), LOG_LEVEL: 'INFO' })
 
   const logs = await createLogComponent({ config })
 
@@ -91,6 +90,6 @@ export async function initTestServerComponents(): Promise<TestServerComponents<a
     config,
     getBaseUrl,
     router,
-    server,
+    server
   }
 }

--- a/test/saveToDisk.spec.ts
+++ b/test/saveToDisk.spec.ts
@@ -1,12 +1,12 @@
-import { test } from './components'
-import { readFileSync, unlinkSync, promises as fsPromises, constants } from 'fs'
+import { createTestMetricsComponent } from '@dcl/metrics'
+import { unlinkSync } from 'fs'
 import { resolve } from 'path'
 import { Readable } from 'stream'
 import { gzipSync } from 'zlib'
-import { checkFileExists, saveContentFileToDisk, streamToBuffer } from '../src/utils'
 import { downloadFileWithRetries } from '../src/downloader'
 import { metricsDefinitions } from '../src/metrics'
-import { createTestMetricsComponent } from '@well-known-components/metrics'
+import { checkFileExists, saveContentFileToDisk, streamToBuffer } from '../src/utils'
+import { test } from './components'
 
 const maxRetries = 10
 const waitTimeBetweenRetries = 100
@@ -23,42 +23,42 @@ test('saveToDisk', ({ components, stubComponents }) => {
   it('prepares the endpoints', () => {
     components.router.get(`/working`, async () => {
       return {
-        body: content.toString(),
+        body: content.toString()
       }
     })
     components.router.get(`/working-redirected-302`, async () => {
       return {
         status: 302,
         headers: {
-          location: '/working',
-        },
+          location: '/working'
+        }
       }
     })
     components.router.get(`/working-redirected-301`, async () => {
       return {
         status: 301,
         headers: {
-          location: '/working',
-        },
+          location: '/working'
+        }
       }
     })
     components.router.get(`/forever-redirecting-301`, async () => {
       return {
         status: 301,
         headers: {
-          location: '/forever-redirecting-301',
-        },
+          location: '/forever-redirecting-301'
+        }
       }
     })
     components.router.get(`/QmInValidHash`, async () => {
       return {
-        body: content.toString(),
+        body: content.toString()
       }
     })
 
     components.router.get(`/contents/alwaysFails`, async () => {
       return {
-        status: 503,
+        status: 503
       }
     })
 
@@ -67,7 +67,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     components.router.get(`/contents/bafkreigwey5vc6q25ilofdu2vjvcag72eqj46lzipi6mredsfpe42ls2ri`, async () => {
       if (wasCalled) {
         return {
-          status: 503,
+          status: 503
         }
       }
 
@@ -76,8 +76,8 @@ test('saveToDisk', ({ components, stubComponents }) => {
         status: 200,
         body: gzipSync('some file'),
         headers: {
-          'content-encoding': 'gzip',
-        },
+          'content-encoding': 'gzip'
+        }
       }
     })
 
@@ -95,9 +95,9 @@ test('saveToDisk', ({ components, stubComponents }) => {
 
       return {
         headers: {
-          'content-length': '100000',
+          'content-length': '100000'
         },
-        body: Readable.from(streamContent(), { encoding: 'utf-8' }),
+        body: Readable.from(streamContent(), { encoding: 'utf-8' })
       }
     })
   })
@@ -106,7 +106,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'working')
     try {
       unlinkSync(filename)
-    } catch { }
+    } catch {}
 
     await saveContentFileToDisk(
       { metrics, storage: components.storage },
@@ -126,7 +126,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'working')
     try {
       unlinkSync(filename)
-    } catch { }
+    } catch {}
 
     await saveContentFileToDisk(
       { metrics, storage: components.storage },
@@ -146,7 +146,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'working')
     try {
       unlinkSync(filename)
-    } catch { }
+    } catch {}
 
     await saveContentFileToDisk(
       { metrics, storage: components.storage },
@@ -179,7 +179,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'fails')
     try {
       unlinkSync(filename)
-    } catch { }
+    } catch {}
 
     // check file exists and has correct content
     expect(await checkFileExists(filename)).toEqual(false)
@@ -202,7 +202,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'fails404')
     try {
       unlinkSync(filename)
-    } catch { }
+    } catch {}
 
     // check file exists and has correct content
     expect(await checkFileExists(filename)).toEqual(false)
@@ -225,7 +225,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'failsECONNREFUSED')
     try {
       unlinkSync(filename)
-    } catch { }
+    } catch {}
 
     // check file exists and has correct content
     expect(await checkFileExists(filename)).toEqual(false)
@@ -249,7 +249,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'failsTLS')
     try {
       unlinkSync(filename)
-    } catch { }
+    } catch {}
 
     // check file exists and has correct content
     expect(await checkFileExists(filename)).toEqual(false)
@@ -273,7 +273,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'decentraland.org')
     try {
       unlinkSync(filename)
-    } catch { }
+    } catch {}
 
     // check file exists and has correct content
     expect(await checkFileExists(filename)).toEqual(false)
@@ -345,7 +345,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     const filename = resolve(contentFolder, 'QmInValidHash')
     try {
       unlinkSync(filename)
-    } catch { }
+    } catch {}
 
     // check file exists and has correct content
     expect(await checkFileExists(filename)).toEqual(false)

--- a/test/saveToDisk.spec.ts
+++ b/test/saveToDisk.spec.ts
@@ -85,11 +85,12 @@ test('saveToDisk', ({ components, stubComponents }) => {
       let chunk = 0
 
       function* streamContent() {
-        // sleep to fool the nagle algorithm
-        chunk++
-        yield 'a'
-        if (chunk == 100) {
-          throw new Error('aborted')
+        while (true) {
+          chunk++
+          yield 'a'
+          if (chunk == 100) {
+            throw new Error('aborted')
+          }
         }
       }
 

--- a/test/saveToDisk.spec.ts
+++ b/test/saveToDisk.spec.ts
@@ -83,24 +83,21 @@ test('saveToDisk', ({ components, stubComponents }) => {
 
     components.router.get(`/fails`, async () => {
       let chunk = 0
-      const stream = new Readable({
-        encoding: 'utf-8',
-        read() {
-          chunk++
-          if (chunk <= 100) {
-            this.push('a')
-          } else {
-            // Abort the stream after 100 chunks
-            this.destroy(new Error('aborted'))
-          }
+
+      function* streamContent() {
+        // sleep to fool the nagle algorithm
+        chunk++
+        yield 'a'
+        if (chunk == 100) {
+          throw new Error('aborted')
         }
-      })
+      }
 
       return {
         headers: {
           'content-length': '100000'
         },
-        body: stream
+        body: Readable.from(streamContent(), { encoding: 'utf-8' })
       }
     })
   })

--- a/test/test-component.ts
+++ b/test/test-component.ts
@@ -1,11 +1,11 @@
-import { IFetchComponent } from '@well-known-components/http-server'
-import * as nodeFetch from 'node-fetch'
+import { createInMemoryStorage, IContentStorageComponent } from '@dcl/catalyst-storage'
+import { IFetchComponent } from '@well-known-components/interfaces'
 import { readFileSync } from 'fs'
 import { readdir, stat } from 'fs/promises'
+import * as nodeFetch from 'node-fetch'
 import { resolve } from 'path'
-import { createInMemoryStorage, IContentStorageComponent } from '@dcl/catalyst-storage'
-import { IProcessedSnapshotStorageComponent } from '../src/types'
 import { Readable } from 'stream'
+import { IProcessedSnapshotStorageComponent } from '../src/types'
 
 export function createFetchComponent() {
   const fetch: IFetchComponent = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,10 +675,10 @@
   resolved "https://registry.yarnpkg.com/@dcl/hashing/-/hashing-3.0.4.tgz#4df2a4cb3a8114765aed34cb57b91c93bf33bfb3"
   integrity sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg==
 
-"@dcl/http-server@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@dcl/http-server/-/http-server-1.0.0.tgz#202fe016e755ac9798668051f466fe496737c232"
-  integrity sha512-Dq7hjrOfwUY2VztmZlk70OwOFkwiLO360BgJw4h2BFfYc0RACmw7TFI/uq/nHMJPNSs2Zi1htzuWQQsPAg1RQw==
+"@dcl/http-server@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@dcl/http-server/-/http-server-1.0.1.tgz#aa0d93b1a9d945c62cf46ba72cfa8d52f55c0332"
+  integrity sha512-dFKJtSr0ESS388PkzOnJLNd2KfsV3nacRZvOlaIH0GpVwemZfYe5SjZv3VTGygKxUA5C/knqiKrUtBiYFP2j3w==
   dependencies:
     "@types/http-errors" "^2.0.4"
     destroy "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,6 +675,21 @@
   resolved "https://registry.yarnpkg.com/@dcl/hashing/-/hashing-3.0.4.tgz#4df2a4cb3a8114765aed34cb57b91c93bf33bfb3"
   integrity sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg==
 
+"@dcl/http-server@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@dcl/http-server/-/http-server-1.0.0.tgz#202fe016e755ac9798668051f466fe496737c232"
+  integrity sha512-Dq7hjrOfwUY2VztmZlk70OwOFkwiLO360BgJw4h2BFfYc0RACmw7TFI/uq/nHMJPNSs2Zi1htzuWQQsPAg1RQw==
+  dependencies:
+    "@types/http-errors" "^2.0.4"
+    destroy "^1.2.0"
+    fp-future "^1.0.1"
+    http-errors "^2.0.0"
+    mitt "^3.0.0"
+    node-fetch "^2.6.9"
+    on-finished "^2.4.1"
+    path-to-regexp "^6.3.0"
+    reflect-metadata "^0.2.2"
+
 "@dcl/schemas@^9.1.1":
   version "9.9.0"
   resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-9.9.0.tgz#868693b46ef3d64b166d095bb0405d5119de461a"
@@ -1164,10 +1179,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/http-errors@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.1.tgz#20172f9578b225f6c7da63446f56d4ce108d5a65"
-  integrity sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==
+"@types/http-errors@^2.0.4":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.5.tgz#5b749ab2b16ba113423feb1a64a95dcd30398472"
+  integrity sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
@@ -1356,24 +1371,27 @@
   dependencies:
     dotenv "^16.0.1"
 
-"@well-known-components/http-server@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@well-known-components/http-server/-/http-server-2.0.0.tgz#85ec93080ae64f962782699db3eeecd597f59405"
-  integrity sha512-baDP0+MpgqTnKLFFXS41WBbg9QIGCXTEA7BHf6JqW1evrTW10MKEx+rgEvQQlhCA5oXxUdKOD+xNnR3GqzGw9w==
+"@well-known-components/fetch-component@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@well-known-components/fetch-component/-/fetch-component-3.0.0.tgz#93921f0d18b1fc21f1f5540cc4ae035a0dabf55d"
+  integrity sha512-ycIaojkwLJvhpicdPsmsEzA9qPbV7voAjrRcVE7+n7UNctIQC8ppymapj0UQ3FFpdEWWVSzjoo33H0BW+sD8eg==
   dependencies:
-    "@types/http-errors" "^2.0.1"
-    destroy "^1.2.0"
-    fp-future "^1.0.1"
-    http-errors "^2.0.0"
-    mitt "^3.0.0"
-    node-fetch "^2.6.9"
-    on-finished "^2.4.1"
-    path-to-regexp "^6.2.1"
+    "@well-known-components/interfaces" "^1.4.1"
+    cross-fetch "^3.1.5"
 
 "@well-known-components/interfaces@^1.1.1", "@well-known-components/interfaces@^1.4.0":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@well-known-components/interfaces/-/interfaces-1.4.2.tgz#e37eb296280abfcab14f0608b3bdfc84d5a21929"
   integrity sha512-1tkr/OhZ4UmnQiST2svKznEiJ86crV2S+AIhokhowR4MexAKWgYlmZpoP6VIcgDVPf7nu8hOtIPMQaCZ+COC0A==
+  dependencies:
+    "@types/node" "^20.3.1"
+    "@types/node-fetch" "^2.5.12"
+    typed-url-params "^1.0.1"
+
+"@well-known-components/interfaces@^1.4.1":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@well-known-components/interfaces/-/interfaces-1.5.2.tgz#ef7001a19d410459e65b216dd948d15be19e4efa"
+  integrity sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==
   dependencies:
     "@types/node" "^20.3.1"
     "@types/node-fetch" "^2.5.12"
@@ -1879,6 +1897,13 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-fetch@^3.1.5:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.2.0.tgz#34e9192f53bc757d6614304d9e5e6fb4edb782e3"
+  integrity sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==
+  dependencies:
+    node-fetch "^2.7.0"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
@@ -1930,9 +1955,9 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-depd@2.0.0:
+depd@~2.0.0:
   version "2.0.0"
-  resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 destroy@^1.2.0:
@@ -1988,7 +2013,7 @@ dotenv@^16.0.1:
 
 ee-first@1.1.1:
   version "1.1.1"
-  resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.188:
@@ -2507,7 +2532,7 @@ form-data@^3.0.0:
 
 fp-future@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.npmjs.org/fp-future/-/fp-future-1.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/fp-future/-/fp-future-1.0.1.tgz#72e6247814f7a706d84939e5f459c2d7ec42316f"
   integrity sha512-2McmZH/KsZqlqHju9+Ox0FC7q7Knve4t6ZeKubbhAz1xpnD7hkCrP8TP5g5QbbD5bA5jBANbXf/ew4x1FjSUrw==
 
 fs.realpath@^1.0.0:
@@ -2728,15 +2753,15 @@ html-escaper@^2.0.0:
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 http-errors@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
-  integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
+  integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
   dependencies:
-    depd "2.0.0"
-    inherits "2.0.4"
-    setprototypeof "1.2.0"
-    statuses "2.0.1"
-    toidentifier "1.0.1"
+    depd "~2.0.0"
+    inherits "~2.0.4"
+    setprototypeof "~1.2.0"
+    statuses "~2.0.2"
+    toidentifier "~1.0.1"
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -2787,7 +2812,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3:
+inherits@2, inherits@^2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3605,9 +3630,9 @@ minimatch@^5.0.1:
     brace-expansion "^2.0.1"
 
 mitt@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.0.tgz#69ef9bd5c80ff6f57473e8d89326d01c414be0bd"
-  integrity sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
+  integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
 ms@2.1.2:
   version "2.1.2"
@@ -3651,10 +3676,17 @@ nise@^5.1.5:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
-node-fetch@^2.6.7, node-fetch@^2.6.9:
+node-fetch@^2.6.7:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
   integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.9, node-fetch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -3721,7 +3753,7 @@ object.values@^1.1.6:
 
 on-finished@^2.4.1:
   version "2.4.1"
-  resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
   dependencies:
     ee-first "1.1.1"
@@ -3861,10 +3893,10 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
-path-to-regexp@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz"
-  integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
+path-to-regexp@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
+  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -3970,6 +4002,11 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+reflect-metadata@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz#400c845b6cba87a21f2c65c4aeb158f4fa4d9c5b"
+  integrity sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==
 
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"
@@ -4109,9 +4146,9 @@ semver@^7.3.7:
   dependencies:
     lru-cache "^6.0.0"
 
-setprototypeof@1.2.0:
+setprototypeof@~1.2.0:
   version "1.2.0"
-  resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 shebang-command@^2.0.0:
@@ -4199,10 +4236,10 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-statuses@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz"
-  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+statuses@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -4335,9 +4372,9 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-toidentifier@1.0.1:
+toidentifier@~1.0.1:
   version "1.0.1"
-  resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
 tr46@~0.0.3:

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,6 +690,13 @@
     path-to-regexp "^6.3.0"
     reflect-metadata "^0.2.2"
 
+"@dcl/metrics@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@dcl/metrics/-/metrics-1.0.0.tgz#d6b109f69835958e82e13bfdd159c6f287c38ac3"
+  integrity sha512-J0zFHYe8mMl0+IlO/XqXB+OJdqSaN5hT4IziXULSVife5NKwq2oHRYm7i240hayImchSQ4Kze/0M8vbWbWsMRw==
+  dependencies:
+    prom-client "^15.1.0"
+
 "@dcl/schemas@^9.1.1":
   version "9.9.0"
   resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-9.9.0.tgz#868693b46ef3d64b166d095bb0405d5119de461a"
@@ -1049,6 +1056,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@opentelemetry/api@^1.4.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
+  integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
+
 "@sinclair/typebox@^0.25.16":
   version "0.25.24"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
@@ -1402,13 +1414,6 @@
   resolved "https://registry.yarnpkg.com/@well-known-components/logger/-/logger-3.1.3.tgz#b1f4a76ac5e0d89c276cf339fe44a61f46023d2f"
   integrity sha512-tTjD27CdfU4SVe+kPfjRbPSqdrw0Crg+M31RNejinCuMEBtEGbhYLtB1M4gn+PSTy2Oi3cI3iOdeQ1xVhMSerQ==
 
-"@well-known-components/metrics@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@well-known-components/metrics/-/metrics-2.0.1.tgz"
-  integrity sha512-jgT9TuxVS9GzVMMYWXNJRM2qXvexuf4xfrFNBYa3w+gqEWCK4Id5R4zBee/bm6/F5yIPauAWxbOS6KNNDBIrGw==
-  dependencies:
-    prom-client "^14.1.0"
-
 "@well-known-components/test-helpers@^1.2.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@well-known-components/test-helpers/-/test-helpers-1.5.4.tgz#a589c1603ddf8ac5e137c1a1c8a51b1eb49066af"
@@ -1687,7 +1692,7 @@ base64-js@^1.0.2:
 
 bintrees@1.0.2:
   version "1.0.2"
-  resolved "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
   integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
 
 brace-expansion@^1.1.7:
@@ -3958,11 +3963,12 @@ pretty-format@^29.0.0, pretty-format@^29.5.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-prom-client@^14.1.0:
-  version "14.1.0"
-  resolved "https://registry.npmjs.org/prom-client/-/prom-client-14.1.0.tgz"
-  integrity sha512-iFWCchQmi4170omLpFXbzz62SQTmPhtBL35v0qGEVRHKcqIeiexaoYeP0vfZTujxEq3tA87iqOdRbC9svS1B9A==
+prom-client@^15.1.0:
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-15.1.3.tgz#69fa8de93a88bc9783173db5f758dc1c69fa8fc2"
+  integrity sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==
   dependencies:
+    "@opentelemetry/api" "^1.4.0"
     tdigest "^0.1.1"
 
 prompts@^2.0.1:
@@ -4336,7 +4342,7 @@ tapable@^2.2.0:
 
 tdigest@^0.1.1:
   version "0.1.2"
-  resolved "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
   integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
   dependencies:
     bintrees "1.0.2"


### PR DESCRIPTION
This PR removes reference to @well-known-components/http-server and uses proper @well-known-component/interfaces and @dcl/http-server instead.