### PR TITLE
refactor: migrate to @dcl/fetch-component and drain response bodies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,27 +26,30 @@
   },
   "dependencies": {
     "@dcl/catalyst-storage": "^4.5.1",
+    "@dcl/core-commons": "^0.10.1",
+    "@dcl/fetch-component": "^1.1.1",
     "@dcl/hashing": "^3.0.3",
-    "@dcl/metrics": "^1.0.0",
+    "@dcl/metrics": "^1.0.1",
     "@dcl/schemas": "^9.1.1",
-    "@well-known-components/fetch-component": "^3.0.0",
-    "@well-known-components/interfaces": "^1.4.0",
+    "@well-known-components/interfaces": "^1.5.2",
     "p-queue": "^6.6.2"
   },
   "engines": {
-    "node": ">16.0.0"
+    "node": ">=22.0.0"
   },
   "engineStrict": true,
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@dcl/eslint-config": "^1.1.1",
-    "@dcl/http-server": "^1.0.1",
+    "@dcl/http-server": "^2.2.1",
+    "@dcl/test-helpers": "^0.2.0",
+    "@types/jest": "^29.5.0",
     "@types/node": "^18.15.11",
     "@well-known-components/env-config-provider": "^1.1.1",
     "@well-known-components/logger": "^3.0.0",
-    "@well-known-components/test-helpers": "^1.2.1",
     "babel-plugin-module-resolver": "^5.0.0",
-    "node-fetch": "^2.6.7",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.5.0",
     "typescript": "^4.5.5"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,9 @@ export { getDeployedEntitiesStreamFromSnapshot, getDeployedEntitiesStreamFromPoi
 // sockets / file descriptors. Overridable via downloadEntityAndContentFiles's last argument.
 const DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY = 10
 
-if (parseInt(process.version.split('.')[0]) < 16) {
+if (parseInt(process.versions.node.split('.')[0], 10) < 22) {
   const { name } = require('../package.json')
-  throw new Error(`In order to work, the package ${name} needs to run in Node v16 or newer to handle streams properly.`)
+  throw new Error(`In order to work, the package ${name} needs to run in Node v22 or newer to handle streams properly.`)
 }
 
 async function downloadProfileAvatars(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { IContentStorageComponent } from '@dcl/catalyst-storage'
 import { SyncDeployment } from '@dcl/schemas'
-import { IBaseComponent, IFetchComponent, ILoggerComponent, IMetricsComponent } from '@well-known-components/interfaces'
+import { IBaseComponent, ILoggerComponent, IMetricsComponent } from '@well-known-components/interfaces'
+import { IFetchComponent } from '@dcl/core-commons'
 import { ExponentialFallofRetryComponent } from './exponential-fallof-retry'
 import { IJobQueue } from './job-queue-port'
 import { metricsDefinitions } from './metrics'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,9 @@
 import { hashV0, hashV1 } from '@dcl/hashing'
-import { IFetchComponent } from '@well-known-components/interfaces'
+import { IFetchComponent, RequestOptions } from '@dcl/core-commons'
 import * as crypto from 'crypto'
 import * as fs from 'fs'
 import * as http from 'http'
 import * as https from 'https'
-import * as fetch from 'node-fetch'
 import { pipeline, Readable, Transform } from 'stream'
 import { promisify } from 'util'
 import * as zlib from 'zlib'
@@ -14,19 +13,50 @@ import { Server, SnapshotsFetcherComponents } from './types'
 const streamPipeline = promisify(pipeline)
 
 // Bounds buffered JSON responses so a malicious server can't OOM the process via response.json().
-// node-fetch rejects bodies larger than `size`.
 const MAX_JSON_RESPONSE_SIZE_IN_BYTES = 50 * 1024 * 1024 // 50 MiB
 
-export async function fetchJson(url: string, fetcher: IFetchComponent, init?: fetch.RequestInit): Promise<any> {
-  // `size` is spread last so the cap can't be accidentally overridden (or removed) by a caller.
-  const response = await fetcher.fetch(url, { ...init, size: MAX_JSON_RESPONSE_SIZE_IN_BYTES })
+// Reads a response body while enforcing a maximum size. The native fetcher (unlike node-fetch) has
+// no `size` option, so we cap manually: read the stream with a running byte count and abort —
+// cancelling the stream to free its socket — if it exceeds the limit.
+async function readBodyWithSizeLimit(response: Response, maxBytes: number): Promise<string> {
+  const reader = response.body?.getReader()
+  if (!reader) {
+    return ''
+  }
+
+  const chunks: Uint8Array[] = []
+  let total = 0
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (value) {
+        total += value.byteLength
+        if (total > maxBytes) {
+          throw new Error(`Response body exceeds the maximum allowed size of ${maxBytes} bytes`)
+        }
+        chunks.push(value)
+      }
+    }
+  } finally {
+    // Frees the socket on the size-exceeded path; a no-op once the stream has been fully read.
+    await reader.cancel().catch(() => undefined)
+  }
+
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+export async function fetchJson(url: string, fetcher: IFetchComponent, init?: RequestOptions): Promise<any> {
+  const response = await fetcher.fetch(url, init)
 
   if (!response.ok) {
+    // Drain the body so undici releases the socket back to the pool before throwing.
+    await response.body?.cancel().catch(() => undefined)
     throw new Error('Error fetching ' + url + '. Status code was: ' + response.status)
   }
 
-  const body = await response.json()
-  return body
+  return JSON.parse(await readBodyWithSizeLimit(response, MAX_JSON_RESPONSE_SIZE_IN_BYTES))
 }
 
 export async function checkFileExists(file: string): Promise<boolean> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,7 +56,12 @@ export async function fetchJson(url: string, fetcher: IFetchComponent, init?: Re
     throw new Error('Error fetching ' + url + '. Status code was: ' + response.status)
   }
 
-  return JSON.parse(await readBodyWithSizeLimit(response, MAX_JSON_RESPONSE_SIZE_IN_BYTES))
+  const body = await readBodyWithSizeLimit(response, MAX_JSON_RESPONSE_SIZE_IN_BYTES)
+  if (body === '') {
+    throw new Error('Error fetching ' + url + '. The response body was empty.')
+  }
+
+  return JSON.parse(body)
 }
 
 export async function checkFileExists(file: string): Promise<boolean> {

--- a/test/components.ts
+++ b/test/components.ts
@@ -1,10 +1,11 @@
 // This file is the "test-environment" analogous for src/components.ts
 // Here we define the test components to be used in the testing environment
 
-import { createRunner } from '@well-known-components/test-helpers'
+import { createFetchComponent } from '@dcl/fetch-component'
+import { createRunner } from '@dcl/test-helpers'
 import { createJobQueue } from '../src/job-queue-port'
 import { SnapshotsFetcherComponents } from '../src/types'
-import { createFetchComponent, createProcessedSnapshotStorageComponent, createStorageComponent } from './test-component'
+import { createProcessedSnapshotStorageComponent, createStorageComponent } from './test-component'
 
 import { createTestMetricsComponent } from '@dcl/metrics'
 import { createConfigComponent } from '@well-known-components/env-config-provider'

--- a/test/functions-for-wkc-test-helpers.ts
+++ b/test/functions-for-wkc-test-helpers.ts
@@ -1,11 +1,11 @@
 // The functions in this file may be migrated to http-server test helpers
 
+import { IHttpServerComponent } from '@dcl/core-commons'
 import { createServerComponent, Router } from '@dcl/http-server'
+import { defaultServerConfig } from '@dcl/test-helpers'
 import { createConfigComponent } from '@well-known-components/env-config-provider'
-import { IConfigComponent, IHttpServerComponent, ILoggerComponent } from '@well-known-components/interfaces'
+import { IConfigComponent, ILoggerComponent } from '@well-known-components/interfaces'
 import { createLogComponent } from '@well-known-components/logger'
-import { defaultServerConfig } from '@well-known-components/test-helpers'
-import { Headers } from 'node-fetch'
 import { Readable } from 'stream'
 
 export type TestServerAppContext<OtherComponents> = {

--- a/test/getDeployedEntitiesStreamFromSnapshot.spec.ts
+++ b/test/getDeployedEntitiesStreamFromSnapshot.spec.ts
@@ -3,12 +3,11 @@ import { test } from './components'
 import { createReadStream, unlinkSync } from 'fs'
 import { resolve } from 'path'
 import { sleep } from '../src/utils'
-import Sinon from 'sinon'
 import { AuthLinkType } from '@dcl/schemas'
 
 const downloadedSnapshotFile = 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu'
 
-test('fetches a stream from snapshots deleting the downloaded file', ({ components, stubComponents }) => {
+test('fetches a stream from snapshots deleting the downloaded file', ({ components, spyComponents }) => {
   const contentFolder = resolve('downloads')
   const authChain = [
     {
@@ -39,10 +38,7 @@ test('fetches a stream from snapshots deleting the downloaded file', ({ componen
   })
 
   it('fetches stream', async () => {
-    const { storage } = stubComponents
-
-    storage.storeStream.callThrough()
-    storage.retrieve.callThrough()
+    const { storage } = spyComponents
 
     const servers = [await components.getBaseUrl()]
 
@@ -62,14 +58,14 @@ test('fetches a stream from snapshots deleting the downloaded file', ({ componen
       new Set(servers)
     )
 
-    Sinon.assert.callCount(storage.delete, 0)
+    expect(storage.delete).toHaveBeenCalledTimes(0)
 
     for await (const deployment of stream) {
       r.push(deployment)
     }
 
     // the downloaded file must be deleted
-    Sinon.assert.calledOnce(storage.delete)
+    expect(storage.delete).toHaveBeenCalledTimes(1)
 
     expect(r).toEqual([
       { entityType: 'profile', entityId: 'ba000000000000000000000000000000000000000000000000000000001', entityTimestamp: 1, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile, servers },
@@ -85,7 +81,7 @@ test('fetches a stream from snapshots deleting the downloaded file', ({ componen
   })
 })
 
-test('fetches a stream without deleting the downloaded file', ({ components, stubComponents }) => {
+test('fetches a stream without deleting the downloaded file', ({ components, spyComponents }) => {
   const contentFolder = resolve('downloads')
   const authChain = [
     {
@@ -116,10 +112,7 @@ test('fetches a stream without deleting the downloaded file', ({ components, stu
   })
 
   it('fetch stream', async () => {
-    const { storage } = stubComponents
-
-    storage.storeStream.callThrough()
-    storage.retrieve.callThrough()
+    const { storage } = spyComponents
 
     const servers = [await components.getBaseUrl()]
 
@@ -140,7 +133,7 @@ test('fetches a stream without deleting the downloaded file', ({ components, stu
       new Set(servers)
     )
 
-    Sinon.assert.callCount(storage.delete, 0)
+    expect(storage.delete).toHaveBeenCalledTimes(0)
 
     for await (const deployment of stream) {
       r.push(deployment)
@@ -160,11 +153,11 @@ test('fetches a stream without deleting the downloaded file', ({ components, stu
     ])
 
     // the downloaded file must not be deleted
-    Sinon.assert.callCount(storage.delete, 0)
+    expect(storage.delete).toHaveBeenCalledTimes(0)
   })
 })
 
-test('does not fetch a stream if fromTimestamp is after the snapshot endTimestamp', ({ components, stubComponents }) => {
+test('does not fetch a stream if fromTimestamp is after the snapshot endTimestamp', ({ components, spyComponents }) => {
   const contentFolder = resolve('downloads')
 
   it('prepares the endpoints', () => {
@@ -188,10 +181,7 @@ test('does not fetch a stream if fromTimestamp is after the snapshot endTimestam
   })
 
   it('fetch stream', async () => {
-    const { storage } = stubComponents
-
-    storage.storeStream.callThrough()
-    storage.retrieve.callThrough()
+    const { storage } = spyComponents
 
     const servers = [await components.getBaseUrl()]
 
@@ -222,7 +212,7 @@ test('does not fetch a stream if fromTimestamp is after the snapshot endTimestam
   })
 })
 
-test('does delete snapshot after usage if its not own snapshot', ({ components, stubComponents }) => {
+test('does delete snapshot after usage if its not own snapshot', ({ components, spyComponents }) => {
   const contentFolder = resolve('downloads')
 
   it('prepares the endpoints', () => {
@@ -246,10 +236,7 @@ test('does delete snapshot after usage if its not own snapshot', ({ components, 
   })
 
   it('fetch stream', async () => {
-    const { storage } = stubComponents
-
-    storage.storeStream.callThrough()
-    storage.retrieve.callThrough()
+    const { storage } = spyComponents
 
     const storageDeleteSpy = jest.spyOn(storage, 'delete')
 

--- a/test/test-component.ts
+++ b/test/test-component.ts
@@ -1,21 +1,9 @@
 import { createInMemoryStorage, IContentStorageComponent } from '@dcl/catalyst-storage'
-import { IFetchComponent } from '@well-known-components/interfaces'
 import { readFileSync } from 'fs'
 import { readdir, stat } from 'fs/promises'
-import * as nodeFetch from 'node-fetch'
 import { resolve } from 'path'
 import { Readable } from 'stream'
 import { IProcessedSnapshotStorageComponent } from '../src/types'
-
-export function createFetchComponent() {
-  const fetch: IFetchComponent = {
-    async fetch(url: nodeFetch.RequestInfo, init?: nodeFetch.RequestInit): Promise<nodeFetch.Response> {
-      return nodeFetch.default(url, init)
-    }
-  }
-
-  return fetch
-}
 
 export async function createStorageComponent(): Promise<IContentStorageComponent> {
   const rootFixturesDir = 'test/fixtures'

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,6 +293,30 @@
     destroy "^1.2.0"
     file-type "^21.1.1"
 
+"@dcl/core-commons@0.10.1", "@dcl/core-commons@^0.10.0", "@dcl/core-commons@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@dcl/core-commons/-/core-commons-0.10.1.tgz#f6b38fd623a5043a571e80d7ba1ac40e9db41973"
+  integrity sha512-iLBpIg15czlzV7No5Wzb3FyreXpqYx8YnVJ8xYKczXpl6C3eqBQoqEA02hRkd/UASbzqcPJeG1wH1wHSxYTmQw==
+  dependencies:
+    "@well-known-components/interfaces" "^1.5.2"
+
+"@dcl/crypto-middleware@^4.0.0":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@dcl/crypto-middleware/-/crypto-middleware-4.1.1.tgz#a46861caa68bf38f0355ce72d77a8232200d54ed"
+  integrity sha512-wNo3D00SyZKoxy3THQj+EMWWatU9F2VTPwqTIVWZj3JlnaKRScNpLOsrHVPETN9FYtTIlJqqhjlUWsjoUGVisw==
+  dependencies:
+    "@dcl/core-commons" "^0.10.0"
+    "@dcl/crypto" "3.7.0"
+
+"@dcl/crypto@3.7.0", "@dcl/crypto@^3.4.5":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@dcl/crypto/-/crypto-3.7.0.tgz#2436370e591ea269da4806ee800e8eec21ff2168"
+  integrity sha512-8HSFLxnIHDeA8I/6yGAUwbCin2TX2oPn2uBLj5UmR0NFAyN5wYJCqbeolaJaIdmqN9RFjdb9ixKOY4uKF5Q2XA==
+  dependencies:
+    "@dcl/schemas" "^25.2.0"
+    eth-connect "^6.0.3"
+    ethereum-cryptography "^2.0.0"
+
 "@dcl/eslint-config@^1.1.1":
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/@dcl/eslint-config/-/eslint-config-1.1.13.tgz#cbce3473384f5bcfdf3c4db983d73f61b03c31a4"
@@ -310,32 +334,49 @@
     eslint-plugin-prettier "^4.2.1"
     prettier "^2.8.8"
 
+"@dcl/fetch-component@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@dcl/fetch-component/-/fetch-component-1.1.1.tgz#8f089f216150bab23d4cb798311796943243bc0b"
+  integrity sha512-Q1d/By58NRFIF7h5oMSSFNFGtcJmoKKY6V3kOo314soCgSH0IETydwaD8Hu2zPWK9TZQVx+eDJppViyKVpt91Q==
+  dependencies:
+    "@dcl/core-commons" "0.10.1"
+
 "@dcl/hashing@^3.0.3":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@dcl/hashing/-/hashing-3.0.4.tgz#4df2a4cb3a8114765aed34cb57b91c93bf33bfb3"
   integrity sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg==
 
-"@dcl/http-server@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@dcl/http-server/-/http-server-1.0.1.tgz#aa0d93b1a9d945c62cf46ba72cfa8d52f55c0332"
-  integrity sha512-dFKJtSr0ESS388PkzOnJLNd2KfsV3nacRZvOlaIH0GpVwemZfYe5SjZv3VTGygKxUA5C/knqiKrUtBiYFP2j3w==
+"@dcl/http-server@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@dcl/http-server/-/http-server-2.2.1.tgz#9b518de3afc54aa7cb9591906a7151375e6d7b5f"
+  integrity sha512-ibhFXABkKpK2X3W83Y1FYM3lShP1NrEzpxE4HtphPZol4oq/GOLNa64Kj7mOR1Rw7Vo5dTjJQFMPq061SvxrwA==
   dependencies:
-    "@types/http-errors" "^2.0.4"
+    "@dcl/core-commons" "0.10.1"
+    "@well-known-components/interfaces" "^1.5.1"
     destroy "^1.2.0"
     fp-future "^1.0.1"
     http-errors "^2.0.0"
     mitt "^3.0.0"
-    node-fetch "^2.6.9"
     on-finished "^2.4.1"
     path-to-regexp "^6.3.0"
     reflect-metadata "^0.2.2"
 
-"@dcl/metrics@^1.0.0":
+"@dcl/metrics@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@dcl/metrics/-/metrics-1.0.1.tgz#de5e762f3872fb16a15a4e56b3fe98b2fabb770b"
   integrity sha512-ZiDHlEVDhPy30UtvsLsUtefOsvDjD2TaR5KIkLTgPXtelqmhOWs26qD8Ldudky34nnqOjlLcokJYmyHltpsxbQ==
   dependencies:
     prom-client "^15.1.0"
+
+"@dcl/schemas@^25.2.0":
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/@dcl/schemas/-/schemas-25.3.0.tgz#5ba7b53e902e9bf8fded3f6dfba1485b08dfe3ae"
+  integrity sha512-ChFW3jU3ELN6YsRvs8TZIueBR8/DDxFcWPOeCoPafjLzSRK4GX9wHYrD3Crent07C3i3tm1rX8L/2rw+S39bzQ==
+  dependencies:
+    ajv "^8.11.0"
+    ajv-errors "^3.0.0"
+    ajv-keywords "^5.1.0"
+    mitt "^3.0.1"
 
 "@dcl/schemas@^9.1.1":
   version "9.15.0"
@@ -345,6 +386,16 @@
     ajv "^8.11.0"
     ajv-errors "^3.0.0"
     ajv-keywords "^5.1.0"
+
+"@dcl/test-helpers@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@dcl/test-helpers/-/test-helpers-0.2.0.tgz#82ac2e8d6aa8554a0813b60a7b3d7a595dde7402"
+  integrity sha512-BlnVYYS12JhtmMnNjCF3vnKRqDRms/jsgpb/knMvNoJpYxZo87wpMedLjBUxoNEjOem+2JLSdzdzStzmOFDi4Q==
+  dependencies:
+    "@dcl/core-commons" "0.10.1"
+    "@dcl/crypto" "^3.4.5"
+    "@dcl/crypto-middleware" "^4.0.0"
+    "@well-known-components/interfaces" "^1.5.2"
 
 "@emnapi/core@1.10.0":
   version "1.10.0"
@@ -676,6 +727,18 @@
   dependencies:
     "@tybys/wasm-util" "^0.10.2"
 
+"@noble/curves@1.4.2", "@noble/curves@~1.4.0":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.4.2.tgz#40309198c76ed71bc6dbf7ba24e81ceb4d0d1fe9"
+  integrity sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==
+  dependencies:
+    "@noble/hashes" "1.4.0"
+
+"@noble/hashes@1.4.0", "@noble/hashes@~1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -707,6 +770,28 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
   integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
 
+"@scure/base@~1.1.6":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
+  integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
+
+"@scure/bip32@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.4.0.tgz#4e1f1e196abedcef395b33b9674a042524e20d67"
+  integrity sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==
+  dependencies:
+    "@noble/curves" "~1.4.0"
+    "@noble/hashes" "~1.4.0"
+    "@scure/base" "~1.1.6"
+
+"@scure/bip39@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.3.0.tgz#0f258c16823ddd00739461ac31398b4e7d6a18c3"
+  integrity sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==
+  dependencies:
+    "@noble/hashes" "~1.4.0"
+    "@scure/base" "~1.1.6"
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.10"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.10.tgz#beefe675f1853f73676aecc915b2bd2ac98c4fc6"
@@ -719,13 +804,6 @@
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@11.2.2":
-  version "11.2.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz#50063cc3574f4a27bd8453180a04171c85cc9699"
-  integrity sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==
-  dependencies:
-    "@sinonjs/commons" "^3.0.0"
-
 "@sinonjs/fake-timers@^10.0.2", "@sinonjs/fake-timers@^10.3.0":
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz#55fdff1ecab9f354019129daf4df0dd4d923ea66"
@@ -737,13 +815,6 @@
   version "11.3.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz#51d6e8d83ca261ff02c0ab0e68e9db23d5cd5999"
   integrity sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==
-  dependencies:
-    "@sinonjs/commons" "^3.0.1"
-
-"@sinonjs/fake-timers@^15.1.1":
-  version "15.4.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz#5d40c151a9e66075fe4520bec40bccfe54931962"
-  integrity sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
 
@@ -840,11 +911,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/http-errors@^2.0.4":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.5.tgz#5b749ab2b16ba113423feb1a64a95dcd30398472"
-  integrity sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
@@ -864,7 +930,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^29.5.2":
+"@types/jest@^29.5.0":
   version "29.5.14"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.14.tgz#2b910912fa1d6856cadcd0c1f95af7df1d6049e5"
   integrity sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==
@@ -906,13 +972,6 @@
   dependencies:
     undici-types "~6.21.0"
 
-"@types/node@^22.5.4":
-  version "22.19.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.21.tgz#5c9d843ea385b31ee937a9f743443830620a32de"
-  integrity sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==
-  dependencies:
-    undici-types "~6.21.0"
-
 "@types/semver@^7.3.12":
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.1.tgz#3ce3af1a5524ef327d2da9e4fd8b6d95c8d70528"
@@ -922,13 +981,6 @@
   version "10.0.20"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.20.tgz#f1585debf4c0d99f9938f4111e5479fb74865146"
   integrity sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==
-  dependencies:
-    "@types/sinonjs__fake-timers" "*"
-
-"@types/sinon@^17.0.1":
-  version "17.0.4"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-17.0.4.tgz#fd9a3e8e07eea1a3f4a6f82a972c899e5778f369"
-  integrity sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==
   dependencies:
     "@types/sinonjs__fake-timers" "*"
 
@@ -1164,15 +1216,7 @@
   dependencies:
     dotenv "^16.0.1"
 
-"@well-known-components/fetch-component@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@well-known-components/fetch-component/-/fetch-component-3.0.0.tgz#93921f0d18b1fc21f1f5540cc4ae035a0dabf55d"
-  integrity sha512-ycIaojkwLJvhpicdPsmsEzA9qPbV7voAjrRcVE7+n7UNctIQC8ppymapj0UQ3FFpdEWWVSzjoo33H0BW+sD8eg==
-  dependencies:
-    "@well-known-components/interfaces" "^1.4.1"
-    cross-fetch "^3.1.5"
-
-"@well-known-components/interfaces@^1.1.1", "@well-known-components/interfaces@^1.4.0", "@well-known-components/interfaces@^1.4.1":
+"@well-known-components/interfaces@^1.1.1", "@well-known-components/interfaces@^1.5.1", "@well-known-components/interfaces@^1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@well-known-components/interfaces/-/interfaces-1.5.2.tgz#ef7001a19d410459e65b216dd948d15be19e4efa"
   integrity sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==
@@ -1185,19 +1229,6 @@
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@well-known-components/logger/-/logger-3.1.3.tgz#b1f4a76ac5e0d89c276cf339fe44a61f46023d2f"
   integrity sha512-tTjD27CdfU4SVe+kPfjRbPSqdrw0Crg+M31RNejinCuMEBtEGbhYLtB1M4gn+PSTy2Oi3cI3iOdeQ1xVhMSerQ==
-
-"@well-known-components/test-helpers@^1.2.1":
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/@well-known-components/test-helpers/-/test-helpers-1.5.8.tgz#c6826fab2c1244f91a0bef809d29fecbff787fdf"
-  integrity sha512-NewY/t2l4D6iGMGlo9P6vsvzGwM1c3CBRPgyhydInNYgXSTqYIasI2h7lWWFwp0LxZeIX4LzNFIv3ZLQyy1wdw==
-  dependencies:
-    "@types/jest" "^29.5.2"
-    "@types/node" "^22.5.4"
-    "@types/sinon" "^17.0.1"
-    jest "^29.5.0"
-    node-fetch "2.x"
-    sinon "^18.0.0"
-    ts-jest "^29.1.0"
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -1665,13 +1696,6 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@^3.1.5:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.2.0.tgz#34e9192f53bc757d6614304d9e5e6fb4edb782e3"
-  integrity sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==
-  dependencies:
-    node-fetch "^2.7.0"
-
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -1785,7 +1809,7 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.4.tgz#7a6dbfda325f25f07517e9b518f897c08332e07d"
   integrity sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==
 
-diff@^5.1.0, diff@^5.2.0:
+diff@^5.1.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.2.tgz#0a4742797281d09cfa699b79ea32d27723623bad"
   integrity sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==
@@ -2154,6 +2178,21 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+eth-connect@^6.0.3:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/eth-connect/-/eth-connect-6.4.0.tgz#c40d47a6618cf799434d6f0f40369186a7b42075"
+  integrity sha512-lbuFFE0qNvGutNH4CiP/fvlbIawK0DARNdmG7qoyOclFMSt1EzqvaLHxpLcx5Gjk/7TDMrguDTHjZQM/6Xt77Q==
+
+ethereum-cryptography@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz#58f2810f8e020aecb97de8c8c76147600b0b8ccf"
+  integrity sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==
+  dependencies:
+    "@noble/curves" "1.4.2"
+    "@noble/hashes" "1.4.0"
+    "@scure/bip32" "1.4.0"
+    "@scure/bip39" "1.3.0"
 
 eventemitter3@^4.0.4:
   version "4.0.7"
@@ -3300,7 +3339,7 @@ jest-worker@^29.7.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^29.5.0:
+jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-29.7.0.tgz#994676fc24177f088f1c5e3737f5697204ff2613"
   integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
@@ -3321,9 +3360,9 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -3542,7 +3581,7 @@ minipass@^4.2.4:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
-mitt@^3.0.0:
+mitt@^3.0.0, mitt@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
@@ -3583,16 +3622,6 @@ nise@^5.1.4:
     just-extend "^6.2.0"
     path-to-regexp "^6.2.1"
 
-nise@^6.0.0:
-  version "6.1.5"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-6.1.5.tgz#a2f4cd07d8d38ebc5ae5500168eea0f08a2fa4b9"
-  integrity sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==
-  dependencies:
-    "@sinonjs/commons" "^3.0.1"
-    "@sinonjs/fake-timers" "^15.1.1"
-    just-extend "^6.2.0"
-    path-to-regexp "^8.3.0"
-
 node-exports-info@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/node-exports-info/-/node-exports-info-1.6.0.tgz#1aedafb01a966059c9a5e791a94a94d93f5c2a13"
@@ -3602,13 +3631,6 @@ node-exports-info@^1.6.0:
     es-errors "^1.3.0"
     object.entries "^1.1.9"
     semver "^6.3.1"
-
-node-fetch@2.x, node-fetch@^2.6.7, node-fetch@^2.6.9, node-fetch@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
-  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
-  dependencies:
-    whatwg-url "^5.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3820,11 +3842,6 @@ path-to-regexp@^6.2.1, path-to-regexp@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
   integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
-
-path-to-regexp@^8.3.0:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz#795c420c4f7ca45c5b887366f622ee0c9852cccd"
-  integrity sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -4099,10 +4116,15 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.7, semver@^7.5.3, semver@^7.5.4, semver@^7.7.1, semver@^7.8.0:
+semver@^7.3.7, semver@^7.5.4, semver@^7.7.1:
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.4.tgz#c73eceebae0616934be8dff28a7fd70757c8e696"
   integrity sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==
+
+semver@^7.5.3, semver@^7.8.0:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -4208,18 +4230,6 @@ sinon@^16.1.3:
     diff "^5.1.0"
     nise "^5.1.4"
     supports-color "^7.2.0"
-
-sinon@^18.0.0:
-  version "18.0.1"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-18.0.1.tgz#464334cdfea2cddc5eda9a4ea7e2e3f0c7a91c5e"
-  integrity sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==
-  dependencies:
-    "@sinonjs/commons" "^3.0.1"
-    "@sinonjs/fake-timers" "11.2.2"
-    "@sinonjs/samsam" "^8.0.0"
-    diff "^5.2.0"
-    nise "^6.0.0"
-    supports-color "^7"
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -4358,7 +4368,7 @@ strtok3@^10.3.4:
   dependencies:
     "@tokenizer/token" "^0.3.0"
 
-supports-color@^7, supports-color@^7.1.0, supports-color@^7.2.0:
+supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -4431,11 +4441,6 @@ token-types@^6.1.1:
     "@borewit/text-codec" "^0.2.1"
     "@tokenizer/token" "^0.3.0"
     ieee754 "^1.2.1"
-
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 ts-jest@^29.1.0:
   version "29.4.11"
@@ -4700,19 +4705,6 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
-
 which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz#d76ec27df7fa165f18d5808374a5fe23c29b176e"
@@ -4834,9 +4826,9 @@ yargs-parser@^21.1.1:
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^17.3.1:
-  version "17.7.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
-  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"


### PR DESCRIPTION
## What

Continues the `@well-known-components` → `@dcl` migration by moving the HTTP
fetcher onto the new `@dcl/fetch-component` and hardening response-body handling.

### Production code
- **`@well-known-components/fetch-component` → `@dcl/fetch-component`**, with
  `IFetchComponent` / `RequestOptions` now sourced from `@dcl/core-commons`.
- **Body consumption.** The undici-backed fetcher has no `size` option and pins
  sockets when a body is left unconsumed. `fetchJson` now:
  - drains the body (`response.body.cancel()`) before throwing on non-2xx,
    returning the socket to the undici pool;
  - reads through a bounded reader that enforces the previous **50 MiB** cap
    manually and cancels the stream if it is exceeded.
- Bumped `@dcl/metrics` and `@well-known-components/interfaces`; node engine → `>=22`.

### Tests
- Harness moved from `@well-known-components/test-helpers` → `@dcl/test-helpers`
  (`createRunner` / `defaultServerConfig`); `@dcl/http-server` bumped to v2.
- Dropped `node-fetch` — tests use the native `@dcl/fetch-component` and global `Headers`.
- Added `jest` / `ts-jest` / `@types/jest` explicitly (the old WKC test-helpers
  bundled them transitively; the new one declares them as peers).
- The one sinon-style suite (`getDeployedEntitiesStreamFromSnapshot`) is converted
  to jest: `spyComponents` (call-through) + `toHaveBeenCalledTimes`, since the new
  stub/spy components return jest mocks rather than sinon stubs.

## Testing
- `yarn build` — clean
- `yarn lint:check` — clean
- `yarn test` — **18 suites / 102 tests pass**, coverage unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
