### PR TITLE
fix: security, correctness and performance hardening + regression tests

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -23,7 +23,7 @@ function isValidSnapshotMetadata(snapshot: any): snapshot is SnapshotMetadata {
     typeof snapshot.timeRange.endTimestamp === 'number' &&
     (snapshot.replacedSnapshotHashes === undefined ||
       (Array.isArray(snapshot.replacedSnapshotHashes) &&
-        snapshot.replacedSnapshotHashes.every((hash: any) => typeof hash === 'string')))
+        snapshot.replacedSnapshotHashes.every((hash: any) => isValidContentHash(hash))))
   )
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,20 +2,61 @@ import { PointerChangesSyncDeployment } from '@dcl/schemas'
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import { metricsDefinitions } from './metrics'
 import { SnapshotMetadata, SnapshotsFetcherComponents } from './types'
-import { contentServerMetricLabels, fetchJson, saveContentFileToDisk as saveContentFile } from './utils'
+import {
+  contentServerMetricLabels,
+  fetchJson,
+  isValidContentHash,
+  saveContentFileToDisk as saveContentFile
+} from './utils'
+
+// The /snapshots payload comes from remote, untrusted servers. We only trust entries that have the
+// shape we actually rely on (a valid content hash and a numeric time range) so that a malformed or
+// malicious response can't break downstream logic (e.g. Math.max over timestamps) or smuggle a
+// path-traversal value through the snapshot hash.
+function isValidSnapshotMetadata(snapshot: any): snapshot is SnapshotMetadata {
+  return (
+    !!snapshot &&
+    typeof snapshot.hash === 'string' &&
+    isValidContentHash(snapshot.hash) &&
+    !!snapshot.timeRange &&
+    typeof snapshot.timeRange.initTimestamp === 'number' &&
+    typeof snapshot.timeRange.endTimestamp === 'number' &&
+    (snapshot.replacedSnapshotHashes === undefined ||
+      (Array.isArray(snapshot.replacedSnapshotHashes) &&
+        snapshot.replacedSnapshotHashes.every((hash: any) => typeof hash === 'string')))
+  )
+}
 
 export async function getSnapshots(
   components: SnapshotsFetcherComponents,
   server: string,
   retries: number
 ): Promise<SnapshotMetadata[]> {
+  const logger = components.logs.getLogger('getSnapshots')
   const incrementalSnapshotsUrl = new URL(`${server}/snapshots`).toString()
-  const newSnapshots: SnapshotMetadata[] = await components.downloadQueue.scheduleJobWithRetries(
+  const response = await components.downloadQueue.scheduleJobWithRetries(
     () => fetchJson(incrementalSnapshotsUrl, components.fetcher, { timeout: 15000 }),
     retries
   )
+
+  if (!Array.isArray(response)) {
+    throw new Error(`Invalid /snapshots response from ${server}: expected an array`)
+  }
+
+  const validSnapshots: SnapshotMetadata[] = []
+  for (const snapshot of response) {
+    if (isValidSnapshotMetadata(snapshot)) {
+      validSnapshots.push(snapshot)
+    } else {
+      logger.error('Ignoring invalid snapshot metadata received from server', {
+        server,
+        snapshot: JSON.stringify(snapshot)
+      })
+    }
+  }
+
   // newest first
-  return newSnapshots.sort((s1, s2) => s2.timeRange.endTimestamp - s1.timeRange.endTimestamp)
+  return validSnapshots.sort((s1, s2) => s2.timeRange.endTimestamp - s1.timeRange.endTimestamp)
 }
 
 export async function* fetchJsonPaginated<T>(

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,10 @@ import {
   saveContentFileToDisk as saveContentFile
 } from './utils'
 
+// Cap how many invalid snapshot entries we log per response, so a server returning many of them
+// (the body can be up to MAX_JSON_RESPONSE_SIZE_IN_BYTES) can't flood the logs.
+const MAX_INVALID_SNAPSHOT_LOGS = 100
+
 // Snapshot metadata comes from untrusted servers; keep only entries with the shape we rely on
 // (valid content hash + numeric time range) so a malformed response can't break downstream logic.
 function isValidSnapshotMetadata(snapshot: any): snapshot is SnapshotMetadata {
@@ -42,15 +46,25 @@ export async function getSnapshots(
   }
 
   const validSnapshots: SnapshotMetadata[] = []
+  let invalidSnapshots = 0
   for (const snapshot of response) {
     if (isValidSnapshotMetadata(snapshot)) {
       validSnapshots.push(snapshot)
-    } else {
+      continue
+    }
+    invalidSnapshots++
+    if (invalidSnapshots <= MAX_INVALID_SNAPSHOT_LOGS) {
       logger.error('Ignoring invalid snapshot metadata received from server', {
         server,
         snapshot: JSON.stringify(snapshot)
       })
     }
+  }
+  if (invalidSnapshots > MAX_INVALID_SNAPSHOT_LOGS) {
+    logger.error('Ignored additional invalid snapshot metadata entries from server', {
+      server,
+      total: String(invalidSnapshots)
+    })
   }
 
   // newest first

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,10 +9,8 @@ import {
   saveContentFileToDisk as saveContentFile
 } from './utils'
 
-// The /snapshots payload comes from remote, untrusted servers. We only trust entries that have the
-// shape we actually rely on (a valid content hash and a numeric time range) so that a malformed or
-// malicious response can't break downstream logic (e.g. Math.max over timestamps) or smuggle a
-// path-traversal value through the snapshot hash.
+// Snapshot metadata comes from untrusted servers; keep only entries with the shape we rely on
+// (valid content hash + numeric time range) so a malformed response can't break downstream logic.
 function isValidSnapshotMetadata(snapshot: any): snapshot is SnapshotMetadata {
   return (
     !!snapshot &&

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -66,8 +66,17 @@ export async function deployEntitiesFromSnapshot(
   let snapshotWasCompletelyStreamed = false
   let numberOfStreamedEntities = 0
   let numberOfProcessedEntities = 0
+  let snapshotWasMarkedAsProcessed = false
   async function saveIfStreamEndedAndAllEntitiesWereProcessed() {
-    if (snapshotWasCompletelyStreamed && numberOfStreamedEntities === numberOfProcessedEntities) {
+    // Use >= (not ===) so an extra markAsDeployed call can't leave the snapshot permanently
+    // unmarked (which would re-download/re-stream it every sync). The flag set (synchronous, before
+    // any await) guarantees we only mark once even if this runs from several callbacks.
+    if (
+      !snapshotWasMarkedAsProcessed &&
+      snapshotWasCompletelyStreamed &&
+      numberOfProcessedEntities >= numberOfStreamedEntities
+    ) {
+      snapshotWasMarkedAsProcessed = true
       await components.processedSnapshotStorage.markSnapshotAsProcessed(snapshotHash)
       components.metrics.increment('dcl_processed_snapshots_total', { state: 'saved' })
     }
@@ -121,6 +130,29 @@ export async function shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded
     ...replacedSnapshotHashes.flat()
   ])
 
+  return decideSnapshotDeploymentFromProcessedSet(
+    components,
+    processedSnapshots,
+    genesisTimestamp,
+    snapshotHash,
+    greatestEndTimestamp,
+    replacedSnapshotHashes
+  )
+}
+
+/**
+ * Same decision as shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded, but operating on an
+ * already-fetched set of processed snapshot hashes. This lets a caller batch the (potentially
+ * expensive) filterProcessedSnapshotsFrom lookup for many snapshots into a single storage call.
+ */
+export async function decideSnapshotDeploymentFromProcessedSet(
+  components: Pick<SnapshotsFetcherComponents, 'processedSnapshotStorage' | 'snapshotStorage'>,
+  processedSnapshots: Set<string>,
+  genesisTimestamp: number,
+  snapshotHash: string,
+  greatestEndTimestamp: number,
+  replacedSnapshotHashes: string[][]
+): Promise<boolean> {
   const snapshotWasProcessed = processedSnapshots.has(snapshotHash)
   const aReplacedGroupWasProcessed = replacedSnapshotHashes.some(
     (replacedGroup) => replacedGroup.length > 0 && replacedGroup.every((s) => processedSnapshots.has(s))

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -68,9 +68,8 @@ export async function deployEntitiesFromSnapshot(
   let numberOfProcessedEntities = 0
   let snapshotWasMarkedAsProcessed = false
   async function saveIfStreamEndedAndAllEntitiesWereProcessed() {
-    // Use >= (not ===) so an extra markAsDeployed call can't leave the snapshot permanently
-    // unmarked (which would re-download/re-stream it every sync). The flag set (synchronous, before
-    // any await) guarantees we only mark once even if this runs from several callbacks.
+    // >= (not ===) so an extra markAsDeployed call can't leave the snapshot unmarked forever; the
+    // flag (set synchronously before any await) ensures we still mark only once.
     if (
       !snapshotWasMarkedAsProcessed &&
       snapshotWasCompletelyStreamed &&

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import { saveContentFileToDisk } from './client'
 import { Path, SnapshotsFetcherComponents } from './types'
-import { pickLeastRecentlyUsedServer, sleep } from './utils'
+import { isValidContentHash, pickRandomServer, sleep } from './utils'
 
 const downloadFileJobsMap = new Map<Path, ReturnType<typeof downloadFileWithRetries>>()
 
@@ -16,14 +16,16 @@ async function downloadJob(
   // cancel early if the file is already downloaded
   if (await components.storage.exist(hashToDownload)) return
 
+  // Sample the number of candidate servers once per job, not once per retry (which would skew the histogram).
+  components.metrics?.observe('dcl_available_servers_histogram', {}, presentInServers.length)
+
   let retries = 0
   let serversToPickFrom: string[] = presentInServers
 
   for (;;) {
     retries++
-    const serverToUse = pickLeastRecentlyUsedServer(serversToPickFrom)
+    const serverToUse = pickRandomServer(serversToPickFrom)
     try {
-      components.metrics?.observe('dcl_available_servers_histogram', {}, presentInServers.length)
       await downloadContentFile(components, hashToDownload, finalFileName, serverToUse)
       components.metrics?.observe('dcl_content_download_job_succeed_retries', {}, retries)
 
@@ -56,6 +58,12 @@ export async function downloadFileWithRetries(
   maxRetries: number,
   waitTimeBetweenRetries: number
 ): Promise<void> {
+  // Reject untrusted hashes that are not plain content addresses before using them to build a
+  // filesystem path. Without this, a value like "../../etc/x" would escape targetTempFolder.
+  if (!isValidContentHash(hashToDownload)) {
+    throw new Error(`Invalid content hash: ${JSON.stringify(hashToDownload)}`)
+  }
+
   const finalFileName = path.resolve(targetTempFolder, hashToDownload)
 
   if (downloadFileJobsMap.has(finalFileName)) {
@@ -86,7 +94,9 @@ async function downloadContentFile(
   finalFileName: string,
   serverToUse: string
 ): Promise<void> {
-  if (!(await components.storage.exist(finalFileName))) {
+  // Storage is keyed by content hash, not by the filesystem path. Checking the hash lets a
+  // concurrent download that targets a different folder short-circuit this one.
+  if (!(await components.storage.exist(hash))) {
     return saveContentFileToDisk(components, serverToUse, hash, finalFileName)
   }
 }

--- a/src/exponential-fallof-retry.ts
+++ b/src/exponential-fallof-retry.ts
@@ -1,6 +1,5 @@
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import { IJobWithLifecycle } from './job-lifecycle-manager'
-import { sleep } from './utils'
 
 /**
  * @public
@@ -46,6 +45,28 @@ export function createExponentialFallofRetry(
 
   let reconnectionCount = 0
 
+  // Allows stop() to interrupt an in-flight retry sleep instead of waiting out the full (possibly
+  // multi-day) interval before the loop notices it was stopped.
+  let cancelCurrentSleep: (() => void) | undefined
+
+  function interruptibleSleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      if (ms <= 0) {
+        resolve()
+        return
+      }
+      const timeout = setTimeout(() => {
+        cancelCurrentSleep = undefined
+        resolve()
+      }, ms)
+      cancelCurrentSleep = () => {
+        clearTimeout(timeout)
+        cancelCurrentSleep = undefined
+        resolve()
+      }
+    })
+  }
+
   async function start() {
     // reset reconnection time
     let reconnectionTime = options.retryTime
@@ -88,7 +109,7 @@ export function createExponentialFallofRetry(
       }
 
       logs.info('Retrying in ' + reconnectionTime.toFixed(1) + 'ms')
-      await sleep(reconnectionTime)
+      await interruptibleSleep(reconnectionTime)
     }
   }
 
@@ -102,10 +123,19 @@ export function createExponentialFallofRetry(
     async start() {
       if (started === true) return
       started = true
-      await start()
+      try {
+        await start()
+      } finally {
+        // Reset so isStopped() is accurate once the loop exits (e.g. exitOnSuccess) and the
+        // component can be started again.
+        started = false
+      }
     },
     async stop() {
       started = false
+      if (cancelCurrentSleep) {
+        cancelCurrentSleep()
+      }
     }
   }
 }

--- a/src/file-processor.ts
+++ b/src/file-processor.ts
@@ -40,26 +40,51 @@ export async function* processDeploymentsInFile(
  * Parses every line and yields RemoteEntityDeployment.
  * @public
  */
+// Maximum number of invalid-line errors logged per snapshot file, so a single corrupt file can't
+// flood the logs.
+const MAX_LINE_ERRORS_TO_LOG = 100
+
 export async function* processDeploymentsInStream(
   stream: NodeJS.ReadableStream,
   logger: ILoggerComponent.ILogger
 ): AsyncIterable<SyncDeployment> {
+  let lineErrorsLogged = 0
+  function logLineError(message: string, extra: Record<string, string>) {
+    if (lineErrorsLogged >= MAX_LINE_ERRORS_TO_LOG) {
+      return
+    }
+    lineErrorsLogged++
+    logger.error(message, extra)
+    if (lineErrorsLogged === MAX_LINE_ERRORS_TO_LOG) {
+      logger.error('Too many invalid lines in snapshot file, suppressing further line errors', {
+        suppressedAfter: String(MAX_LINE_ERRORS_TO_LOG)
+      })
+    }
+  }
+
   for await (const line of processLineByLine(stream)) {
     const theLine = line.trim()
     if (theLine.startsWith('{') && theLine.endsWith('}')) {
-      const parsedLine = JSON.parse(theLine)
+      let parsedLine: any
+      try {
+        parsedLine = JSON.parse(theLine)
+      } catch (error: any) {
+        // A single malformed line should not abort processing of the whole snapshot file.
+        logLineError('ERROR: Could not parse line in snapshot file', {
+          line: theLine,
+          error: error?.message ?? JSON.stringify(error)
+        })
+        continue
+      }
       if (SnapshotSyncDeployment.validate(parsedLine)) {
         yield parsedLine
       } else if (PointerChangesSyncDeployment.validate(parsedLine)) {
         yield parsedLine
       } else {
-        const errors = {
-          ...SnapshotSyncDeployment.validate.errors,
-          ...PointerChangesSyncDeployment.validate.errors
-        }
-        logger.error('ERROR: Invalid entity deployment in snapshot file', {
-          deployment: parsedLine,
-          error: JSON.stringify(errors)
+        logLineError('ERROR: Invalid entity deployment in snapshot file', {
+          deployment: JSON.stringify(parsedLine),
+          snapshotErrors: JSON.stringify(SnapshotSyncDeployment.validate.errors),
+          pointerChangesErrors: JSON.stringify(PointerChangesSyncDeployment.validate.errors)
         })
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,10 @@ export { IDeployerComponent, SynchronizerComponent } from './types'
 export { createSynchronizer } from './synchronizer'
 export { getDeployedEntitiesStreamFromSnapshot, getDeployedEntitiesStreamFromPointerChanges } from './stream-entities'
 
-// Max number of content files downloaded in parallel for a single entity. Bounds socket / file
-// descriptor / temp-file usage so an entity declaring a huge content[] can't exhaust resources.
-const ENTITY_FILE_DOWNLOAD_CONCURRENCY = 10
+// Default maximum number of content files downloaded in parallel for a single entity. Bounds
+// socket / file descriptor / temp-file usage so an entity declaring a huge content[] can't exhaust
+// resources. Overridable per call via downloadEntityAndContentFiles's contentFilesConcurrency arg.
+const DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY = 10
 
 if (parseInt(process.version.split('.')[0]) < 16) {
   const { name } = require('../package.json')
@@ -31,6 +32,7 @@ async function downloadProfileAvatars(
   targetFolder: string,
   maxRetries: number,
   waitTimeBetweenRetries: number,
+  concurrency: number,
   entityMetadata:
     {
       type: string
@@ -47,7 +49,7 @@ async function downloadProfileAvatars(
     .filter(snapshot => !entityMetadata.content || entityMetadata.content.find(content => content.hash === snapshot) === undefined)
   if (snapshots.length > 0) {
     logger.info(`Downloading snapshots ${snapshots} for fixing entity ${JSON.stringify(entityMetadata)}`)
-    const downloadQueue = new PQueue({ concurrency: ENTITY_FILE_DOWNLOAD_CONCURRENCY })
+    const downloadQueue = new PQueue({ concurrency })
     await Promise.all(
       snapshots.map(snapshot => downloadQueue.add(() => downloadFileWithRetries(
         components,
@@ -67,6 +69,8 @@ async function downloadProfileAvatars(
  * Downloads an entity and its dependency files to a folder in the disk.
  *
  * Returns the parsed JSON file of the deployed entityHash
+ * @param contentFilesConcurrency - Maximum number of content files to download in parallel for this
+ *   entity. Defaults to {@link DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY} (10).
  * @public
  */
 export async function downloadEntityAndContentFiles(
@@ -76,7 +80,8 @@ export async function downloadEntityAndContentFiles(
   _serverMapLRU: Map<Server, number>,
   targetFolder: string,
   maxRetries: number,
-  waitTimeBetweenRetries: number
+  waitTimeBetweenRetries: number,
+  contentFilesConcurrency: number = DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY
 ): Promise<unknown> {
   const logger = components.logs.getLogger(`downloadEntityAndContentFiles)`)
 
@@ -125,11 +130,12 @@ export async function downloadEntityAndContentFiles(
       targetFolder,
       maxRetries,
       waitTimeBetweenRetries,
+      contentFilesConcurrency,
       entityMetadata)
   }
 
   if (entityMetadata.content) {
-    const downloadQueue = new PQueue({ concurrency: ENTITY_FILE_DOWNLOAD_CONCURRENCY })
+    const downloadQueue = new PQueue({ concurrency: contentFilesConcurrency })
     await Promise.all(
       entityMetadata.content.map((content) =>
         downloadQueue.add(() =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { ILoggerComponent } from '@well-known-components/interfaces'
+import PQueue from 'p-queue'
 import { downloadFileWithRetries } from './downloader'
 import {
   ContentMapping,
@@ -12,6 +13,10 @@ export { metricsDefinitions } from './metrics'
 export { IDeployerComponent, SynchronizerComponent } from './types'
 export { createSynchronizer } from './synchronizer'
 export { getDeployedEntitiesStreamFromSnapshot, getDeployedEntitiesStreamFromPointerChanges } from './stream-entities'
+
+// Max number of content files downloaded in parallel for a single entity. Bounds socket / file
+// descriptor / temp-file usage so an entity declaring a huge content[] can't exhaust resources.
+const ENTITY_FILE_DOWNLOAD_CONCURRENCY = 10
 
 if (parseInt(process.version.split('.')[0]) < 16) {
   const { name } = require('../package.json')
@@ -42,8 +47,9 @@ async function downloadProfileAvatars(
     .filter(snapshot => !entityMetadata.content || entityMetadata.content.find(content => content.hash === snapshot) === undefined)
   if (snapshots.length > 0) {
     logger.info(`Downloading snapshots ${snapshots} for fixing entity ${JSON.stringify(entityMetadata)}`)
+    const downloadQueue = new PQueue({ concurrency: ENTITY_FILE_DOWNLOAD_CONCURRENCY })
     await Promise.all(
-      snapshots.map(snapshot => downloadFileWithRetries(
+      snapshots.map(snapshot => downloadQueue.add(() => downloadFileWithRetries(
         components,
         snapshot,
         targetFolder,
@@ -52,7 +58,7 @@ async function downloadProfileAvatars(
         maxRetries,
         waitTimeBetweenRetries
       ).catch(() => logger.info(`File ${snapshot} not available for download.`))
-      )
+      ))
     )
   }
 }
@@ -87,13 +93,13 @@ export async function downloadEntityAndContentFiles(
 
   const content = await components.storage.retrieve(entityId)
 
-  let contentStream = ''
-
-  if (content) {
-    const stream = await content.asStream()
-    const buffer = await streamToBuffer(stream)
-    contentStream = await buffer.toString()
+  if (!content) {
+    throw new Error(`Entity file ${entityId} could not be retrieved from storage after download`)
   }
+
+  const stream = await content.asStream()
+  const buffer = await streamToBuffer(stream)
+  const contentStream = buffer.toString()
 
   const entityMetadata: {
     type: string,
@@ -123,16 +129,19 @@ export async function downloadEntityAndContentFiles(
   }
 
   if (entityMetadata.content) {
+    const downloadQueue = new PQueue({ concurrency: ENTITY_FILE_DOWNLOAD_CONCURRENCY })
     await Promise.all(
       entityMetadata.content.map((content) =>
-        downloadFileWithRetries(
-          components,
-          content.hash,
-          targetFolder,
-          presentInServers,
-          _serverMapLRU,
-          maxRetries,
-          waitTimeBetweenRetries
+        downloadQueue.add(() =>
+          downloadFileWithRetries(
+            components,
+            content.hash,
+            targetFolder,
+            presentInServers,
+            _serverMapLRU,
+            maxRetries,
+            waitTimeBetweenRetries
+          )
         )
       )
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,8 @@ export { IDeployerComponent, SynchronizerComponent } from './types'
 export { createSynchronizer } from './synchronizer'
 export { getDeployedEntitiesStreamFromSnapshot, getDeployedEntitiesStreamFromPointerChanges } from './stream-entities'
 
-// Default maximum number of content files downloaded in parallel for a single entity. Bounds
-// socket / file descriptor / temp-file usage so an entity declaring a huge content[] can't exhaust
-// resources. Overridable per call via downloadEntityAndContentFiles's contentFilesConcurrency arg.
+// Default cap on content files downloaded in parallel per entity, so a huge content[] can't exhaust
+// sockets / file descriptors. Overridable via downloadEntityAndContentFiles's last argument.
 const DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY = 10
 
 if (parseInt(process.version.split('.')[0]) < 16) {

--- a/src/job-lifecycle-manager.ts
+++ b/src/job-lifecycle-manager.ts
@@ -42,7 +42,7 @@ export function createJobLifecycleManagerComponent(
       for (const [name, job] of createdJobs) {
         if (!desiredJobNames.has(name)) {
           logs.info('Stopping job', { name })
-          job.stop().catch(logs.error)
+          job.stop().catch((err) => logs.error(err))
           createdJobs.delete(name)
         }
       }
@@ -55,7 +55,7 @@ export function createJobLifecycleManagerComponent(
           createdJobs.set(name, job)
           job
             .start()
-            .catch(logs.error)
+            .catch((err) => logs.error(err))
             .finally(() => {
               // then remove it from the list of running jobs after it ends
               if (createdJobs.get(name) === job) {

--- a/src/serial-job-runner.ts
+++ b/src/serial-job-runner.ts
@@ -1,0 +1,59 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { IJobWithLifecycle } from './job-lifecycle-manager'
+
+/**
+ * Runs jobs one at a time in FIFO order. Enqueuing while a job is running just appends; the running
+ * chain re-arms itself in each job's `finally`, so the queue always drains regardless of how many
+ * jobs were enqueued mid-flight.
+ */
+export type SerialJobRunner = {
+  /** Append a job. Starts it immediately if nothing else is queued/running. */
+  enqueue(job: IJobWithLifecycle): void
+  /** Number of jobs queued, including the one currently running. */
+  size(): number
+  /** Stop the running job and drop the rest; no further jobs will start. */
+  stop(): Promise<void>
+}
+
+export function createSerialJobRunner(logger: ILoggerComponent.ILogger): SerialJobRunner {
+  const jobs: IJobWithLifecycle[] = []
+  let stopped = false
+
+  function startNext() {
+    if (stopped || jobs.length === 0) {
+      return
+    }
+    jobs[0]
+      .start()
+      .catch((err) => logger.error(err))
+      .finally(() => {
+        jobs.shift()
+        startNext()
+      })
+  }
+
+  return {
+    enqueue(job: IJobWithLifecycle) {
+      if (stopped) {
+        return
+      }
+      jobs.push(job)
+      // Only kick off the chain when this is the sole queued job; otherwise the currently-running
+      // chain picks it up when it finishes.
+      if (jobs.length === 1) {
+        startNext()
+      }
+    },
+    size() {
+      return jobs.length
+    },
+    async stop() {
+      stopped = true
+      const runningJob = jobs[0]
+      jobs.length = 0
+      if (runningJob) {
+        await runningJob.stop()
+      }
+    }
+  }
+}

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -79,11 +79,8 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
   // fetch the /pointer-changes of the remote server using the last timestamp from the previous step with a grace period of 20 min
   const genesisTimestamp = options.fromTimestamp || 0
   let greatestLocalTimestampProcessed = genesisTimestamp
-  // Each poll re-fetches from `greatestLocalTimestampProcessed` (the server treats `from` as
-  // inclusive), so the deployments at exactly that timestamp come back every cycle. Track the
-  // entityIds already yielded at the high-water timestamp so we don't re-yield (and re-schedule)
-  // them. Keyed by entityId at that exact timestamp, this only suppresses true duplicates and never
-  // skips a distinct deployment.
+  // `from` is inclusive, so each poll re-returns the deployments at the high-water timestamp. Track
+  // the entityIds already yielded at that timestamp to skip those re-yields (never a distinct one).
   let entityIdsYieldedAtGreatestTimestamp = new Set<string>()
   logs.debug('Starting to stream entities from Pointer-Changes.', {
     contentServer,

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -79,6 +79,12 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
   // fetch the /pointer-changes of the remote server using the last timestamp from the previous step with a grace period of 20 min
   const genesisTimestamp = options.fromTimestamp || 0
   let greatestLocalTimestampProcessed = genesisTimestamp
+  // Each poll re-fetches from `greatestLocalTimestampProcessed` (the server treats `from` as
+  // inclusive), so the deployments at exactly that timestamp come back every cycle. Track the
+  // entityIds already yielded at the high-water timestamp so we don't re-yield (and re-schedule)
+  // them. Keyed by entityId at that exact timestamp, this only suppresses true duplicates and never
+  // skips a distinct deployment.
+  let entityIdsYieldedAtGreatestTimestamp = new Set<string>()
   logs.debug('Starting to stream entities from Pointer-Changes.', {
     contentServer,
     timestamp: new Date(genesisTimestamp).toISOString()
@@ -87,15 +93,25 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
     // 1. download pointer changes and yield
     const pointerChanges = fetchPointerChanges(components, contentServer, greatestLocalTimestampProcessed, logs)
     for await (const deployment of pointerChanges) {
-      // selectively ignore deployments by localTimestamp
-      if (deployment.localTimestamp >= genesisTimestamp) {
-        components.metrics?.increment('dcl_entities_deployments_streamed_total', { source: 'pointer-changes' })
-        yield deployment
+      const localTimestamp = deployment.localTimestamp
+
+      // when we move past the previous high-water timestamp, reset the per-timestamp dedup set
+      if (localTimestamp > greatestLocalTimestampProcessed) {
+        greatestLocalTimestampProcessed = localTimestamp
+        entityIdsYieldedAtGreatestTimestamp = new Set<string>()
       }
 
-      // update greatest processed local timestamp
-      if (deployment.localTimestamp) {
-        greatestLocalTimestampProcessed = Math.max(greatestLocalTimestampProcessed, deployment.localTimestamp)
+      const alreadyYielded =
+        localTimestamp === greatestLocalTimestampProcessed &&
+        entityIdsYieldedAtGreatestTimestamp.has(deployment.entityId)
+
+      // selectively ignore deployments by localTimestamp, and skip ones already yielded this run
+      if (localTimestamp >= genesisTimestamp && !alreadyYielded) {
+        components.metrics?.increment('dcl_entities_deployments_streamed_total', { source: 'pointer-changes' })
+        yield deployment
+        if (localTimestamp === greatestLocalTimestampProcessed) {
+          entityIdsYieldedAtGreatestTimestamp.add(deployment.entityId)
+        }
       }
     }
 

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -6,8 +6,9 @@ import {
   deployEntitiesFromPointerChanges,
   deployEntitiesFromSnapshot
 } from './deploy-entities'
-import { ExponentialFallofRetryComponent, createExponentialFallofRetry } from './exponential-fallof-retry'
+import { createExponentialFallofRetry } from './exponential-fallof-retry'
 import { createJobLifecycleManagerComponent } from './job-lifecycle-manager'
+import { createSerialJobRunner } from './serial-job-runner'
 import {
   IDeployerComponent,
   SnapshotMetadata,
@@ -33,7 +34,8 @@ export async function createSynchronizer(
   const bootstrappingServersFromPointerChanges: Set<string> = new Set()
   const syncingServers: Set<string> = new Set()
   const lastEntityTimestampFromSnapshotsByServer: Map<string, number> = new Map()
-  const syncJobs: ExponentialFallofRetryComponent[] = []
+  // Sync jobs are serialized: only one runs at a time, the rest queue (FIFO).
+  const syncJobsRunner = createSerialJobRunner(logger)
   const pointerChangesShiftFix = 20 * 60_000
 
   let isStopped = false
@@ -350,21 +352,6 @@ export async function createSynchronizer(
     }
   }
 
-  // Runs queued sync jobs one at a time, in FIFO order. Each job re-arms the chain in its finally,
-  // so the queue keeps draining no matter how many jobs were enqueued while one was running.
-  function startNextSyncJob() {
-    if (syncJobs.length === 0) {
-      return
-    }
-    syncJobs[0]
-      .start()
-      .catch((err) => logger.error(err))
-      .finally(() => {
-        syncJobs.shift()
-        startNextSyncJob()
-      })
-  }
-
   return {
     async syncWithServers(serversToSync: Set<string>) {
       if (isStopped) {
@@ -398,12 +385,7 @@ export async function createSynchronizer(
           )
         })
       }
-      syncJobs.push(newSyncJob)
-      // Only kick off the chain when this is the sole queued job; otherwise the currently-running
-      // chain will pick it up when it finishes (see startNextSyncJob).
-      if (syncJobs.length === 1) {
-        startNextSyncJob()
-      }
+      syncJobsRunner.enqueue(newSyncJob)
       return newSyncJob
     },
     async stop() {
@@ -411,12 +393,7 @@ export async function createSynchronizer(
       if (!isStopped) {
         isStopped = true
 
-        if (syncJobs.length > 0) {
-          await syncJobs[0].stop()
-          while (syncJobs.length > 0) {
-            syncJobs.shift()
-          }
-        }
+        await syncJobsRunner.stop()
         syncingServers.clear()
         if (deployPointerChangesAfterBootstrapJobManager.stop) {
           await deployPointerChangesAfterBootstrapJobManager.stop()

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -96,9 +96,8 @@ export async function createSynchronizer(
     type Snapshot = SnapshotMetadata & { server: string }
     const snapshotsByHash: Map<string, Snapshot[]> = new Map()
     const snapshotLastTimestampByServer: Map<string, number> = new Map()
-    // Fetch every server's snapshots concurrently. getSnapshots already runs through the
-    // concurrency-limited downloadQueue, so this just feeds that queue instead of starving it with
-    // one serial round-trip per server. The synchronous map mutations below run without interleaving.
+    // Fetch all servers concurrently; getSnapshots already runs through the concurrency-limited
+    // downloadQueue. The synchronous map mutations below can't interleave (no await between them).
     await Promise.all(
       Array.from(serversToSync).map(async (server) => {
         try {
@@ -124,9 +123,8 @@ export async function createSynchronizer(
       autoStart: false
     })
 
-    // Resolve which snapshot hashes were already processed in a single storage call for the whole
-    // set, instead of one round-trip per snapshot. The per-snapshot decisions below then read from
-    // this set (and only hit snapshotStorage.has / markSnapshotAsProcessed in the branches that need it).
+    // Resolve all processed snapshot hashes in one storage call instead of one per snapshot; the
+    // per-snapshot decisions below read from this set.
     const allSnapshotHashesToCheck = new Set<string>()
     for (const [snapshotHash, snapshots] of snapshotsByHash) {
       allSnapshotHashesToCheck.add(snapshotHash)

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -2,9 +2,9 @@ import future from 'fp-future'
 import PQueue from 'p-queue'
 import { getSnapshots } from './client'
 import {
+  decideSnapshotDeploymentFromProcessedSet,
   deployEntitiesFromPointerChanges,
-  deployEntitiesFromSnapshot,
-  shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded
+  deployEntitiesFromSnapshot
 } from './deploy-entities'
 import { ExponentialFallofRetryComponent, createExponentialFallofRetry } from './exponential-fallof-retry'
 import { createJobLifecycleManagerComponent } from './job-lifecycle-manager'
@@ -46,8 +46,9 @@ export async function createSynchronizer(
       try {
         await syncFromSnapshots(syncingServers)
       } catch (e: any) {
-        // we don't log the exception here because createExponentialFallofRetry(logger, options) receives the logger
-        logger.error(`Error syncing snapshots: ${JSON.stringify(e)}`)
+        // The full error (with stack) is logged by createExponentialFallofRetry; here we add context.
+        // Note: JSON.stringify(error) is "{}", so log the message explicitly.
+        logger.error(`Error syncing snapshots: ${e?.message ?? JSON.stringify(e)}`)
         throw e
       }
     },
@@ -60,7 +61,8 @@ export async function createSynchronizer(
 
   function pointerChangesStartingTimestamp(server: string): number {
     const lastTimestamp = lastEntityTimestampFromSnapshotsByServer.get(server)
-    if (!lastTimestamp) {
+    // Note: a last timestamp of 0 (genesis) is valid, so we must check for undefined explicitly.
+    if (lastTimestamp === undefined) {
       throw new Error(
         `Can't start pointer changes stream without last entity timestamp for ${server}. This should never happen.`
       )
@@ -92,46 +94,80 @@ export async function createSynchronizer(
     type Snapshot = SnapshotMetadata & { server: string }
     const snapshotsByHash: Map<string, Snapshot[]> = new Map()
     const snapshotLastTimestampByServer: Map<string, number> = new Map()
-    for (const server of serversToSync) {
-      try {
-        const snapshots = await getSnapshots(components, server, options.requestMaxRetries)
-        snapshotLastTimestampByServer.set(server, Math.max(...snapshots.map((s) => s.timeRange.endTimestamp)))
-        for (const snapshot of snapshots) {
-          const snapshotMetadatas = snapshotsByHash.get(snapshot.hash) ?? []
-          snapshotMetadatas.push({ ...snapshot, server })
-          snapshotsByHash.set(snapshot.hash, snapshotMetadatas)
+    // Fetch every server's snapshots concurrently. getSnapshots already runs through the
+    // concurrency-limited downloadQueue, so this just feeds that queue instead of starving it with
+    // one serial round-trip per server. The synchronous map mutations below run without interleaving.
+    await Promise.all(
+      Array.from(serversToSync).map(async (server) => {
+        try {
+          const snapshots = await getSnapshots(components, server, options.requestMaxRetries)
+          // A server may legitimately have no snapshots yet (e.g. brand new). Math.max() of an empty
+          // list is -Infinity, so fall back to the genesis timestamp to keep a sane starting point.
+          const lastTimestamp =
+            snapshots.length > 0 ? Math.max(...snapshots.map((s) => s.timeRange.endTimestamp)) : genesisTimestamp
+          snapshotLastTimestampByServer.set(server, lastTimestamp)
+          for (const snapshot of snapshots) {
+            const snapshotMetadatas = snapshotsByHash.get(snapshot.hash) ?? []
+            snapshotMetadatas.push({ ...snapshot, server })
+            snapshotsByHash.set(snapshot.hash, snapshotMetadatas)
+          }
+        } catch (error) {
+          logger.info(`Error getting snapshots from ${server}.`)
         }
-      } catch (error) {
-        logger.info(`Error getting snapshots from ${server}.`)
-      }
-    }
+      })
+    )
 
     const deploymentsProcessorsQueue = new PQueue({
       concurrency: 10,
       autoStart: false
     })
 
-    const timeRangesOfEntitiesToDeploy: TimeRange[] = []
+    // Resolve which snapshot hashes were already processed in a single storage call for the whole
+    // set, instead of one round-trip per snapshot. The per-snapshot decisions below then read from
+    // this set (and only hit snapshotStorage.has / markSnapshotAsProcessed in the branches that need it).
+    const allSnapshotHashesToCheck = new Set<string>()
     for (const [snapshotHash, snapshots] of snapshotsByHash) {
-      const replacedSnapshotHashes = snapshots.map((s) => s.replacedSnapshotHashes ?? [])
-      const greatestEndTimestamp = Math.max(...snapshots.map((s) => s.timeRange.endTimestamp))
-      const shouldProcessSnapshot = await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
-        components,
-        genesisTimestamp,
-        snapshotHash,
-        greatestEndTimestamp,
-        replacedSnapshotHashes
-      )
-      if (shouldProcessSnapshot) {
-        const servers = new Set(snapshots.map((s) => s.server))
-        timeRangesOfEntitiesToDeploy.push(...snapshots.map((s) => s.timeRange))
-        deploymentsProcessorsQueue
-          .add(async () => {
-            await deployEntitiesFromSnapshot(components, options, snapshotHash, servers, () => isStopped)
-          })
-          .catch(logger.error)
+      allSnapshotHashesToCheck.add(snapshotHash)
+      for (const snapshot of snapshots) {
+        for (const replacedHash of snapshot.replacedSnapshotHashes ?? []) {
+          allSnapshotHashesToCheck.add(replacedHash)
+        }
       }
     }
+    const processedSnapshots =
+      allSnapshotHashesToCheck.size > 0
+        ? await components.processedSnapshotStorage.filterProcessedSnapshotsFrom(Array.from(allSnapshotHashesToCheck))
+        : new Set<string>()
+
+    const timeRangesOfEntitiesToDeploy: TimeRange[] = []
+    // Each decision may still hit snapshotStorage; run them with bounded concurrency instead of a
+    // serial chain. The synchronous push/enqueue after each await can't interleave.
+    const shouldProcessChecksQueue = new PQueue({ concurrency: 10 })
+    await Promise.all(
+      Array.from(snapshotsByHash).map(([snapshotHash, snapshots]) =>
+        shouldProcessChecksQueue.add(async () => {
+          const replacedSnapshotHashes = snapshots.map((s) => s.replacedSnapshotHashes ?? [])
+          const greatestEndTimestamp = Math.max(...snapshots.map((s) => s.timeRange.endTimestamp))
+          const shouldProcessSnapshot = await decideSnapshotDeploymentFromProcessedSet(
+            components,
+            processedSnapshots,
+            genesisTimestamp,
+            snapshotHash,
+            greatestEndTimestamp,
+            replacedSnapshotHashes
+          )
+          if (shouldProcessSnapshot) {
+            const servers = new Set(snapshots.map((s) => s.server))
+            timeRangesOfEntitiesToDeploy.push(...snapshots.map((s) => s.timeRange))
+            deploymentsProcessorsQueue
+              .add(async () => {
+                await deployEntitiesFromSnapshot(components, options, snapshotHash, servers, () => isStopped)
+              })
+              .catch((err) => logger.error(err))
+          }
+        })
+      )
+    )
 
     logger.info('Warming up deployer.')
     await components.deployer.prepareForDeploymentsIn(timeRangesOfEntitiesToDeploy)
@@ -187,7 +223,7 @@ export async function createSynchronizer(
       })
     }
 
-    if (minStartingPoint) {
+    if (minStartingPoint !== undefined) {
       await components.deployer.prepareForDeploymentsIn([
         {
           initTimestamp: minStartingPoint,
@@ -314,6 +350,21 @@ export async function createSynchronizer(
     }
   }
 
+  // Runs queued sync jobs one at a time, in FIFO order. Each job re-arms the chain in its finally,
+  // so the queue keeps draining no matter how many jobs were enqueued while one was running.
+  function startNextSyncJob() {
+    if (syncJobs.length === 0) {
+      return
+    }
+    syncJobs[0]
+      .start()
+      .catch((err) => logger.error(err))
+      .finally(() => {
+        syncJobs.shift()
+        startNextSyncJob()
+      })
+  }
+
   return {
     async syncWithServers(serversToSync: Set<string>) {
       if (isStopped) {
@@ -348,13 +399,10 @@ export async function createSynchronizer(
         })
       }
       syncJobs.push(newSyncJob)
+      // Only kick off the chain when this is the sole queued job; otherwise the currently-running
+      // chain will pick it up when it finishes (see startNextSyncJob).
       if (syncJobs.length === 1) {
-        syncJobs[0].start().finally(async () => {
-          syncJobs.shift()
-          if (syncJobs.length > 0) {
-            syncJobs[0].start().catch(logger.error)
-          }
-        })
+        startNextSyncJob()
       }
       return newSyncJob
     },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,9 +13,8 @@ import { Server, SnapshotsFetcherComponents } from './types'
 
 const streamPipeline = promisify(pipeline)
 
-// Upper bound for buffered JSON responses (snapshot lists, pointer-change pages). Without it,
-// node-fetch's response.json() buffers the whole body, so a malicious/compromised server could
-// OOM the process with a huge payload. node-fetch rejects responses larger than `size`.
+// Bounds buffered JSON responses so a malicious server can't OOM the process via response.json().
+// node-fetch rejects bodies larger than `size`.
 const MAX_JSON_RESPONSE_SIZE_IN_BYTES = 50 * 1024 * 1024 // 50 MiB
 
 export async function fetchJson(url: string, fetcher: IFetchComponent, init?: fetch.RequestInit): Promise<any> {
@@ -42,9 +41,8 @@ export async function sleep(time: number): Promise<void> {
   return new Promise<void>((resolve) => setTimeout(resolve, time))
 }
 
-// Content hashes are IPFS CIDs (base58 "Qm..." or base32 "ba...") and are therefore strictly
-// alphanumeric. Validating against this charset before using a hash to build a filesystem path
-// (path.resolve) or a storage key prevents path traversal from untrusted/remote hash values.
+// Content hashes are IPFS CIDs (base58/base32), hence alphanumeric. Validating against this charset
+// before using a hash in a path or storage key prevents path traversal from untrusted hashes.
 const VALID_CONTENT_HASH = /^[a-zA-Z0-9]+$/
 export function isValidContentHash(hash: string): boolean {
   return typeof hash === 'string' && hash.length > 0 && hash.length <= 128 && VALID_CONTENT_HASH.test(hash)
@@ -242,9 +240,7 @@ export function pickRandomServer(serversToPickFrom: Server[]): string {
   if (serversToPickFrom.length === 0) {
     throw new Error('Cannot pick a server from an empty list of servers')
   }
-  // We could use round-robin or a fancier load-balancing algorithm to spread downloads across
-  // servers, but with thousands of "load balancing events" a uniformly-random pick spreads the
-  // load evenly enough in practice while staying dead simple.
+  // A uniformly-random pick spreads load across servers well enough at scale, without round-robin bookkeeping.
   return serversToPickFrom[Math.floor(Math.random() * serversToPickFrom.length)]
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs'
 import * as http from 'http'
 import * as https from 'https'
 import * as fetch from 'node-fetch'
-import { pipeline, Readable } from 'stream'
+import { pipeline, Readable, Transform } from 'stream'
 import { promisify } from 'util'
 import * as zlib from 'zlib'
 import { ContentServerMetricLabels } from './metrics'
@@ -13,8 +13,13 @@ import { Server, SnapshotsFetcherComponents } from './types'
 
 const streamPipeline = promisify(pipeline)
 
+// Upper bound for buffered JSON responses (snapshot lists, pointer-change pages). Without it,
+// node-fetch's response.json() buffers the whole body, so a malicious/compromised server could
+// OOM the process with a huge payload. node-fetch rejects responses larger than `size`.
+const MAX_JSON_RESPONSE_SIZE_IN_BYTES = 50 * 1024 * 1024 // 50 MiB
+
 export async function fetchJson(url: string, fetcher: IFetchComponent, init?: fetch.RequestInit): Promise<any> {
-  const response = await fetcher.fetch(url, init)
+  const response = await fetcher.fetch(url, { size: MAX_JSON_RESPONSE_SIZE_IN_BYTES, ...init })
 
   if (!response.ok) {
     throw new Error('Error fetching ' + url + '. Status code was: ' + response.status)
@@ -34,6 +39,14 @@ export async function checkFileExists(file: string): Promise<boolean> {
 export async function sleep(time: number): Promise<void> {
   if (time <= 0) return
   return new Promise<void>((resolve) => setTimeout(resolve, time))
+}
+
+// Content hashes are IPFS CIDs (base58 "Qm..." or base32 "ba...") and are therefore strictly
+// alphanumeric. Validating against this charset before using a hash to build a filesystem path
+// (path.resolve) or a storage key prevents path traversal from untrusted/remote hash values.
+const VALID_CONTENT_HASH = /^[a-zA-Z0-9]+$/
+export function isValidContentHash(hash: string): boolean {
+  return typeof hash === 'string' && hash.length > 0 && hash.length <= 128 && VALID_CONTENT_HASH.test(hash)
 }
 
 export async function assertHash(filename: string, hash: string) {
@@ -116,6 +129,31 @@ export async function saveContentFileToDisk(
   }
 }
 
+// Stop following redirects after this many hops.
+const MAX_REDIRECTS = 10
+// Abort a download after this many milliseconds of socket inactivity. Healthy downloads keep the
+// socket busy, so this only trips on stalled connections (e.g. a server that stops sending bytes).
+const DOWNLOAD_INACTIVITY_TIMEOUT_MS = 30_000
+// Hard cap on the number of bytes written to disk (after decompression). Protects against gzip
+// bombs and otherwise unbounded responses that could exhaust the disk.
+const MAX_DOWNLOADED_FILE_SIZE_IN_BYTES = 1024 * 1024 * 1024 // 1 GiB
+
+// Fails the pipeline once more than maxBytes have flowed through it. Placed *after* gunzip so it
+// bounds the decompressed size.
+function createSizeLimiter(maxBytes: number): Transform {
+  let total = 0
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      total += chunk.length
+      if (total > maxBytes) {
+        callback(new Error(`Downloaded file exceeds the maximum allowed size of ${maxBytes} bytes`))
+      } else {
+        callback(null, chunk)
+      }
+    }
+  })
+}
+
 function downloadFile(
   originalUrlString: string,
   metricsLabels: ContentServerMetricLabels,
@@ -123,10 +161,14 @@ function downloadFile(
   tmpFileName: string
 ) {
   return new Promise<void>((resolve, reject) => {
-    const MAX_REDIRECTS = 10
-
-    function requestWithRedirects(redirectedUrl: string, redirects: number) {
-      const url = new URL(redirectedUrl, originalUrlString)
+    function requestWithRedirects(redirectedUrl: string, baseUrl: string, redirects: number) {
+      // Relative redirects must be resolved against the URL that issued them, not the original URL.
+      const url = new URL(redirectedUrl, baseUrl)
+      // Only http(s) is supported; reject other schemes (e.g. file:) a redirect could point to.
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        reject(new Error('Unsupported protocol in URL ' + url.toString()))
+        return
+      }
       const httpModule = url.protocol === 'https:' ? https : http
       if (redirects > MAX_REDIRECTS) {
         reject(new Error('Too much redirects'))
@@ -140,58 +182,65 @@ function downloadFile(
         metricsLabels
       ) || { end: () => {} }
 
-      httpModule
-        .get(url.toString(), { headers: { 'accept-encoding': 'gzip' } }, (response) => {
-          if ((response.statusCode === 302 || response.statusCode === 301) && response.headers.location) {
-            // handle redirection
-            requestWithRedirects(response.headers.location!, redirects + 1)
-            return
-          } else if (!response.statusCode || response.statusCode > 300) {
-            reject(new Error('Invalid response from ' + url + ' status: ' + response.statusCode))
-            return
-          } else {
-            const file = fs.createWriteStream(tmpFileName, {
-              emitClose: true
+      const request = httpModule.get(url.toString(), { headers: { 'accept-encoding': 'gzip' } }, (response) => {
+        if ((response.statusCode === 302 || response.statusCode === 301) && response.headers.location) {
+          // drain the redirect response so its socket is freed (and its inactivity timer cleared)
+          response.resume()
+          // handle redirection
+          requestWithRedirects(response.headers.location!, url.toString(), redirects + 1)
+          return
+        } else if (!response.statusCode || response.statusCode > 300) {
+          response.resume()
+          reject(new Error('Invalid response from ' + url + ' status: ' + response.statusCode))
+          return
+        } else {
+          const file = fs.createWriteStream(tmpFileName, {
+            emitClose: true
+          })
+
+          const isGzip = response.headers['content-encoding'] === 'gzip'
+          const sizeLimiter = createSizeLimiter(MAX_DOWNLOADED_FILE_SIZE_IN_BYTES)
+
+          const pipe = isGzip
+            ? streamPipeline(response, zlib.createGunzip(), sizeLimiter, file)
+            : streamPipeline(response, sizeLimiter, file)
+
+          pipe
+            .then(() => {
+              file.close() // close() is async, call cb after close completes.
+              components.metrics?.increment('dcl_content_download_bytes_total', metricsLabels, file.bytesWritten)
+              endTimeMeasurement()
+              resolve()
             })
+            .catch((err) => {
+              file.close()
+              reject(err)
+              components.metrics?.increment('dcl_content_download_errors_total', metricsLabels)
+              endTimeMeasurement()
+            })
+        }
+      })
 
-            const isGzip = response.headers['content-encoding'] === 'gzip'
+      // Reject (instead of hanging forever) when the connection stalls before/while downloading.
+      request.setTimeout(DOWNLOAD_INACTIVITY_TIMEOUT_MS, () => {
+        request.destroy(new Error('Timeout while downloading ' + url.toString()))
+      })
 
-            const pipe = isGzip ? streamPipeline(response, zlib.createGunzip(), file) : streamPipeline(response, file)
-
-            pipe
-              .then(() => {
-                file.close() // close() is async, call cb after close completes.
-                components.metrics?.increment('dcl_content_download_bytes_total', metricsLabels, file.bytesWritten)
-                endTimeMeasurement()
-                resolve()
-              })
-              .catch((err) => {
-                file.close()
-                reject(err)
-                components.metrics?.increment('dcl_content_download_errors_total', metricsLabels)
-                endTimeMeasurement()
-              })
-          }
-        })
-        .on('error', function (err) {
-          reject(err)
-          components.metrics?.increment('dcl_content_download_errors_total', metricsLabels)
-          endTimeMeasurement()
-        })
+      request.on('error', function (err) {
+        reject(err)
+        components.metrics?.increment('dcl_content_download_errors_total', metricsLabels)
+        endTimeMeasurement()
+      })
     }
 
-    requestWithRedirects(originalUrlString, 0)
+    requestWithRedirects(originalUrlString, originalUrlString, 0)
   })
 }
 
-export function pickLeastRecentlyUsedServer(serversToPickFrom: Server[]): string {
-  // Here is the thing. We could perfectly use round-robin to download content files
-  // and/or spend precious CPU cycles in a fancy load balancing algorithm.
-  // But we are dealing with thousands of "load balancing events". And Math.random()
-  // has a **normal distribution**, which has in practice (and big numbers) the same
-  // effect, load balancing.
-  //
-  // Math is lovely.
+export function pickRandomServer(serversToPickFrom: Server[]): string {
+  // We could use round-robin or a fancier load-balancing algorithm to spread downloads across
+  // servers, but with thousands of "load balancing events" a uniformly-random pick spreads the
+  // load evenly enough in practice while staying dead simple.
   return serversToPickFrom[Math.floor(Math.random() * serversToPickFrom.length)]
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,8 @@ const streamPipeline = promisify(pipeline)
 const MAX_JSON_RESPONSE_SIZE_IN_BYTES = 50 * 1024 * 1024 // 50 MiB
 
 export async function fetchJson(url: string, fetcher: IFetchComponent, init?: fetch.RequestInit): Promise<any> {
-  const response = await fetcher.fetch(url, { size: MAX_JSON_RESPONSE_SIZE_IN_BYTES, ...init })
+  // `size` is spread last so the cap can't be accidentally overridden (or removed) by a caller.
+  const response = await fetcher.fetch(url, { ...init, size: MAX_JSON_RESPONSE_SIZE_IN_BYTES })
 
   if (!response.ok) {
     throw new Error('Error fetching ' + url + '. Status code was: ' + response.status)
@@ -238,6 +239,9 @@ function downloadFile(
 }
 
 export function pickRandomServer(serversToPickFrom: Server[]): string {
+  if (serversToPickFrom.length === 0) {
+    throw new Error('Cannot pick a server from an empty list of servers')
+  }
   // We could use round-robin or a fancier load-balancing algorithm to spread downloads across
   // servers, but with thousands of "load balancing events" a uniformly-random pick spreads the
   // load evenly enough in practice while staying dead simple.

--- a/test/decideSnapshotDeploymentFromProcessedSet.spec.ts
+++ b/test/decideSnapshotDeploymentFromProcessedSet.spec.ts
@@ -1,0 +1,119 @@
+import { decideSnapshotDeploymentFromProcessedSet } from '../src/deploy-entities'
+
+describe('decideSnapshotDeploymentFromProcessedSet', () => {
+  const snapshotHash = 'snapshotHash'
+  const genesisTimestamp = 100
+  let markSnapshotAsProcessed: jest.Mock
+  let snapshotStorageHas: jest.Mock
+  let components: any
+
+  beforeEach(() => {
+    markSnapshotAsProcessed = jest.fn().mockResolvedValue(undefined)
+    snapshotStorageHas = jest.fn().mockResolvedValue(false)
+    components = {
+      processedSnapshotStorage: { markSnapshotAsProcessed, filterProcessedSnapshotsFrom: jest.fn() },
+      snapshotStorage: { has: snapshotStorageHas }
+    }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when the snapshot is already in the processed set', () => {
+    it('should return false and not mark it as processed again', async () => {
+      const result = await decideSnapshotDeploymentFromProcessedSet(
+        components,
+        new Set([snapshotHash]),
+        genesisTimestamp,
+        snapshotHash,
+        genesisTimestamp + 1,
+        []
+      )
+      expect(result).toBe(false)
+      expect(markSnapshotAsProcessed).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the snapshot is not processed', () => {
+    describe('and its greatest end timestamp is not newer than the genesis timestamp', () => {
+      it('should return false', async () => {
+        const result = await decideSnapshotDeploymentFromProcessedSet(
+          components,
+          new Set(),
+          genesisTimestamp,
+          snapshotHash,
+          genesisTimestamp,
+          []
+        )
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('and it is newer than genesis and not already present in the snapshot storage', () => {
+      beforeEach(() => {
+        snapshotStorageHas.mockResolvedValue(false)
+      })
+
+      it('should return true', async () => {
+        const result = await decideSnapshotDeploymentFromProcessedSet(
+          components,
+          new Set(),
+          genesisTimestamp,
+          snapshotHash,
+          genesisTimestamp + 1,
+          []
+        )
+        expect(result).toBe(true)
+      })
+    })
+
+    describe('and it is newer than genesis but already present in the snapshot storage', () => {
+      beforeEach(() => {
+        snapshotStorageHas.mockResolvedValue(true)
+      })
+
+      it('should return false', async () => {
+        const result = await decideSnapshotDeploymentFromProcessedSet(
+          components,
+          new Set(),
+          genesisTimestamp,
+          snapshotHash,
+          genesisTimestamp + 1,
+          []
+        )
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('and a full replaced-hashes group is already in the processed set', () => {
+      it('should mark the snapshot as processed and return false', async () => {
+        const result = await decideSnapshotDeploymentFromProcessedSet(
+          components,
+          new Set(['h1', 'h2']),
+          genesisTimestamp,
+          snapshotHash,
+          genesisTimestamp + 1,
+          [['h1', 'h2']]
+        )
+        expect(result).toBe(false)
+        expect(markSnapshotAsProcessed).toHaveBeenCalledWith(snapshotHash)
+      })
+    })
+
+    describe('and no replaced-hashes group is fully in the processed set', () => {
+      it('should not mark the snapshot and decide based on the timestamp', async () => {
+        const result = await decideSnapshotDeploymentFromProcessedSet(
+          components,
+          new Set(['h1']),
+          genesisTimestamp,
+          snapshotHash,
+          genesisTimestamp + 1,
+          [['h1', 'h2']]
+        )
+        expect(result).toBe(true)
+        expect(markSnapshotAsProcessed).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/test/deployEntitiesFromSnapshot.spec.ts
+++ b/test/deployEntitiesFromSnapshot.spec.ts
@@ -163,6 +163,38 @@ describe('deployEntitiesFromSnapshot', () => {
     })
   })
 
+  test('when the deployer calls markAsDeployed more times than the streamed entities', ({ components }) => {
+    it('still marks the snapshot as processed exactly once', async () => {
+      mockDeployedEntitiesStreamWith([
+        { entityId: 'id1', entityType: 't1', pointers: ['p1'], entityTimestamp: 0, authChain: [], snapshotHash, servers },
+        { entityId: 'id2', entityType: 't2', pointers: ['p2'], entityTimestamp: 1, authChain: [], snapshotHash, servers }
+      ])
+      const deployerMock = {
+        async scheduleEntityDeployment(entity: DeployableEntity) {
+          if (entity.markAsDeployed) {
+            // a misbehaving/over-eager deployer marks the same entity as deployed twice
+            await entity.markAsDeployed()
+            await entity.markAsDeployed()
+          }
+        },
+        onIdle: jest.fn(),
+        prepareForDeploymentsIn: jest.fn()
+      }
+      const markSnapshotAsProcessedSpy = jest.spyOn(components.processedSnapshotStorage, 'markSnapshotAsProcessed')
+
+      await deployEntitiesFromSnapshot(
+        componentsWithDeployer(components, deployerMock),
+        streamOptions,
+        snapshotHash,
+        new Set(servers),
+        () => false
+      )
+
+      expect(markSnapshotAsProcessedSpy).toBeCalledTimes(1)
+      expect(markSnapshotAsProcessedSpy).toBeCalledWith(snapshotHash)
+    })
+  })
+
   test('when the stream is cancelled', ({ components }) => {
     it('stops the deployments of the entities', async () => {
       mockDeployedEntitiesStreamWith([

--- a/test/downloadEntityFileConcurrency.spec.ts
+++ b/test/downloadEntityFileConcurrency.spec.ts
@@ -1,0 +1,61 @@
+import { createInMemoryStorage } from '@dcl/catalyst-storage'
+import { createReadStream } from 'fs'
+import { resolve } from 'path'
+import { Readable } from 'stream'
+import { downloadEntityAndContentFiles } from '../src'
+import { sleep } from '../src/utils'
+import { test } from './components'
+
+// Real, hash-addressed fixtures (their contents hash to these ids), so the hash check on download passes.
+const contentHashes = [
+  'QmazJLZfUmZgNMTdwWSmJRvw4dBfcjS9GuqkwkKGRWb4K6',
+  'QmUiEzCQPxz5eHq7KXMrGq7PiM1fnZNvZg2sWELQnuYank',
+  'Qma14gteWwHrn61kv4zkRABKzopWd5ZXBppHRhbqikfaev',
+  'QmWxyDrJWABXjGonFpUxJD8YYzz2xiFNxupGwYKTbySaZD'
+]
+
+test('downloadEntityAndContentFiles content download concurrency', ({ components }) => {
+  const contentFolder = resolve('downloads')
+  // alphanumeric so it passes hash validation; pre-seeded in storage so the entity download is skipped
+  const entityId = 'sceneentitydownloadconcurrencytest'
+  let inFlight = 0
+  let maxInFlight = 0
+
+  it('prepares the endpoints', () => {
+    components.router.get('/contents/:file', async (ctx) => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      // hold the request open so that any concurrent downloads would overlap and be counted
+      await sleep(40)
+      inFlight--
+      return { body: createReadStream('test/fixtures/' + ctx.params.file) }
+    })
+  })
+
+  describe('when a concurrency of 1 is configured', () => {
+    it('should download the content files serially and still fetch all of them', async () => {
+      const storage = createInMemoryStorage()
+      const entity = {
+        type: 'scene',
+        content: contentHashes.map((hash, index) => ({ file: `file-${index}`, hash }))
+      }
+      await storage.storeStream(entityId, Readable.from([Buffer.from(JSON.stringify(entity))]))
+
+      await downloadEntityAndContentFiles(
+        { fetcher: components.fetcher, logs: components.logs, metrics: components.metrics, storage },
+        entityId,
+        [await components.getBaseUrl()],
+        new Map(),
+        contentFolder,
+        10, // maxRetries
+        0, // waitTimeBetweenRetries
+        1 // contentFilesConcurrency
+      )
+
+      expect(maxInFlight).toEqual(1)
+      for (const hash of contentHashes) {
+        expect(await storage.exist(hash)).toBe(true)
+      }
+    })
+  })
+})

--- a/test/downloadFileWithRedirects.spec.ts
+++ b/test/downloadFileWithRedirects.spec.ts
@@ -1,0 +1,56 @@
+import { createTestMetricsComponent } from '@dcl/metrics'
+import { resolve } from 'path'
+import { metricsDefinitions } from '../src/metrics'
+import { saveContentFileToDisk, streamToBuffer } from '../src/utils'
+import { test } from './components'
+
+test('downloadFile redirect handling', ({ components }) => {
+  const metrics = createTestMetricsComponent(metricsDefinitions)
+  const contentFolder = resolve('downloads')
+  const content = Buffer.from('redirect-target-content', 'utf-8')
+
+  it('prepares the endpoints', () => {
+    // Chained redirects: /start -> /sub/second -> (relative) "third".
+    // The relative "third" must resolve against /sub/second (the redirecting URL), i.e. /sub/third,
+    // NOT against the original /start. /third is wired to 404 to catch the old (buggy) base behavior.
+    components.router.get('/start', async () => ({ status: 302, headers: { location: '/sub/second' } }))
+    components.router.get('/sub/second', async () => ({ status: 302, headers: { location: 'third' } }))
+    components.router.get('/sub/third', async () => ({ body: content.toString() }))
+    components.router.get('/third', async () => ({ status: 404 }))
+
+    // Redirect to an unsupported (non-http) protocol.
+    components.router.get('/redirect-to-file', async () => ({
+      status: 302,
+      headers: { location: 'file:///etc/passwd' }
+    }))
+  })
+
+  describe('when a relative redirect is followed', () => {
+    it('should resolve it against the redirecting URL and download the content', async () => {
+      await saveContentFileToDisk(
+        { metrics, storage: components.storage },
+        (await components.getBaseUrl()) + '/start',
+        resolve(contentFolder, 'redirect-chain'),
+        'redirect-chain',
+        false
+      )
+
+      const stored = await streamToBuffer(await (await components.storage.retrieve('redirect-chain'))!.asStream())
+      expect(stored).toEqual(content)
+    })
+  })
+
+  describe('when a redirect points to a non-http(s) protocol', () => {
+    it('should reject with an unsupported protocol error', async () => {
+      await expect(
+        saveContentFileToDisk(
+          { metrics, storage: components.storage },
+          (await components.getBaseUrl()) + '/redirect-to-file',
+          resolve(contentFolder, 'unsupported-protocol'),
+          'unsupported-protocol',
+          false
+        )
+      ).rejects.toThrow('Unsupported protocol')
+    })
+  })
+})

--- a/test/exponential-fallof-retry.spec.ts
+++ b/test/exponential-fallof-retry.spec.ts
@@ -42,4 +42,58 @@ describe('createExponentialFallofRetry', () => {
     expect(component.getRetryCount()).toEqual(11)
     expect(totalCount).toEqual(11)
   })
+
+  describe('when stop() is called while the component is sleeping between retries', () => {
+    let logger: any
+
+    beforeEach(async () => {
+      const config = createConfigComponent({})
+      const logs = await createLogComponent({ config })
+      logger = logs.getLogger('logger')
+    })
+
+    it('should stop promptly instead of waiting out the full retry interval', async () => {
+      const firstActionRun = future<void>()
+      const component = createExponentialFallofRetry(logger, {
+        async action() {
+          firstActionRun.resolve()
+        },
+        // Large enough that the test would time out if the sleep were not interrupted by stop().
+        retryTime: 1_000_000
+      })
+
+      const startPromise = component.start()
+      await firstActionRun
+      // give the loop a moment to enter the retry sleep
+      await sleep(50)
+      await component.stop()
+      await startPromise
+
+      expect(component.isStopped()).toEqual(true)
+    })
+  })
+
+  describe('when the action succeeds and exitOnSuccess is enabled', () => {
+    let logger: any
+
+    beforeEach(async () => {
+      const config = createConfigComponent({})
+      const logs = await createLogComponent({ config })
+      logger = logs.getLogger('logger')
+    })
+
+    it('should report the component as stopped once the loop exits', async () => {
+      const component = createExponentialFallofRetry(logger, {
+        async action() {
+          // succeeds immediately
+        },
+        retryTime: 1000,
+        exitOnSuccess: true
+      })
+
+      await component.start()
+
+      expect(component.isStopped()).toEqual(true)
+    })
+  })
 })

--- a/test/getDeployedEntitiesStreamFromPointerChanges.spec.ts
+++ b/test/getDeployedEntitiesStreamFromPointerChanges.spec.ts
@@ -132,3 +132,74 @@ test('fetches a stream from pointer-changes from 0 if timestamp is not specified
     ])
   })
 })
+
+test('does not re-yield boundary deployments across polls', ({ components }) => {
+  const authChain = [
+    {
+      type: AuthLinkType.SIGNER,
+      payload: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5',
+      signature: '',
+    },
+  ]
+  const idA = 'ba000000000000000000000000000000000000000000000000000000010'
+  const idB = 'ba000000000000000000000000000000000000000000000000000000011'
+
+  it('prepares the endpoints', () => {
+    // The poll re-fetches from the high-water timestamp (inclusive), so the deployment at that
+    // timestamp comes back every cycle. from=1 re-returns idA (ts 1) alongside the new idB (ts 2).
+    components.router.get('/pointer-changes', async (ctx) => {
+      const from = ctx.url.searchParams.get('from')
+      if (from === '0') {
+        return {
+          body: {
+            deltas: [
+              { entityType: 'profile', entityId: idA, entityTimestamp: 1, localTimestamp: 1, authChain, pointers: ['0x1'] }
+            ],
+            pagination: {}
+          }
+        }
+      }
+      if (from === '1') {
+        return {
+          body: {
+            deltas: [
+              { entityType: 'profile', entityId: idA, entityTimestamp: 1, localTimestamp: 1, authChain, pointers: ['0x1'] },
+              { entityType: 'profile', entityId: idB, entityTimestamp: 2, localTimestamp: 2, authChain, pointers: ['0x1'] }
+            ],
+            pagination: {}
+          }
+        }
+      }
+      return {
+        body: {
+          deltas: [
+            { entityType: 'profile', entityId: idB, entityTimestamp: 2, localTimestamp: 2, authChain, pointers: ['0x1'] }
+          ],
+          pagination: {}
+        }
+      }
+    })
+  })
+
+  it('yields each deployment at the boundary timestamp only once', async () => {
+    const yieldedEntityIds: string[] = []
+    const stream = getDeployedEntitiesStreamFromPointerChanges(
+      components,
+      {
+        pointerChangesWaitTime: 20,
+        fromTimestamp: 0
+      },
+      await components.getBaseUrl()
+    )
+
+    for await (const deployment of stream) {
+      yieldedEntityIds.push(deployment.entityId)
+      // stop once the second poll has surfaced the new deployment
+      if (deployment.entityId === idB) {
+        break
+      }
+    }
+
+    expect(yieldedEntityIds).toEqual([idA, idB])
+  })
+})

--- a/test/getSnapshots.spec.ts
+++ b/test/getSnapshots.spec.ts
@@ -52,3 +52,33 @@ test('getSnapshots when the response is not an array', ({ components }) => {
     await expect(getSnapshots(components, await components.getBaseUrl(), 10)).rejects.toThrow('expected an array')
   })
 })
+
+test('getSnapshots when the response contains many invalid entries', ({ components }) => {
+  const numberOfInvalidEntries = 150
+
+  it('prepares the endpoints', () => {
+    components.router.get('/snapshots', async () => ({
+      // every entry has a path-traversal hash, so all are rejected
+      body: Array.from({ length: numberOfInvalidEntries }, (_unused, index) => ({ hash: `../bad-${index}` }))
+    }))
+  })
+
+  it('caps the invalid-entry error logs and still returns no snapshots', async () => {
+    const errorMock = jest.fn()
+    jest.spyOn(components.logs, 'getLogger').mockReturnValue({
+      log: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: errorMock
+    })
+
+    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+
+    expect(snapshots).toEqual([])
+    // 100 per-entry errors + 1 summary line
+    expect(errorMock).toHaveBeenCalledTimes(101)
+
+    jest.restoreAllMocks()
+  })
+})

--- a/test/getSnapshots.spec.ts
+++ b/test/getSnapshots.spec.ts
@@ -25,6 +25,12 @@ test('getSnapshots when the response mixes valid and invalid snapshot metadata',
         { timeRange: { initTimestamp: 0, endTimestamp: 10 } },
         // missing timeRange
         { hash: 'notimerange' },
+        // valid hash but a replaced-snapshot hash that is not a valid content hash
+        {
+          hash: 'bafkreig6sfhegnp4okzecgx3v6gj6pohh5qzw6zjtrdqtggx64743rkmz4',
+          timeRange: { initTimestamp: 0, endTimestamp: 60 },
+          replacedSnapshotHashes: ['../../evil']
+        },
         // not an object
         'not-an-object'
       ]

--- a/test/getSnapshots.spec.ts
+++ b/test/getSnapshots.spec.ts
@@ -1,0 +1,48 @@
+import { getSnapshots } from '../src/client'
+import { test } from './components'
+
+const validSnapshot = {
+  hash: 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu',
+  timeRange: { initTimestamp: 0, endTimestamp: 100 },
+  replacedSnapshotHashes: []
+}
+const newerValidSnapshot = {
+  hash: 'bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha',
+  timeRange: { initTimestamp: 100, endTimestamp: 200 }
+}
+
+test('getSnapshots when the response mixes valid and invalid snapshot metadata', ({ components }) => {
+  it('prepares the endpoints', () => {
+    components.router.get('/snapshots', async () => ({
+      body: [
+        validSnapshot,
+        newerValidSnapshot,
+        // path-traversal hash
+        { hash: '../../etc/passwd', timeRange: { initTimestamp: 0, endTimestamp: 50 } },
+        // non-numeric timestamp
+        { hash: 'validlookinghash', timeRange: { initTimestamp: 0, endTimestamp: 'not-a-number' } },
+        // missing hash
+        { timeRange: { initTimestamp: 0, endTimestamp: 10 } },
+        // missing timeRange
+        { hash: 'notimerange' },
+        // not an object
+        'not-an-object'
+      ]
+    }))
+  })
+
+  it('returns only the valid snapshots, sorted newest first', async () => {
+    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+    expect(snapshots).toEqual([newerValidSnapshot, validSnapshot])
+  })
+})
+
+test('getSnapshots when the response is not an array', ({ components }) => {
+  it('prepares the endpoints', () => {
+    components.router.get('/snapshots', async () => ({ body: { not: 'an array' } }))
+  })
+
+  it('rejects indicating that an array was expected', async () => {
+    await expect(getSnapshots(components, await components.getBaseUrl(), 10)).rejects.toThrow('expected an array')
+  })
+})

--- a/test/isValidContentHash.spec.ts
+++ b/test/isValidContentHash.spec.ts
@@ -1,5 +1,5 @@
 import { downloadFileWithRetries } from '../src/downloader'
-import { isValidContentHash } from '../src/utils'
+import { isValidContentHash, pickRandomServer } from '../src/utils'
 
 describe('isValidContentHash', () => {
   describe('when the hash is a valid CIDv0 (Qm) content hash', () => {
@@ -62,6 +62,21 @@ describe('downloadFileWithRetries', () => {
         downloadFileWithRetries({ storage } as any, '../../etc/passwd', '/tmp/downloads', [], new Map(), 1, 0)
       ).rejects.toThrow('Invalid content hash')
       expect(storage.exist).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('pickRandomServer', () => {
+  describe('when the list contains at least one server', () => {
+    it('should return one of the servers in the list', () => {
+      const servers = ['https://a.example.com', 'https://b.example.com']
+      expect(servers).toContain(pickRandomServer(servers))
+    })
+  })
+
+  describe('when the list of servers is empty', () => {
+    it('should throw instead of returning undefined', () => {
+      expect(() => pickRandomServer([])).toThrow('empty list of servers')
     })
   })
 })

--- a/test/isValidContentHash.spec.ts
+++ b/test/isValidContentHash.spec.ts
@@ -1,0 +1,67 @@
+import { downloadFileWithRetries } from '../src/downloader'
+import { isValidContentHash } from '../src/utils'
+
+describe('isValidContentHash', () => {
+  describe('when the hash is a valid CIDv0 (Qm) content hash', () => {
+    it('should return true', () => {
+      expect(isValidContentHash('QmXx5dDq7nnPuCCP43Ngc7iq4kkqDfC5PEJGawUHYLGxUn')).toBe(true)
+    })
+  })
+
+  describe('when the hash is a valid CIDv1 (ba) content hash', () => {
+    it('should return true', () => {
+      expect(isValidContentHash('bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu')).toBe(true)
+    })
+  })
+
+  describe('when the hash contains a path traversal sequence', () => {
+    it('should return false', () => {
+      expect(isValidContentHash('../../etc/passwd')).toBe(false)
+    })
+  })
+
+  describe('when the hash contains a path separator', () => {
+    it('should return false', () => {
+      expect(isValidContentHash('abc/def')).toBe(false)
+    })
+  })
+
+  describe('when the hash contains a dot', () => {
+    it('should return false', () => {
+      expect(isValidContentHash('file.txt')).toBe(false)
+    })
+  })
+
+  describe('when the hash is empty', () => {
+    it('should return false', () => {
+      expect(isValidContentHash('')).toBe(false)
+    })
+  })
+
+  describe('when the hash exceeds the maximum allowed length', () => {
+    it('should return false', () => {
+      expect(isValidContentHash('a'.repeat(129))).toBe(false)
+    })
+  })
+})
+
+describe('downloadFileWithRetries', () => {
+  describe('when the hash to download is not a valid content hash', () => {
+    let storage: { exist: jest.Mock }
+
+    beforeEach(() => {
+      storage = { exist: jest.fn() }
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('should reject with an invalid content hash error before touching storage', async () => {
+      await expect(
+        downloadFileWithRetries({ storage } as any, '../../etc/passwd', '/tmp/downloads', [], new Map(), 1, 0)
+      ).rejects.toThrow('Invalid content hash')
+      expect(storage.exist).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/test/processor.spec.ts
+++ b/test/processor.spec.ts
@@ -1,8 +1,19 @@
 import { AuthLinkType } from '@dcl/schemas'
-import { processDeploymentsInFile } from '../src/file-processor'
+import { Readable } from 'stream'
+import { processDeploymentsInFile, processDeploymentsInStream } from '../src/file-processor'
 import { createStorageComponent } from './test-component'
 import { test } from './components'
 import { ILoggerComponent } from '@well-known-components/interfaces'
+
+function streamOfLines(lines: string[]): Readable {
+  return Readable.from(
+    (function* () {
+      for (const line of lines) {
+        yield line + '\n'
+      }
+    })()
+  )
+}
 
 test('processor', ({ components, stubComponents }) => {
 
@@ -56,6 +67,81 @@ test('processor', ({ components, stubComponents }) => {
           // noop
         }
       }).rejects.toThrow('does not exist')
+    })
+  })
+})
+
+describe('processDeploymentsInStream', () => {
+  const authChain = [
+    {
+      type: AuthLinkType.SIGNER,
+      payload: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5',
+      signature: ''
+    }
+  ]
+  let errorMock: jest.Mock
+  let logger: ILoggerComponent.ILogger
+
+  beforeEach(() => {
+    errorMock = jest.fn()
+    logger = { log: jest.fn(), debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: errorMock }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when the stream contains a malformed JSON line between valid deployments', () => {
+    let deployment1: any
+    let deployment2: any
+    let stream: Readable
+
+    beforeEach(() => {
+      deployment1 = {
+        entityType: 'profile',
+        entityId: 'ba000000000000000000000000000000000000000000000000000000001',
+        entityTimestamp: 1,
+        authChain,
+        pointers: ['0x1']
+      }
+      deployment2 = {
+        entityType: 'profile',
+        entityId: 'ba000000000000000000000000000000000000000000000000000000002',
+        entityTimestamp: 2,
+        authChain,
+        pointers: ['0x1']
+      }
+      stream = streamOfLines([JSON.stringify(deployment1), '{not valid json}', JSON.stringify(deployment2)])
+    })
+
+    it('should skip the malformed line and still yield the valid deployments', async () => {
+      const yielded: any[] = []
+      for await (const deployment of processDeploymentsInStream(stream, logger)) {
+        yielded.push(deployment)
+      }
+      expect(yielded).toEqual([deployment1, deployment2])
+    })
+
+    it('should log a single error for the malformed line', async () => {
+      for await (const _deployment of processDeploymentsInStream(stream, logger)) {
+        // drain
+      }
+      expect(errorMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when the stream contains more invalid lines than the logging cap', () => {
+    let stream: Readable
+
+    beforeEach(() => {
+      stream = streamOfLines(new Array(150).fill('{not valid json}'))
+    })
+
+    it('should cap the logged errors at 100 plus one suppression message', async () => {
+      for await (const _deployment of processDeploymentsInStream(stream, logger)) {
+        // drain the (empty) stream of valid deployments
+      }
+      expect(errorMock).toHaveBeenCalledTimes(101)
     })
   })
 })

--- a/test/serial-job-runner.spec.ts
+++ b/test/serial-job-runner.spec.ts
@@ -1,0 +1,120 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import future from 'fp-future'
+import { createSerialJobRunner } from '../src/serial-job-runner'
+import { IJobWithLifecycle } from '../src/job-lifecycle-manager'
+import { sleep } from '../src/utils'
+
+describe('createSerialJobRunner', () => {
+  let logger: ILoggerComponent.ILogger
+  let runner: ReturnType<typeof createSerialJobRunner>
+
+  beforeEach(() => {
+    logger = { log: jest.fn(), debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+    runner = createSerialJobRunner(logger)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when more jobs are enqueued than can be running at once', () => {
+    let startOrder: string[]
+    let allStarted: ReturnType<typeof future<void>>
+
+    beforeEach(() => {
+      startOrder = []
+      allStarted = future<void>()
+    })
+
+    it('should run every enqueued job in FIFO order', async () => {
+      const makeJob = (id: string, isLast = false): IJobWithLifecycle => ({
+        async start() {
+          startOrder.push(id)
+          if (isLast) {
+            allStarted.resolve()
+          }
+        },
+        async stop() {}
+      })
+
+      runner.enqueue(makeJob('a'))
+      runner.enqueue(makeJob('b'))
+      runner.enqueue(makeJob('c', true))
+
+      await allStarted
+
+      expect(startOrder).toEqual(['a', 'b', 'c'])
+    })
+  })
+
+  describe('when a job is still running', () => {
+    let startOrder: string[]
+    let releaseFirstJob: ReturnType<typeof future<void>>
+
+    beforeEach(() => {
+      startOrder = []
+      releaseFirstJob = future<void>()
+    })
+
+    it('should not start the next job until the running one finishes', async () => {
+      runner.enqueue({
+        async start() {
+          startOrder.push('a')
+          await releaseFirstJob
+        },
+        async stop() {}
+      })
+      runner.enqueue({
+        async start() {
+          startOrder.push('b')
+        },
+        async stop() {}
+      })
+
+      await sleep(20)
+      expect(startOrder).toEqual(['a'])
+
+      releaseFirstJob.resolve()
+      await sleep(20)
+      expect(startOrder).toEqual(['a', 'b'])
+    })
+  })
+
+  describe('when stop() is called while a job is running and others are queued', () => {
+    let startOrder: string[]
+    let firstJobStopped: boolean
+    let releaseFirstJob: ReturnType<typeof future<void>>
+
+    beforeEach(() => {
+      startOrder = []
+      firstJobStopped = false
+      releaseFirstJob = future<void>()
+    })
+
+    it('should stop the running job and never start the queued ones', async () => {
+      runner.enqueue({
+        async start() {
+          startOrder.push('a')
+          await releaseFirstJob
+        },
+        async stop() {
+          firstJobStopped = true
+          releaseFirstJob.resolve()
+        }
+      })
+      runner.enqueue({
+        async start() {
+          startOrder.push('b')
+        },
+        async stop() {}
+      })
+
+      await sleep(20)
+      await runner.stop()
+      await sleep(20)
+
+      expect(firstJobStopped).toBe(true)
+      expect(startOrder).toEqual(['a'])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

A hardening pass over the download, sync and parsing paths, plus regression tests for every behavioral change. All findings came from successive review rounds (security, bugs, performance). No public API was removed or renamed.

**Verification:** `tsc --noEmit` ✅ · `eslint` ✅ · `jest` ✅ — **93 tests (up from 64), 16 suites**.

## Security

- **Path traversal** — validate content hashes (alphanumeric CIDs, `src/utils.ts` `isValidContentHash`) before building filesystem paths / storage keys, enforced in `downloadFileWithRetries`.
- **Gzip bomb / unbounded download** — cap decompressed bytes written to disk.
- **Hanging downloads** — socket-inactivity timeout on content downloads (they previously had none and could hang forever).
- **Redirects** — resolve relative redirects against the redirecting URL (not the original) and reject non-`http(s)` targets.
- **Unbounded JSON** — cap buffered response size in `fetchJson`.
- **Resource exhaustion** — bound per-entity content-file download concurrency.
- **Log flooding** — cap per-file invalid-line error logging.
- **Untrusted input** — validate the `/snapshots` response shape, dropping malformed entries.

## Bug fixes

- `pointerChangesStartingTimestamp` now treats a genesis timestamp of `0` as valid (`=== undefined`, not falsy) — previously a new/empty server at genesis threw and could never sync.
- Guard `Math.max` over an empty snapshot list (fall back to genesis instead of `-Infinity`).
- `downloadContentFile` dedups on the content **hash**, not the file path.
- Guard `JSON.parse` of missing entity content and of malformed snapshot lines (one bad line no longer aborts the whole snapshot).
- **Sync-job chain** now serializes correctly: the queue drains past the 2nd job under overlapping `syncWithServers` calls (it previously stalled, silently stopping all further sync jobs).
- `exponential-fallof-retry`: reset `started` once the loop exits (accurate `isStopped()`, restartable) and make the retry sleep abortable by `stop()`.
- Warm up the deployer at genesis (`minStartingPoint !== undefined`) — fixes silently-skipped deployments for bloom-filter-backed deployers (e.g. catalyst).
- Tolerate a deployer that over-reports `markAsDeployed` (`>=` with a save-once guard) so a snapshot can't be re-processed forever.

## Performance

- Fetch each server's snapshots concurrently instead of serially.
- Batch the processed-snapshot lookup into a single storage call; run per-snapshot decisions with bounded concurrency.
- Sample the available-servers histogram once per job, not once per retry.
- Dedup pointer-changes boundary deployments that the inclusive `from=` re-fetch returns on every poll.

## Tests

29 new regression tests across 8 files (4 new, 4 extended). Each is designed to fail against the pre-fix behavior (e.g. the abortable-sleep test would hang ~1000s without the fix; the completion-count test gets 0 `markSnapshotAsProcessed` calls under the old `===`).

## Follow-ups (not in this PR)

From a review of the consumers (`catalyst`, `deployments-to-sqs`, `asset-bundle-registry`): all three deep-import from `@dcl/snapshots-fetcher/dist/*`. A separate change to **widen the package root exports** (so they can drop `/dist/` paths) and **typed/retryable errors** (consumers currently regex-match `status: 4\d{2}`) would further improve integration. Happy to open those separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)