### PR TITLE
fix: serialize evictions and re-verify stored bytes before deleting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,61 @@ async function verifyBufferHash(buffer: Uint8Array, entityId: string): Promise<H
   return 'unverifiable'
 }
 
+// Serializes evictions per entity (same pattern as the module-scoped download-job map above). Two
+// callers can read the same corrupt copy concurrently; without serialization + re-verification, the
+// first eviction plus a retry can heal the cache with a fresh good copy that the second (stale)
+// caller then deletes based on the old bytes it already read.
+const inflightEvictions = new Map<string, Promise<unknown>>()
+function withEvictionLock<T>(entityId: string, fn: () => Promise<T>): Promise<T> {
+  const prev = inflightEvictions.get(entityId) ?? Promise.resolve()
+  const run = prev.then(fn, fn)
+  const guard = run.then(
+    () => undefined,
+    () => undefined
+  )
+  inflightEvictions.set(entityId, guard)
+  void guard.then(() => {
+    if (inflightEvictions.get(entityId) === guard) inflightEvictions.delete(entityId)
+  })
+  return run
+}
+
+/**
+ * Evicts the stored entity file after its bytes failed hash verification, and returns a
+ * human-readable outcome for the caller's error message. Runs under a per-entity lock and
+ * re-verifies the bytes CURRENTLY in storage — not the ones the caller read earlier — so a copy
+ * that was already healed (evicted and re-downloaded hash-valid) by a concurrent caller is never
+ * deleted on stale evidence.
+ */
+async function evictCorruptEntityFile(
+  components: Pick<SnapshotsFetcherComponents, 'storage' | 'metrics'>,
+  entityId: string
+): Promise<string> {
+  return withEvictionLock(entityId, async () => {
+    try {
+      const current = await components.storage.retrieve(entityId)
+      if (!current) {
+        // A concurrent eviction already removed it.
+        return 'the corrupt local copy was already removed; a later retry will re-download it'
+      }
+      const currentBuffer = await streamToBuffer(await current.asStream())
+      if ((await verifyBufferHash(currentBuffer, entityId)) !== 'mismatch') {
+        return 'the local copy has since been replaced by a hash-valid one, which was kept'
+      }
+    } catch {
+      // The re-read failed (transient storage error): deleting on stale evidence alone is not safe.
+      return 'the local copy could not be re-verified; it was kept and a later retry will re-check it'
+    }
+    try {
+      await components.storage.delete([entityId])
+    } catch {
+      return 'could not remove the corrupt local copy; a later retry will attempt it again'
+    }
+    components.metrics.increment('dcl_corrupt_entity_files_evicted_total')
+    return 'removed the corrupt local copy so it can be re-downloaded'
+  })
+}
+
 if (parseInt(process.versions.node.split('.')[0], 10) < 22) {
   const { name } = require('../package.json')
   throw new Error(`In order to work, the package ${name} needs to run in Node v22 or newer to handle streams properly.`)
@@ -153,19 +208,7 @@ export async function downloadEntityAndContentFiles(
   // best-effort: if it fails, the descriptive error still wins and the next retry re-attempts it.
   const verification = await verifyBufferHash(buffer, entityId)
   if (verification === 'mismatch') {
-    let evicted = false
-    try {
-      await components.storage.delete([entityId])
-      evicted = true
-    } catch {
-      // keep evicted = false; the error thrown below reflects that the copy could not be removed
-    }
-    if (evicted) {
-      components.metrics.increment('dcl_corrupt_entity_files_evicted_total')
-    }
-    const outcome = evicted
-      ? 'removed the corrupt local copy so it can be re-downloaded'
-      : 'could not remove the corrupt local copy; a later retry will attempt it again'
+    const outcome = await evictCorruptEntityFile(components, entityId)
     throw new Error(`The stored entity file for ${entityId} failed content-hash verification; ${outcome}.`)
   }
 

--- a/test/downloadEntityCorruptFile.spec.ts
+++ b/test/downloadEntityCorruptFile.spec.ts
@@ -193,6 +193,123 @@ test('downloadEntityAndContentFiles with a corrupt stored entity file', ({ compo
     })
   })
 
+  describe('when the corrupt copy is healed by a concurrent caller before the eviction re-check', () => {
+    let storage: IContentStorageComponent
+    let entityId: string
+    let deleteCalls: string[][]
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      // The caller reads a corrupt copy; by the time its eviction runs, a concurrent eviction plus
+      // retry has already replaced the stored file with a hash-valid one — which must be kept.
+      const goodBytes = Buffer.from('{"type":"scene","content":[]}')
+      entityId = await hashV1(goodBytes)
+      const inner = createInMemoryStorage()
+      await inner.storeStream(entityId, Readable.from([Buffer.from('corrupt half-written bytes')]))
+      deleteCalls = []
+      let retrieveCalls = 0
+      storage = {
+        ...inner,
+        async retrieve(fileId: string) {
+          retrieveCalls++
+          // First read (the caller's) sees the corrupt copy; the eviction re-check sees the heal.
+          if (retrieveCalls === 1) return inner.retrieve(fileId)
+          return {
+            async asStream() {
+              return Readable.from([goodBytes])
+            }
+          } as any
+        },
+        async delete(ids: string[]) {
+          deleteCalls.push(ids)
+          return inner.delete(ids)
+        }
+      }
+      thrownError = await downloadWith(storage, entityId)
+    })
+
+    it('should explain the copy was replaced by a hash-valid one and kept', () => {
+      expect(thrownError?.message).toContain('replaced by a hash-valid one, which was kept')
+    })
+
+    it('should not delete the healed copy', () => {
+      expect(deleteCalls).toEqual([])
+    })
+  })
+
+  describe('when a concurrent eviction already removed the corrupt copy', () => {
+    let storage: IContentStorageComponent
+    let entityId: string
+    let deleteCalls: string[][]
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      entityId = await hashV1(Buffer.from('{"type":"scene","content":[]}'))
+      const inner = createInMemoryStorage()
+      await inner.storeStream(entityId, Readable.from([Buffer.from('corrupt half-written bytes')]))
+      deleteCalls = []
+      let retrieveCalls = 0
+      storage = {
+        ...inner,
+        async retrieve(fileId: string) {
+          retrieveCalls++
+          // First read sees the corrupt copy; the eviction re-check finds it already gone.
+          if (retrieveCalls === 1) return inner.retrieve(fileId)
+          return undefined
+        },
+        async delete(ids: string[]) {
+          deleteCalls.push(ids)
+          return inner.delete(ids)
+        }
+      }
+      thrownError = await downloadWith(storage, entityId)
+    })
+
+    it('should report the copy as already removed', () => {
+      expect(thrownError?.message).toContain('already removed; a later retry will re-download it')
+    })
+
+    it('should not issue a second delete', () => {
+      expect(deleteCalls).toEqual([])
+    })
+  })
+
+  describe('when the eviction re-check read fails transiently', () => {
+    let storage: IContentStorageComponent
+    let entityId: string
+    let deleteCalls: string[][]
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      entityId = await hashV1(Buffer.from('{"type":"scene","content":[]}'))
+      const inner = createInMemoryStorage()
+      await inner.storeStream(entityId, Readable.from([Buffer.from('corrupt half-written bytes')]))
+      deleteCalls = []
+      let retrieveCalls = 0
+      storage = {
+        ...inner,
+        async retrieve(fileId: string) {
+          retrieveCalls++
+          if (retrieveCalls === 1) return inner.retrieve(fileId)
+          throw new Error('transient re-read failure')
+        },
+        async delete(ids: string[]) {
+          deleteCalls.push(ids)
+          return inner.delete(ids)
+        }
+      }
+      thrownError = await downloadWith(storage, entityId)
+    })
+
+    it('should keep the copy because stale evidence alone is not enough to delete', () => {
+      expect(thrownError?.message).toContain('could not be re-verified')
+    })
+
+    it('should not delete the stored file', () => {
+      expect(deleteCalls).toEqual([])
+    })
+  })
+
   describe('when the stored entity file is corrupt and evicting it fails', () => {
     let storage: IContentStorageComponent
     let entityId: string

--- a/test/downloadEntityCorruptFile.spec.ts
+++ b/test/downloadEntityCorruptFile.spec.ts
@@ -237,6 +237,73 @@ test('downloadEntityAndContentFiles with a corrupt stored entity file', ({ compo
     })
   })
 
+  describe('when two overlapping downloads race on the same corrupt entity', () => {
+    let storage: IContentStorageComponent
+    let entityId: string
+    let deleteCalls: string[][]
+    let outcomes: (Error | undefined)[]
+
+    beforeEach(async () => {
+      // Two real downloadEntityAndContentFiles calls overlap on the same id. A barrier holds both
+      // until each has read the corrupt copy, so the loser of the eviction lock is guaranteed to
+      // act on stale evidence; the heal (retry re-downloading a good copy) is planted inside the
+      // winner's delete, which the per-entity lock orders strictly before the loser's re-check.
+      const corruptBytes = Buffer.from('corrupt half-written bytes')
+      const goodBytes = Buffer.from('{"type":"scene","content":[]}')
+      entityId = await hashV1(goodBytes)
+      const inner = createInMemoryStorage()
+      await inner.storeStream(entityId, Readable.from([corruptBytes]))
+      deleteCalls = []
+      let retrieveCalls = 0
+      let arrivedReaders = 0
+      let releaseReaders: () => void = () => undefined
+      const bothReadersArrived = new Promise<void>((res) => (releaseReaders = res))
+      storage = {
+        ...inner,
+        async retrieve(fileId: string) {
+          retrieveCalls++
+          // The first two retrieves are the two callers' initial reads: hold both at the barrier so
+          // neither eviction can start until both hold the corrupt bytes.
+          if (retrieveCalls <= 2) {
+            arrivedReaders++
+            if (arrivedReaders === 2) releaseReaders()
+            await bothReadersArrived
+            return {
+              async asStream() {
+                return Readable.from([corruptBytes])
+              }
+            } as any
+          }
+          // Later retrieves are the serialized eviction re-checks: they see the CURRENT bytes.
+          return inner.retrieve(fileId)
+        },
+        async delete(ids: string[]) {
+          deleteCalls.push(ids)
+          await inner.delete(ids)
+          // Simulate the retry healing the cache before the loser's turn on the eviction lock.
+          await inner.storeStream(entityId, Readable.from([goodBytes]))
+        }
+      }
+      outcomes = await Promise.all([downloadWith(storage, entityId), downloadWith(storage, entityId)])
+    })
+
+    it('should evict exactly once across both callers', () => {
+      expect(deleteCalls).toHaveLength(1)
+    })
+
+    it('should let one caller evict and make the other keep the healed copy', () => {
+      const messages = outcomes.map((error) => error?.message ?? '')
+      expect(messages.filter((message) => message.includes('removed the corrupt local copy'))).toHaveLength(1)
+      expect(
+        messages.filter((message) => message.includes('replaced by a hash-valid one, which was kept'))
+      ).toHaveLength(1)
+    })
+
+    it('should keep the healed copy in storage', async () => {
+      expect(await storage.exist(entityId)).toBe(true)
+    })
+  })
+
   describe('when a concurrent eviction already removed the corrupt copy', () => {
     let storage: IContentStorageComponent
     let entityId: string


### PR DESCRIPTION
## what

follow-up to #203, closing the concurrent-cache-heal race noted in its review:

> two callers can both read the same corrupt local entity, one deletes it and a later retry re-downloads a good copy, then the second stale caller can delete that good copy based on the old bytes it already read.

## change

`evictCorruptEntityFile` now applies both of the suggested mitigations:

- **per-entity serialization** — evictions for the same `entityId` run one at a time (module-scoped promise-chain lock, same pattern as the downloader's job map), so two stale callers cannot interleave their delete decisions.
- **re-verification of the CURRENT bytes** — inside the locked section, the bytes presently in storage are re-read and re-hashed immediately before `delete([entityId])`. Only a confirmed mismatch deletes:
  - copy healed in the meantime (hash-valid now) → kept, error says it was replaced;
  - copy already removed by a concurrent eviction → no second delete;
  - re-read fails transiently → kept (stale evidence alone is never grounds to delete), a later retry re-checks.

the `dcl_corrupt_entity_files_evicted_total` metric still counts only actual deletes, and each outcome is reflected in the thrown entity-scoped error message.

a store landing between the re-verify and the delete remains theoretically possible (downloads are not serialized with evictions), but the window is now a single awaited call on an already-rare path, and the next retry heals it — the same fallback the review accepted.

## test

adds three regression suites: healed-before-re-check (kept, no delete), already-removed (no second delete), and transient re-read failure (kept). all previous eviction/keep behaviors re-verified. full suite green (125 passed).