### PR TITLE
fix: evict a corrupt entity file so it can be re-downloaded

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { hashV0, hashV1 } from '@dcl/hashing'
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import PQueue from 'p-queue'
 import { downloadFileWithRetries } from './downloader'
@@ -17,6 +18,25 @@ export { getDeployedEntitiesStreamFromSnapshot, getDeployedEntitiesStreamFromPoi
 // Default cap on content files downloaded in parallel per entity, so a huge content[] can't exhaust
 // sockets / file descriptors. Overridable via downloadEntityAndContentFiles's last argument.
 const DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY = 10
+
+/**
+ * True only when the bytes can be hashed with the id's scheme AND the result differs — i.e. the
+ * local copy is proven not to be the content the id addresses (a truncated/partial write). An
+ * unknown scheme or a hashing failure proves nothing, so it never reports corruption.
+ */
+async function isLocalCopyCorrupt(buffer: Uint8Array, entityId: string): Promise<boolean> {
+  try {
+    if (entityId.startsWith('Qm')) {
+      return (await hashV0(buffer)) !== entityId
+    }
+    if (entityId.startsWith('ba')) {
+      return (await hashV1(buffer)) !== entityId
+    }
+  } catch {
+    // fall through: unprovable
+  }
+  return false
+}
 
 if (parseInt(process.versions.node.split('.')[0], 10) < 22) {
   const { name } = require('../package.json')
@@ -118,13 +138,27 @@ export async function downloadEntityAndContentFiles(
     }
     entityMetadata = JSON.parse(contentStream)
   } catch (error: any) {
-    // The bytes were read successfully but are empty or not valid JSON — typically a truncated/partial
-    // local copy left by an interrupted write, which `storage.exist` reports as present so `downloadJob`
-    // skips re-downloading it. Left in place it is a permanent poison pill: every retry re-reads the
-    // same bytes and re-fails with a context-free "Unexpected end of JSON input". Evict it so the next
-    // attempt re-downloads (and hash-verifies) a clean copy, and surface an entity-scoped error. The
-    // eviction is best-effort: if it fails, the descriptive error must still win, and the next retry
-    // will attempt the eviction again.
+    const cause = error?.message ?? String(error)
+
+    // A parse failure alone does not prove the LOCAL copy is corrupt: storage is content-addressed
+    // and shared between entity and content files, so a malformed (or malicious) remote feed can
+    // advertise an entityId that is really the hash of an already-cached, perfectly valid non-JSON
+    // content file — evicting on parse failure would let such a feed delete arbitrary cached
+    // content. Only evict when the bytes fail hash verification against the entityId, which pins
+    // the failure to a truncated/partial local write; hash-valid bytes would be re-downloaded
+    // byte-identical anyway, so eviction could never help.
+    if (!(await isLocalCopyCorrupt(buffer, entityId))) {
+      throw new Error(
+        `Failed to parse the downloaded entity file for ${entityId}; the stored bytes match the content hash, so the local copy was kept. Cause: ${cause}`
+      )
+    }
+
+    // The local copy is proven corrupt — typically a truncated/partial file left by an interrupted
+    // write, which `storage.exist` reports as present so `downloadJob` skips re-downloading it. Left
+    // in place it is a permanent poison pill: every retry re-reads the same bytes and re-fails with
+    // a context-free "Unexpected end of JSON input". Evict it so the next attempt re-downloads (and
+    // hash-verifies) a clean copy, and surface an entity-scoped error. The eviction is best-effort:
+    // if it fails, the descriptive error must still win, and the next retry will attempt it again.
     let evicted = false
     try {
       await components.storage.delete([entityId])
@@ -135,7 +169,6 @@ export async function downloadEntityAndContentFiles(
     if (evicted) {
       components.metrics.increment('dcl_corrupt_entity_files_evicted_total')
     }
-    const cause = error?.message ?? String(error)
     const outcome = evicted
       ? 'removed the corrupt local copy so it can be re-downloaded'
       : 'could not remove the corrupt local copy; a later retry will attempt it again'

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,12 @@ async function downloadProfileAvatars(
  * Downloads an entity and its dependency files to a folder in the disk.
  *
  * Returns the parsed JSON file of the deployed entityHash
+ *
+ * @remarks When the locally stored entity file fails content-hash verification (a truncated or
+ * partial local write), the corrupt copy is evicted from storage and the call throws — recovery
+ * relies on the caller retrying, which re-downloads and hash-verifies a clean copy. One-shot
+ * callers that never retry should be aware the first such call only heals the cache, it does not
+ * return the entity.
  * @param contentFilesConcurrency - Maximum number of content files to download in parallel for this
  *   entity. Defaults to {@link DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY} (10).
  * @public

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,12 +125,21 @@ export async function downloadEntityAndContentFiles(
     // attempt re-downloads (and hash-verifies) a clean copy, and surface an entity-scoped error. The
     // eviction is best-effort: if it fails, the descriptive error must still win, and the next retry
     // will attempt the eviction again.
-    await components.storage.delete([entityId]).catch(() => {})
-    components.metrics.increment('dcl_corrupt_entity_files_evicted_total')
+    let evicted = false
+    try {
+      await components.storage.delete([entityId])
+      evicted = true
+    } catch {
+      // keep evicted = false; the error thrown below reflects that the copy could not be removed
+    }
+    if (evicted) {
+      components.metrics.increment('dcl_corrupt_entity_files_evicted_total')
+    }
     const cause = error?.message ?? String(error)
-    throw new Error(
-      `Failed to parse the downloaded entity file for ${entityId}; removed the corrupt local copy so it can be re-downloaded. Cause: ${cause}`
-    )
+    const outcome = evicted
+      ? 'removed the corrupt local copy so it can be re-downloaded'
+      : 'could not remove the corrupt local copy; a later retry will attempt it again'
+    throw new Error(`Failed to parse the downloaded entity file for ${entityId}; ${outcome}. Cause: ${cause}`)
   }
 
   if (entityMetadata.type === 'profile' && entityMetadata.metadata) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,9 +120,13 @@ export async function downloadEntityAndContentFiles(
     // skips re-downloading it. Left in place it is a permanent poison pill: every retry re-reads the
     // same bytes and re-fails with a context-free "Unexpected end of JSON input". Evict it so the
     // next attempt re-downloads (and hash-verifies) a clean copy, and surface an entity-scoped error.
-    await components.storage.delete([entityId])
+    // The eviction is best-effort: if it fails, the descriptive error must still win, and the next
+    // retry will attempt the eviction again.
+    await components.storage.delete([entityId]).catch(() => {})
+    components.metrics.increment('dcl_corrupt_entity_files_evicted_total')
+    const cause = error?.message ?? String(error)
     throw new Error(
-      `Failed to parse the downloaded entity file for ${entityId}; removed the corrupt local copy so it can be re-downloaded. Cause: ${error.message}`
+      `Failed to parse the downloaded entity file for ${entityId}; removed the corrupt local copy so it can be re-downloaded. Cause: ${cause}`
     )
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,22 +20,25 @@ export { getDeployedEntitiesStreamFromSnapshot, getDeployedEntitiesStreamFromPoi
 const DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY = 10
 
 /**
- * True only when the bytes can be hashed with the id's scheme AND the result differs — i.e. the
- * local copy is proven not to be the content the id addresses (a truncated/partial write). An
- * unknown scheme or a hashing failure proves nothing, so it never reports corruption.
+ * Verifies stored bytes against the content-addressed id that claims them. 'mismatch' proves the
+ * local copy is not the content the id addresses (a truncated/partial or mis-keyed write); 'match'
+ * proves it is byte-identical to what a re-download would return. An unknown scheme or a hashing
+ * failure proves nothing either way.
  */
-async function isLocalCopyCorrupt(buffer: Uint8Array, entityId: string): Promise<boolean> {
+type HashVerification = 'match' | 'mismatch' | 'unverifiable'
+
+async function verifyBufferHash(buffer: Uint8Array, entityId: string): Promise<HashVerification> {
   try {
     if (entityId.startsWith('Qm')) {
-      return (await hashV0(buffer)) !== entityId
+      return (await hashV0(buffer)) === entityId ? 'match' : 'mismatch'
     }
     if (entityId.startsWith('ba')) {
-      return (await hashV1(buffer)) !== entityId
+      return (await hashV1(buffer)) === entityId ? 'match' : 'mismatch'
     }
   } catch {
     // fall through: unprovable
   }
-  return false
+  return 'unverifiable'
 }
 
 if (parseInt(process.versions.node.split('.')[0], 10) < 22) {
@@ -121,44 +124,23 @@ export async function downloadEntityAndContentFiles(
     throw new Error(`Entity file ${entityId} could not be retrieved from storage after download`)
   }
 
-  // Read the bytes outside the eviction path below. A failure here is a transient storage/read error,
-  // not proof the stored bytes are corrupt, so it must not trigger the destructive delete.
+  // Read the bytes outside any destructive path. A failure here is a transient storage/read error,
+  // not proof the stored bytes are corrupt, so it must not trigger an eviction.
   const stream = await content.asStream()
   const buffer = await streamToBuffer(stream)
   const contentStream = buffer.toString()
 
-  let entityMetadata: {
-    type: string
-    metadata?: any
-    content?: Array<ContentMapping>
-  }
-  try {
-    if (contentStream === '') {
-      throw new Error('the stored entity file was empty')
-    }
-    entityMetadata = JSON.parse(contentStream)
-  } catch (error: any) {
-    const cause = error?.message ?? String(error)
-
-    // A parse failure alone does not prove the LOCAL copy is corrupt: storage is content-addressed
-    // and shared between entity and content files, so a malformed (or malicious) remote feed can
-    // advertise an entityId that is really the hash of an already-cached, perfectly valid non-JSON
-    // content file — evicting on parse failure would let such a feed delete arbitrary cached
-    // content. Only evict when the bytes fail hash verification against the entityId, which pins
-    // the failure to a truncated/partial local write; hash-valid bytes would be re-downloaded
-    // byte-identical anyway, so eviction could never help.
-    if (!(await isLocalCopyCorrupt(buffer, entityId))) {
-      throw new Error(
-        `Failed to parse the downloaded entity file for ${entityId}; the stored bytes match the content hash, so the local copy was kept. Cause: ${cause}`
-      )
-    }
-
-    // The local copy is proven corrupt — typically a truncated/partial file left by an interrupted
-    // write, which `storage.exist` reports as present so `downloadJob` skips re-downloading it. Left
-    // in place it is a permanent poison pill: every retry re-reads the same bytes and re-fails with
-    // a context-free "Unexpected end of JSON input". Evict it so the next attempt re-downloads (and
-    // hash-verifies) a clean copy, and surface an entity-scoped error. The eviction is best-effort:
-    // if it fails, the descriptive error must still win, and the next retry will attempt it again.
+  // Enforce the content-addressed invariant BEFORE trusting the bytes at all. `downloadJob` skips
+  // the download when `storage.exist(entityId)` is true, so a truncated/partial or mis-keyed local
+  // file is served here unverified — and if it happens to parse as JSON it would otherwise be
+  // processed as the wrong entity. A proven mismatch is the only ground for the destructive
+  // eviction: hash-valid bytes would be re-downloaded byte-identical, so removing them never helps,
+  // and a malformed (or malicious) remote feed advertising the hash of an already-cached non-JSON
+  // content file must not be able to delete that legitimate content. Left in place, a corrupt copy
+  // is a permanent poison pill: every retry re-reads the same bytes and re-fails. The eviction is
+  // best-effort: if it fails, the descriptive error still wins and the next retry re-attempts it.
+  const verification = await verifyBufferHash(buffer, entityId)
+  if (verification === 'mismatch') {
     let evicted = false
     try {
       await components.storage.delete([entityId])
@@ -172,7 +154,28 @@ export async function downloadEntityAndContentFiles(
     const outcome = evicted
       ? 'removed the corrupt local copy so it can be re-downloaded'
       : 'could not remove the corrupt local copy; a later retry will attempt it again'
-    throw new Error(`Failed to parse the downloaded entity file for ${entityId}; ${outcome}. Cause: ${cause}`)
+    throw new Error(`The stored entity file for ${entityId} failed content-hash verification; ${outcome}.`)
+  }
+
+  let entityMetadata: {
+    type: string
+    metadata?: any
+    content?: Array<ContentMapping>
+  }
+  try {
+    if (contentStream === '') {
+      throw new Error('the stored entity file was empty')
+    }
+    entityMetadata = JSON.parse(contentStream)
+  } catch (error: any) {
+    // The bytes are hash-valid (or unverifiable) yet not entity JSON, so this is not local
+    // corruption — surface an entity-scoped error without touching the stored file.
+    const cause = error?.message ?? String(error)
+    const kept =
+      verification === 'match'
+        ? 'the stored bytes match the content hash, so the local copy was kept'
+        : 'the stored bytes could not be proven corrupt (unverifiable hash scheme), so the local copy was kept'
+    throw new Error(`Failed to parse the downloaded entity file for ${entityId}; ${kept}. Cause: ${cause}`)
   }
 
   if (entityMetadata.type === 'profile' && entityMetadata.metadata) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,17 +22,24 @@ const DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY = 10
 /**
  * Verifies stored bytes against the content-addressed id that claims them. 'mismatch' proves the
  * local copy is not the content the id addresses (a truncated/partial or mis-keyed write); 'match'
- * proves it is byte-identical to what a re-download would return. An unknown scheme or a hashing
- * failure proves nothing either way.
+ * proves it is byte-identical to what a re-download would return. An unknown scheme, a
+ * syntactically invalid CID or a hashing failure proves nothing either way — a computed hash can
+ * never equal a malformed id, so treating such ids as verifiable would turn every one of them into
+ * grounds for destructive eviction.
  */
 type HashVerification = 'match' | 'mismatch' | 'unverifiable'
 
+// hashV0 emits Qm + 44 base58btc chars; hashV1 emits ba + 57 lowercase base32 chars (sha256 CIDv1,
+// the only shapes content entities use). Ids outside these shapes are unverifiable, not mismatched.
+const HASH_V0_CID = /^Qm[1-9A-HJ-NP-Za-km-z]{44}$/
+const HASH_V1_CID = /^ba[a-z2-7]{57}$/
+
 async function verifyBufferHash(buffer: Uint8Array, entityId: string): Promise<HashVerification> {
   try {
-    if (entityId.startsWith('Qm')) {
+    if (HASH_V0_CID.test(entityId)) {
       return (await hashV0(buffer)) === entityId ? 'match' : 'mismatch'
     }
-    if (entityId.startsWith('ba')) {
+    if (HASH_V1_CID.test(entityId)) {
       return (await hashV1(buffer)) === entityId ? 'match' : 'mismatch'
     }
   } catch {
@@ -128,7 +135,6 @@ export async function downloadEntityAndContentFiles(
   // not proof the stored bytes are corrupt, so it must not trigger an eviction.
   const stream = await content.asStream()
   const buffer = await streamToBuffer(stream)
-  const contentStream = buffer.toString()
 
   // Enforce the content-addressed invariant BEFORE trusting the bytes at all. `downloadJob` skips
   // the download when `storage.exist(entityId)` is true, so a truncated/partial or mis-keyed local
@@ -156,6 +162,9 @@ export async function downloadEntityAndContentFiles(
       : 'could not remove the corrupt local copy; a later retry will attempt it again'
     throw new Error(`The stored entity file for ${entityId} failed content-hash verification; ${outcome}.`)
   }
+
+  // Decode only bytes that survived (or could not be subjected to) hash verification.
+  const contentStream = buffer.toString()
 
   let entityMetadata: {
     type: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,27 +101,30 @@ export async function downloadEntityAndContentFiles(
     throw new Error(`Entity file ${entityId} could not be retrieved from storage after download`)
   }
 
+  // Read the bytes outside the eviction path below. A failure here is a transient storage/read error,
+  // not proof the stored bytes are corrupt, so it must not trigger the destructive delete.
+  const stream = await content.asStream()
+  const buffer = await streamToBuffer(stream)
+  const contentStream = buffer.toString()
+
   let entityMetadata: {
     type: string
     metadata?: any
     content?: Array<ContentMapping>
   }
   try {
-    const stream = await content.asStream()
-    const buffer = await streamToBuffer(stream)
-    const contentStream = buffer.toString()
     if (contentStream === '') {
       throw new Error('the stored entity file was empty')
     }
     entityMetadata = JSON.parse(contentStream)
   } catch (error: any) {
-    // The stored entity file is empty or not valid JSON — almost always a truncated/partial local
-    // copy left by an interrupted write, which `storage.exist` reports as present so `downloadJob`
+    // The bytes were read successfully but are empty or not valid JSON — typically a truncated/partial
+    // local copy left by an interrupted write, which `storage.exist` reports as present so `downloadJob`
     // skips re-downloading it. Left in place it is a permanent poison pill: every retry re-reads the
-    // same bytes and re-fails with a context-free "Unexpected end of JSON input". Evict it so the
-    // next attempt re-downloads (and hash-verifies) a clean copy, and surface an entity-scoped error.
-    // The eviction is best-effort: if it fails, the descriptive error must still win, and the next
-    // retry will attempt the eviction again.
+    // same bytes and re-fails with a context-free "Unexpected end of JSON input". Evict it so the next
+    // attempt re-downloads (and hash-verifies) a clean copy, and surface an entity-scoped error. The
+    // eviction is best-effort: if it fails, the descriptive error must still win, and the next retry
+    // will attempt the eviction again.
     await components.storage.delete([entityId]).catch(() => {})
     components.metrics.increment('dcl_corrupt_entity_files_evicted_total')
     const cause = error?.message ?? String(error)

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,10 +167,10 @@ export async function downloadEntityAndContentFiles(
       throw new Error('the stored entity file was empty')
     }
     entityMetadata = JSON.parse(contentStream)
-  } catch (error: any) {
+  } catch (error: unknown) {
     // The bytes are hash-valid (or unverifiable) yet not entity JSON, so this is not local
     // corruption — surface an entity-scoped error without touching the stored file.
-    const cause = error?.message ?? String(error)
+    const cause = error instanceof Error ? error.message : String(error)
     const kept =
       verification === 'match'
         ? 'the stored bytes match the content hash, so the local copy was kept'

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,15 +101,30 @@ export async function downloadEntityAndContentFiles(
     throw new Error(`Entity file ${entityId} could not be retrieved from storage after download`)
   }
 
-  const stream = await content.asStream()
-  const buffer = await streamToBuffer(stream)
-  const contentStream = buffer.toString()
-
-  const entityMetadata: {
-    type: string,
-    metadata?: any,
+  let entityMetadata: {
+    type: string
+    metadata?: any
     content?: Array<ContentMapping>
-  } = JSON.parse(contentStream)
+  }
+  try {
+    const stream = await content.asStream()
+    const buffer = await streamToBuffer(stream)
+    const contentStream = buffer.toString()
+    if (contentStream === '') {
+      throw new Error('the stored entity file was empty')
+    }
+    entityMetadata = JSON.parse(contentStream)
+  } catch (error: any) {
+    // The stored entity file is empty or not valid JSON — almost always a truncated/partial local
+    // copy left by an interrupted write, which `storage.exist` reports as present so `downloadJob`
+    // skips re-downloading it. Left in place it is a permanent poison pill: every retry re-reads the
+    // same bytes and re-fails with a context-free "Unexpected end of JSON input". Evict it so the
+    // next attempt re-downloads (and hash-verifies) a clean copy, and surface an entity-scoped error.
+    await components.storage.delete([entityId])
+    throw new Error(
+      `Failed to parse the downloaded entity file for ${entityId}; removed the corrupt local copy so it can be re-downloaded. Cause: ${error.message}`
+    )
+  }
 
   if (entityMetadata.type === 'profile' && entityMetadata.metadata) {
     /*

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -30,7 +30,7 @@ export const metricsDefinitions = validateMetricsDeclaration({
   },
 
   dcl_corrupt_entity_files_evicted_total: {
-    help: 'Total entity files evicted from storage because they were empty or could not be parsed',
+    help: 'Total stored entity files evicted after failing content-hash verification (truncated or partial local writes)',
     type: 'counter',
     labelNames: []
   },

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -29,6 +29,12 @@ export const metricsDefinitions = validateMetricsDeclaration({
     labelNames: ['remote_server']
   },
 
+  dcl_corrupt_entity_files_evicted_total: {
+    help: 'Total entity files evicted from storage because they were empty or could not be parsed',
+    type: 'counter',
+    labelNames: []
+  },
+
   dcl_entities_deployments_processed_total: {
     help: 'Entities processed from remote catalysts',
     type: 'counter',

--- a/test/downloadEntityCorruptFile.spec.ts
+++ b/test/downloadEntityCorruptFile.spec.ts
@@ -77,6 +77,46 @@ test('downloadEntityAndContentFiles with a corrupt stored entity file', ({ compo
     })
   })
 
+  describe('when the stored entity file is empty and evicting it fails', () => {
+    let storage: IContentStorageComponent
+    let entityId: string
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      entityId = 'evictionfailureentitytest'
+      const inner = createInMemoryStorage()
+      await inner.storeStream(entityId, Readable.from([Buffer.from('')]))
+      storage = {
+        ...inner,
+        async delete() {
+          throw new Error('delete is unavailable')
+        }
+      }
+      thrownError = undefined
+      try {
+        await downloadEntityAndContentFiles(
+          { fetcher: components.fetcher, logs: components.logs, metrics: components.metrics, storage },
+          entityId,
+          [await components.getBaseUrl()],
+          new Map(),
+          contentFolder,
+          10,
+          0
+        )
+      } catch (error: any) {
+        thrownError = error
+      }
+    })
+
+    it('should still surface the entity-scoped parse error, not the delete error', () => {
+      expect(thrownError?.message).toContain(entityId)
+    })
+
+    it('should report that the corrupt copy could not be removed', () => {
+      expect(thrownError?.message).toContain('could not remove the corrupt local copy')
+    })
+  })
+
   describe('when reading the stored entity file fails transiently', () => {
     let storage: IContentStorageComponent
     let entityId: string

--- a/test/downloadEntityCorruptFile.spec.ts
+++ b/test/downloadEntityCorruptFile.spec.ts
@@ -130,6 +130,38 @@ test('downloadEntityAndContentFiles with a corrupt stored entity file', ({ compo
     })
   })
 
+  describe('when the entity id has a known prefix but is not a syntactically valid cid', () => {
+    let storage: IContentStorageComponent
+    let entityId: string
+    let deleteCalls: string[][]
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      // Starts with 'Qm' but is not a valid CID: a computed hash can never equal it, so treating it
+      // as verifiable would make EVERY such id grounds for destructive eviction.
+      entityId = 'Qmnotavalidcid'
+      const inner = createInMemoryStorage()
+      await inner.storeStream(entityId, Readable.from([Buffer.from('arbitrary cached bytes')]))
+      deleteCalls = []
+      storage = {
+        ...inner,
+        async delete(ids: string[]) {
+          deleteCalls.push(ids)
+          return inner.delete(ids)
+        }
+      }
+      thrownError = await downloadWith(storage, entityId)
+    })
+
+    it('should explain the copy was kept because corruption is unprovable', () => {
+      expect(thrownError?.message).toContain('could not be proven corrupt (unverifiable hash scheme)')
+    })
+
+    it('should not delete the stored file', () => {
+      expect(deleteCalls).toEqual([])
+    })
+  })
+
   describe('when the entity id uses an unverifiable hash scheme and the bytes are not JSON', () => {
     let storage: IContentStorageComponent
     let entityId: string

--- a/test/downloadEntityCorruptFile.spec.ts
+++ b/test/downloadEntityCorruptFile.spec.ts
@@ -1,0 +1,79 @@
+import { createInMemoryStorage, IContentStorageComponent } from '@dcl/catalyst-storage'
+import { resolve } from 'path'
+import { Readable } from 'stream'
+import { downloadEntityAndContentFiles } from '../src'
+import { test } from './components'
+
+test('downloadEntityAndContentFiles with a corrupt stored entity file', ({ components }) => {
+  const contentFolder = resolve('downloads')
+
+  describe('when the stored entity file is empty', () => {
+    let storage: IContentStorageComponent
+    let entityId: string
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      storage = createInMemoryStorage()
+      entityId = 'emptyentityfilepoisonpilltest'
+      // Seed an empty file so exist() is true and the download step is skipped, reproducing the
+      // truncated local copy an interrupted write leaves behind.
+      await storage.storeStream(entityId, Readable.from([Buffer.from('')]))
+      thrownError = undefined
+      try {
+        await downloadEntityAndContentFiles(
+          { fetcher: components.fetcher, logs: components.logs, metrics: components.metrics, storage },
+          entityId,
+          [await components.getBaseUrl()],
+          new Map(),
+          contentFolder,
+          10,
+          0
+        )
+      } catch (error: any) {
+        thrownError = error
+      }
+    })
+
+    it('should reject with an error naming the entity instead of a context-free parse error', () => {
+      expect(thrownError?.message).toContain(entityId)
+    })
+
+    it('should evict the corrupt file so a later retry re-downloads it', async () => {
+      expect(await storage.exist(entityId)).toBe(false)
+    })
+  })
+
+  describe('when the stored entity file is not valid JSON', () => {
+    let storage: IContentStorageComponent
+    let entityId: string
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      storage = createInMemoryStorage()
+      entityId = 'invalidjsonentityfilepoisonpilltest'
+      await storage.storeStream(entityId, Readable.from([Buffer.from('{ "type": "profile"')]))
+      thrownError = undefined
+      try {
+        await downloadEntityAndContentFiles(
+          { fetcher: components.fetcher, logs: components.logs, metrics: components.metrics, storage },
+          entityId,
+          [await components.getBaseUrl()],
+          new Map(),
+          contentFolder,
+          10,
+          0
+        )
+      } catch (error: any) {
+        thrownError = error
+      }
+    })
+
+    it('should reject with an error naming the entity instead of a context-free parse error', () => {
+      expect(thrownError?.message).toContain(entityId)
+    })
+
+    it('should evict the corrupt file so a later retry re-downloads it', async () => {
+      expect(await storage.exist(entityId)).toBe(false)
+    })
+  })
+})

--- a/test/downloadEntityCorruptFile.spec.ts
+++ b/test/downloadEntityCorruptFile.spec.ts
@@ -76,4 +76,56 @@ test('downloadEntityAndContentFiles with a corrupt stored entity file', ({ compo
       expect(await storage.exist(entityId)).toBe(false)
     })
   })
+
+  describe('when reading the stored entity file fails transiently', () => {
+    let storage: IContentStorageComponent
+    let entityId: string
+    let deleteCalls: string[][]
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      entityId = 'transientreaderrorentitytest'
+      const inner = createInMemoryStorage()
+      // Seed a valid entity so exist() is true (the download is skipped) and there is something to
+      // delete; the read itself is then made to fail transiently.
+      await inner.storeStream(entityId, Readable.from([Buffer.from('{"type":"scene"}')]))
+      deleteCalls = []
+      storage = {
+        ...inner,
+        async retrieve() {
+          return {
+            async asStream() {
+              throw new Error('transient read failure')
+            }
+          } as any
+        },
+        async delete(ids: string[]) {
+          deleteCalls.push(ids)
+          return inner.delete(ids)
+        }
+      }
+      thrownError = undefined
+      try {
+        await downloadEntityAndContentFiles(
+          { fetcher: components.fetcher, logs: components.logs, metrics: components.metrics, storage },
+          entityId,
+          [await components.getBaseUrl()],
+          new Map(),
+          contentFolder,
+          10,
+          0
+        )
+      } catch (error: any) {
+        thrownError = error
+      }
+    })
+
+    it('should propagate the read error rather than a parse error', () => {
+      expect(thrownError?.message).toContain('transient read failure')
+    })
+
+    it('should not evict the stored file', () => {
+      expect(deleteCalls).toEqual([])
+    })
+  })
 })

--- a/test/downloadEntityCorruptFile.spec.ts
+++ b/test/downloadEntityCorruptFile.spec.ts
@@ -1,4 +1,5 @@
 import { createInMemoryStorage, IContentStorageComponent } from '@dcl/catalyst-storage'
+import { hashV0, hashV1 } from '@dcl/hashing'
 import { resolve } from 'path'
 import { Readable } from 'stream'
 import { downloadEntityAndContentFiles } from '../src'
@@ -7,31 +8,35 @@ import { test } from './components'
 test('downloadEntityAndContentFiles with a corrupt stored entity file', ({ components }) => {
   const contentFolder = resolve('downloads')
 
-  describe('when the stored entity file is empty', () => {
+  async function downloadWith(storage: IContentStorageComponent, entityId: string): Promise<Error | undefined> {
+    try {
+      await downloadEntityAndContentFiles(
+        { fetcher: components.fetcher, logs: components.logs, metrics: components.metrics, storage },
+        entityId,
+        [await components.getBaseUrl()],
+        new Map(),
+        contentFolder,
+        10,
+        0
+      )
+      return undefined
+    } catch (error: any) {
+      return error
+    }
+  }
+
+  describe('when the stored entity file is empty and fails hash verification', () => {
     let storage: IContentStorageComponent
     let entityId: string
     let thrownError: Error | undefined
 
     beforeEach(async () => {
       storage = createInMemoryStorage()
-      entityId = 'emptyentityfilepoisonpilltest'
-      // Seed an empty file so exist() is true and the download step is skipped, reproducing the
-      // truncated local copy an interrupted write leaves behind.
+      // The id addresses the original (non-empty) entity, so the empty local copy is a proven
+      // truncated write: hash('') can never equal it.
+      entityId = await hashV1(Buffer.from('{"type":"profile","content":[]}'))
       await storage.storeStream(entityId, Readable.from([Buffer.from('')]))
-      thrownError = undefined
-      try {
-        await downloadEntityAndContentFiles(
-          { fetcher: components.fetcher, logs: components.logs, metrics: components.metrics, storage },
-          entityId,
-          [await components.getBaseUrl()],
-          new Map(),
-          contentFolder,
-          10,
-          0
-        )
-      } catch (error: any) {
-        thrownError = error
-      }
+      thrownError = await downloadWith(storage, entityId)
     })
 
     it('should reject with an error naming the entity instead of a context-free parse error', () => {
@@ -43,29 +48,17 @@ test('downloadEntityAndContentFiles with a corrupt stored entity file', ({ compo
     })
   })
 
-  describe('when the stored entity file is not valid JSON', () => {
+  describe('when the stored entity file is truncated JSON and fails hash verification', () => {
     let storage: IContentStorageComponent
     let entityId: string
     let thrownError: Error | undefined
 
     beforeEach(async () => {
       storage = createInMemoryStorage()
-      entityId = 'invalidjsonentityfilepoisonpilltest'
+      // A Qm-addressed entity whose local copy lost its tail mid-write.
+      entityId = await hashV0(Buffer.from('{"type":"profile","content":[]}'))
       await storage.storeStream(entityId, Readable.from([Buffer.from('{ "type": "profile"')]))
-      thrownError = undefined
-      try {
-        await downloadEntityAndContentFiles(
-          { fetcher: components.fetcher, logs: components.logs, metrics: components.metrics, storage },
-          entityId,
-          [await components.getBaseUrl()],
-          new Map(),
-          contentFolder,
-          10,
-          0
-        )
-      } catch (error: any) {
-        thrownError = error
-      }
+      thrownError = await downloadWith(storage, entityId)
     })
 
     it('should reject with an error naming the entity instead of a context-free parse error', () => {
@@ -77,13 +70,50 @@ test('downloadEntityAndContentFiles with a corrupt stored entity file', ({ compo
     })
   })
 
-  describe('when the stored entity file is empty and evicting it fails', () => {
+  describe('when the stored bytes are not JSON but match the content hash', () => {
+    let storage: IContentStorageComponent
+    let entityId: string
+    let deleteCalls: string[][]
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      // A valid, hash-correct non-JSON file (e.g. an image) that a malformed or malicious remote
+      // feed advertises as an entityId. Evicting it would delete legitimate cached content.
+      const bytes = Buffer.from('not json at all — could be a cached png')
+      entityId = await hashV1(bytes)
+      const inner = createInMemoryStorage()
+      await inner.storeStream(entityId, Readable.from([bytes]))
+      deleteCalls = []
+      storage = {
+        ...inner,
+        async delete(ids: string[]) {
+          deleteCalls.push(ids)
+          return inner.delete(ids)
+        }
+      }
+      thrownError = await downloadWith(storage, entityId)
+    })
+
+    it('should surface an entity-scoped parse error explaining the copy was kept', () => {
+      expect(thrownError?.message).toContain('the stored bytes match the content hash, so the local copy was kept')
+    })
+
+    it('should not delete the hash-valid cached content', () => {
+      expect(deleteCalls).toEqual([])
+    })
+
+    it('should keep the file in storage', async () => {
+      expect(await storage.exist(entityId)).toBe(true)
+    })
+  })
+
+  describe('when the stored entity file is corrupt and evicting it fails', () => {
     let storage: IContentStorageComponent
     let entityId: string
     let thrownError: Error | undefined
 
     beforeEach(async () => {
-      entityId = 'evictionfailureentitytest'
+      entityId = await hashV1(Buffer.from('{"type":"scene","content":[]}'))
       const inner = createInMemoryStorage()
       await inner.storeStream(entityId, Readable.from([Buffer.from('')]))
       storage = {
@@ -92,20 +122,7 @@ test('downloadEntityAndContentFiles with a corrupt stored entity file', ({ compo
           throw new Error('delete is unavailable')
         }
       }
-      thrownError = undefined
-      try {
-        await downloadEntityAndContentFiles(
-          { fetcher: components.fetcher, logs: components.logs, metrics: components.metrics, storage },
-          entityId,
-          [await components.getBaseUrl()],
-          new Map(),
-          contentFolder,
-          10,
-          0
-        )
-      } catch (error: any) {
-        thrownError = error
-      }
+      thrownError = await downloadWith(storage, entityId)
     })
 
     it('should still surface the entity-scoped parse error, not the delete error', () => {
@@ -124,7 +141,7 @@ test('downloadEntityAndContentFiles with a corrupt stored entity file', ({ compo
     let thrownError: Error | undefined
 
     beforeEach(async () => {
-      entityId = 'transientreaderrorentitytest'
+      entityId = await hashV1(Buffer.from('{"type":"scene"}'))
       const inner = createInMemoryStorage()
       // Seed a valid entity so exist() is true (the download is skipped) and there is something to
       // delete; the read itself is then made to fail transiently.
@@ -144,20 +161,7 @@ test('downloadEntityAndContentFiles with a corrupt stored entity file', ({ compo
           return inner.delete(ids)
         }
       }
-      thrownError = undefined
-      try {
-        await downloadEntityAndContentFiles(
-          { fetcher: components.fetcher, logs: components.logs, metrics: components.metrics, storage },
-          entityId,
-          [await components.getBaseUrl()],
-          new Map(),
-          contentFolder,
-          10,
-          0
-        )
-      } catch (error: any) {
-        thrownError = error
-      }
+      thrownError = await downloadWith(storage, entityId)
     })
 
     it('should propagate the read error rather than a parse error', () => {

--- a/test/downloadEntityCorruptFile.spec.ts
+++ b/test/downloadEntityCorruptFile.spec.ts
@@ -107,6 +107,60 @@ test('downloadEntityAndContentFiles with a corrupt stored entity file', ({ compo
     })
   })
 
+  describe('when the stored bytes are valid JSON but fail hash verification', () => {
+    let storage: IContentStorageComponent
+    let entityId: string
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      storage = createInMemoryStorage()
+      // A mis-keyed local file: parse-valid entity JSON stored under a DIFFERENT entity's hash.
+      // Without the pre-parse hash gate it would be processed as the wrong entity's metadata.
+      entityId = await hashV1(Buffer.from('{"type":"scene","content":[{"file":"a.glb","hash":"x"}]}'))
+      await storage.storeStream(entityId, Readable.from([Buffer.from('{"type":"profile","content":[]}')]))
+      thrownError = await downloadWith(storage, entityId)
+    })
+
+    it('should reject with an entity-scoped hash-verification error instead of processing the wrong entity', () => {
+      expect(thrownError?.message).toContain(`${entityId} failed content-hash verification`)
+    })
+
+    it('should evict the mis-keyed file so a later retry re-downloads it', async () => {
+      expect(await storage.exist(entityId)).toBe(false)
+    })
+  })
+
+  describe('when the entity id uses an unverifiable hash scheme and the bytes are not JSON', () => {
+    let storage: IContentStorageComponent
+    let entityId: string
+    let deleteCalls: string[][]
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      // Neither Qm nor ba: corruption cannot be proven, so the copy must never be deleted.
+      entityId = 'zUnknownSchemeEntityId'
+      const inner = createInMemoryStorage()
+      await inner.storeStream(entityId, Readable.from([Buffer.from('')]))
+      deleteCalls = []
+      storage = {
+        ...inner,
+        async delete(ids: string[]) {
+          deleteCalls.push(ids)
+          return inner.delete(ids)
+        }
+      }
+      thrownError = await downloadWith(storage, entityId)
+    })
+
+    it('should explain the copy was kept because corruption is unprovable', () => {
+      expect(thrownError?.message).toContain('could not be proven corrupt (unverifiable hash scheme)')
+    })
+
+    it('should not delete the stored file', () => {
+      expect(deleteCalls).toEqual([])
+    })
+  })
+
   describe('when the stored entity file is corrupt and evicting it fails', () => {
     let storage: IContentStorageComponent
     let entityId: string


### PR DESCRIPTION
## what

`downloadEntityAndContentFiles` read the entity file back from local storage and ran an unguarded `JSON.parse` on it. when that file is empty or truncated — typically a partial local copy left by an interrupted write, which `storage.exist` reports as present so `downloadJob` skips re-downloading it — the parse threw a bare `Unexpected end of JSON input` with no entity context. worse, the corrupt file was never removed, so every sync/retry re-read the same bytes and re-failed forever (a permanent poison pill; it surfaced as a failed deployment on catalyst whose only clue was that opaque message).

## change

guard the read and parse. on an empty body or a parse failure:
- `storage.delete([entityId])` the corrupt copy, so the next attempt sees `exist() === false` and re-downloads + hash-verifies a clean file, and
- throw an error that names the entity instead of the context-free parse error.

this is a different parse from the already-shipped `fetchJson` empty-body guard, which covers http snapshot/pointer bodies — not the entity file read from storage.

## related

the companion fix in `@dcl/catalyst-storage` (atomic `storeStream`) stops the partial file from being created in the first place; this change lets any already-corrupt copy self-heal on the next retry. either fix alone helps; together they close the loop.

## test

adds coverage: an empty stored entity file and an invalid-json stored entity file each reject with an error naming the entity and evict the file. full suite green (106 passed).