### PR TITLE
fix!: repair the unimportable package and stop sync advancing past undeployed entities (v3, Node 24)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,4 +3,3 @@ dist/
 *.js
 *.d.ts
 *.json
-src/index.ts

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,3 @@
-
-ifneq ($(CI), true)
-LOCAL_ARG = --local --verbose --diagnostics
-endif
-
 test:
 	CI=true \
 		node --trace-warnings node_modules/.bin/jest --detectOpenHandles --coverage --colors --runInBand $(TESTARGS)
@@ -13,12 +8,12 @@ test-watch:
 
 build:
 	./node_modules/.bin/tsc -p tsconfig.json
-	rm -rf node_modules/@microsoft/api-extractor/node_modules/typescript || true
-	./node_modules/.bin/api-extractor run $(LOCAL_ARG) --typescript-compiler-folder ./node_modules/typescript
+
+lint:
+	./node_modules/.bin/eslint '**/*.{js,ts}'
 
 clean:
-	rm downloads/Qm*
-	rm downloads/ba*
 	rm -rf dist
+	rm -f downloads/Qm* downloads/ba*
 
-.PHONY: build test clean
+.PHONY: build test test-watch lint clean

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Synchronizes deployed entities from a set of Decentraland content servers. It bo
 servers' snapshot files and then keeps up with their `/pointer-changes` feeds, handing every entity to
 a deployer component supplied by the caller.
 
-Requires Node 22 or newer.
+Requires Node 24 or newer.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,17 @@ Remote servers are treated as untrusted, which constrains where requests may go:
 ## Shutdown
 
 `synchronizer.stop()` waits for in-flight work to finish rather than only signalling it, so once it
-resolves nothing is still deploying or mutating state. Retry ladders and poll intervals are abandoned
-when stopping, which bounds that wait at roughly one in-flight request — but it is not instant, so give
-it room in your termination grace period.
+resolves nothing is still deploying or mutating state. That includes your deployer: because
+`scheduleEntityDeployment` may resolve before the entity is actually deployed, `stop()` awaits
+`deployer.onIdle()` last, so an asynchronous or batching deployer is drained before it returns. Retry
+ladders and poll intervals are abandoned when stopping, which bounds that wait at roughly one in-flight
+request plus whatever your deployer still has queued — so give it room in your termination grace period.
+
+For the same reason, `onIdle()` is awaited at the two bootstrap transitions as well: before a server's
+last-entity timestamp is advanced after its snapshots, and before it is promoted from pointer-changes
+bootstrap to syncing. Both of those decide where the server resumes from, so they must reflect entities
+that were actually deployed rather than merely scheduled. A deployer whose `onIdle()` never resolves will
+therefore stall the bootstrap.
 
 Anything you schedule through `createJobQueue({ timeout })` must be **idempotent**: a timed-out attempt
 is retried, and because a promise cannot be cancelled the original keeps running alongside it.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,19 @@ For the same reason, `onIdle()` is awaited at the two bootstrap transitions as w
 last-entity timestamp is advanced after its snapshots, and before it is promoted from pointer-changes
 bootstrap to syncing. Both of those decide where the server resumes from, so they must reflect entities
 that were actually deployed rather than merely scheduled. A deployer whose `onIdle()` never resolves will
-therefore stall the bootstrap.
+therefore stall the bootstrap, and one that rejects it leaves the affected servers in bootstrap to be
+retried rather than dropping them.
+
+Two consequences worth stating plainly, because your deployer decides both:
+
+- **`markAsDeployed()` is load-bearing, not optional telemetry.** It is the only signal that an entity
+  actually deployed. `onIdle()` resolving proves the queue drained, not that every entity reported back,
+  so after it drains the snapshot's processed marker is re-read: a snapshot whose entities did not all
+  report is treated as incomplete, and the servers advertising it stay in snapshot bootstrap with their
+  timestamps held back. A deployer that never calls `markAsDeployed()` will therefore never finish
+  bootstrapping — previously it would have advanced anyway and skipped those entities.
+- **Deployments must be idempotent.** An incomplete snapshot is retried, so entities that did deploy are
+  scheduled again on the next pass.
 
 Anything you schedule through `createJobQueue({ timeout })` must be **idempotent**: a timed-out attempt
 is retried, and because a promise cannot be cancelled the original keeps running alongside it.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,86 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/decentraland/snapshots-fetcher/badge.svg)](https://coveralls.io/github/decentraland/snapshots-fetcher)
 
-##TODO
+Synchronizes deployed entities from a set of Decentraland content servers. It bootstraps from the
+servers' snapshot files and then keeps up with their `/pointer-changes` feeds, handing every entity to
+a deployer component supplied by the caller.
 
-- verify hashes of downloaded files before success
-- download files to temp folder before verification, move to final folder after successful (download+hash verification)
+Requires Node 22 or newer.
+
+## Usage
+
+`createSynchronizer` needs a full set of components. Everything required to build them is exported
+from the package root:
+
+```ts
+import { createJobQueue, createSynchronizer } from '@dcl/snapshots-fetcher'
+
+const synchronizer = await createSynchronizer(
+  {
+    metrics,
+    fetcher,
+    logs,
+    storage,
+    processedSnapshotStorage,
+    snapshotStorage,
+    downloadQueue: createJobQueue({ concurrency: 10, autoStart: true }),
+    deployer
+  },
+  {
+    bootstrapReconnection: { reconnectTime: 5_000, reconnectRetryTimeExponent: 1.5 },
+    syncingReconnection: { reconnectTime: 1_000, reconnectRetryTimeExponent: 1.2 },
+    tmpDownloadFolder: 'downloads',
+    requestMaxRetries: 10,
+    requestRetryWaitTime: 5_000,
+    pointerChangesWaitTime: 5_000
+  }
+)
+
+const syncJob = await synchronizer.syncWithServers(new Set(['https://peer.decentraland.org/content']))
+await syncJob.onSyncFinished()
+```
+
+`onSyncFinished()` resolves once every server has bootstrapped, and **rejects** if the synchronizer is
+stopped before that happens — so a shutdown never leaves the caller waiting.
+
+### Tuning concurrency
+
+The synchronizer's parallelism defaults to 10 on both of its internal queues. Override either one when
+your bandwidth, deployer throughput or the remote servers' rate limits call for it:
+
+```ts
+await createSynchronizer(components, {
+  // …
+  concurrency: {
+    snapshotDeployments: 4, // snapshots streamed and deployed at once
+    snapshotChecks: 20 // processed-snapshot decisions at once (bounds snapshotStorage load)
+  }
+})
+```
+
+Both must be integers `>= 1`; `createSynchronizer` rejects otherwise. The number of content files
+fetched in parallel *per entity* is a separate argument to `downloadEntityAndContentFiles`
+(`contentFilesConcurrency`, default 10), since that call belongs to your deployer.
+
+The `deployer` implements `IDeployerComponent`. Its `scheduleEntityDeployment` may return before the
+entity is actually deployed; calling the entity's `markAsDeployed()` once it is, is what allows the
+snapshot it came from to be recorded as processed.
+
+Register `metricsDefinitions` with your metrics component to expose this package's metrics.
+
+## Downloads and integrity
+
+Content files are downloaded to `tmpDownloadFolder`, hash-verified, and only then handed to the
+`storage` component keyed by their content hash. Bytes that do not match the hash addressing them are
+deleted rather than stored, and a stored entity file that fails verification is evicted so a retry can
+re-download it. Downloads are bounded in size, follow a limited number of redirects, and abort on
+socket inactivity.
+
+## Development
+
+```bash
+yarn install
+yarn build        # or: make build
+yarn test         # or: make test
+yarn lint:check   # or: make lint
+```

--- a/README.md
+++ b/README.md
@@ -77,6 +77,27 @@ deleted rather than stored, and a stored entity file that fails verification is 
 re-download it. Downloads are bounded in size, follow a limited number of redirects, and abort on
 socket inactivity.
 
+Remote servers are treated as untrusted, which constrains where requests may go:
+
+- Redirects are followed only to **publicly routable** addresses. A redirect resolving to a private,
+  loopback, link-local (including `169.254.169.254`) or unique-local address is refused, and a host
+  whose resolved address changes public↔non-public mid-download is refused as DNS rebinding. The host
+  you originally asked for is exempt, so a private catalyst — or loopback in local development — keeps
+  working.
+- JSON endpoints (`/snapshots`, `/pointer-changes`) follow redirects only **within the same origin**,
+  and paginate only within the same origin.
+
+## Shutdown
+
+`synchronizer.stop()` waits for in-flight work to finish rather than only signalling it, so once it
+resolves nothing is still deploying or mutating state. Retry ladders and poll intervals are abandoned
+when stopping, which bounds that wait at roughly one in-flight request — but it is not instant, so give
+it room in your termination grace period.
+
+Anything you schedule through `createJobQueue({ timeout })` must be **idempotent**: a timed-out attempt
+is retried, and because a promise cannot be cancelled the original keeps running alongside it.
+`onIdle()` and `stop()` do wait for those abandoned executions, so quiescence remains accurate.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ await createSynchronizer(components, {
   // …
   transferLimits: {
     requestTimeoutInMs: 15_000, // inactivity deadline on a JSON body read, refreshed per chunk
-    maxDownloadedFileSizeInBytes: 1024 * 1024 * 1024, // 1 GiB ceiling per content file, after gunzip
+    downloadInactivityTimeoutInMs: 30_000, // the same, for a content-file download
+    maxDownloadedFileSizeInBytes: 1024 * 1024 * 1024, // 1 GiB ceiling per content file
     minTransferRateInBytesPerSecond: 4096, // floor a transfer must average to continue
     transferRateGracePeriodInMs: 60_000 // how long before the rate is judged at all
   }
@@ -86,6 +87,13 @@ arriving, never whether they add up to progress. Lower it on a constrained link,
 `transferRateGracePeriodInMs` alongside it if your peers are slow to get going. **Setting it to `0`
 disables the check**, restoring the pre-`3.0.0` behaviour where an arbitrarily slow transfer continued
 as long as it kept sending something.
+
+`maxDownloadedFileSizeInBytes` is applied on both sides of a gzip boundary: to the decompressed bytes,
+which is the gzip-bomb bound, and to the compressed response as well. The second one matters because a
+peer can stream valid gzip indefinitely while producing no decompressed output at all — concatenated
+empty gzip members are legal — so a bound only on the decompressed side never gets a byte to measure. For
+real content the compressed bound never binds: gzip exceeds its input only for incompressible data, and
+then by about 0.03%.
 
 `createSynchronizer` validates these up front, so a bad value is rejected at construction rather than
 surfacing as a puzzling failure on one download later. Every field must be an integer; the two rate

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ await createSynchronizer(components, {
     downloadInactivityTimeoutInMs: 30_000, // the same, for a content-file download
     maxDownloadedFileSizeInBytes: 1024 * 1024 * 1024, // 1 GiB ceiling per content file
     minTransferRateInBytesPerSecond: 4096, // floor a transfer must average to continue
-    transferRateGracePeriodInMs: 60_000 // how long before the rate is judged at all
+    transferRateGracePeriodInMs: 60_000, // how long before the rate is judged at all
+    maxPagesPerPaginatedCall: 10_000 // pages one /pointer-changes poll will follow
   }
 })
 ```
@@ -99,6 +100,13 @@ peer can stream valid gzip indefinitely while producing no decompressed output a
 empty gzip members are legal — so a bound only on the decompressed side never gets a byte to measure. For
 real content the compressed bound never binds: gzip exceeds its input only for incompressible data, and
 then by about 0.03%.
+
+`maxPagesPerPaginatedCall` bounds the amplification one poll can produce: a server that keeps advertising
+a `next` link makes every page another request to the same path. The default sits far above any legitimate
+page count, so lower it if you would rather cap that tightly than tolerate an unusually deep backlog in a
+single poll. There is deliberately no wall-clock budget for a paginated call — pagination progress is not
+committed until the poll completes, so aborting a long walk discards it and resumes from the last
+confirmed timestamp, which would leave a genuinely deep backlog restarting the same walk forever.
 
 `createSynchronizer` validates these up front, so a bad value is rejected at construction rather than
 surfacing as a puzzling failure on one download later. Every field must be an integer; the two rate

--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ await createSynchronizer(components, {
 })
 ```
 
-Both must be integers `>= 1`; `createSynchronizer` rejects otherwise. The number of content files
+Both must be integers `>= 1`; `createSynchronizer` rejects otherwise. So does
+`downloadEntityAndContentFiles` for its `contentFilesConcurrency` argument, before it spends any request,
+and `createJobQueue` for its `concurrency` (**required**) and `timeout`. An unknown key in
+`transferLimits` is rejected too, rather than falling back to the default for the limit you meant. The number of content files
 fetched in parallel *per entity* is a separate argument to `downloadEntityAndContentFiles`
 (`contentFilesConcurrency`, default 10), since that call belongs to your deployer.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ arriving, never whether they add up to progress. Lower it on a constrained link,
 disables the check**, restoring the pre-`3.0.0` behaviour where an arbitrarily slow transfer continued
 as long as it kept sending something.
 
+Content downloads accept `Content-Encoding: gzip` case-insensitively, plus the legacy `x-gzip` alias.
+Any other coding — `br`, `deflate`, or several layered together — is refused up front with a message
+naming it, rather than being written undecoded and surfacing as a hash mismatch once the retries are
+spent.
+
 `maxDownloadedFileSizeInBytes` is applied on both sides of a gzip boundary: to the decompressed bytes,
 which is the gzip-bomb bound, and to the compressed response as well. The second one matters because a
 peer can stream valid gzip indefinitely while producing no decompressed output at all — concatenated
@@ -98,6 +103,12 @@ then by about 0.03%.
 `createSynchronizer` validates these up front, so a bad value is rejected at construction rather than
 surfacing as a puzzling failure on one download later. Every field must be an integer; the two rate
 fields accept `0`, the timeout and size cap require `>= 1`.
+
+Downloads of the same hash are de-duplicated while one is in flight, keyed by the hash alone: a caller
+that joins an existing transfer inherits the bounds of whoever started it. The hash is a content address,
+so a second transfer under different bounds would spend real bandwidth reaching a byte-identical result.
+Under `createSynchronizer` every caller threads the same options, so this only arises if you call the
+download helpers directly with differing limits.
 
 The same object is accepted by `getDeployedEntitiesStreamFromSnapshot`,
 `getDeployedEntitiesStreamFromPointerChanges` (on their options) and `downloadEntityAndContentFiles` (as

--- a/README.md
+++ b/README.md
@@ -84,8 +84,16 @@ Remote servers are treated as untrusted, which constrains where requests may go:
   whose resolved address changes public↔non-public mid-download is refused as DNS rebinding. The host
   you originally asked for is exempt, so a private catalyst — or loopback in local development — keeps
   working.
-- JSON endpoints (`/snapshots`, `/pointer-changes`) follow redirects only **within the same origin**,
-  and paginate only within the same origin.
+- JSON endpoints (`/snapshots`, `/pointer-changes`) **do not follow redirects at all** — a redirect
+  response is refused. An origin check cannot help here: a URL origin is a hostname, not an address, so
+  a host can answer the first request from a public address and rebind the name before the next one. The
+  download path pins the resolved address instead, but the fetch component exposes no hook to do the
+  same, so refusing redirects is the only complete answer on this path.
+- Pagination follows a `next` link only within the **same origin and the same path** as the request that
+  started the call, so a server can move the query string but cannot aim the next request at a different
+  endpoint. Note this bounds *what* is requested, not *where* it resolves: DNS rebinding on the first
+  request of a poll is not defended against on this path, and closing it needs a fetch component that
+  can pin resolution.
 
 ## Shutdown
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,39 @@ Both must be integers `>= 1`; `createSynchronizer` rejects otherwise. The number
 fetched in parallel *per entity* is a separate argument to `downloadEntityAndContentFiles`
 (`contentFilesConcurrency`, default 10), since that call belongs to your deployer.
 
+### Tuning transfer limits
+
+Bounds on individual HTTP transfers. Omit `transferLimits`, or any field within it, to keep the values
+this package used before they were configurable — the defaults below are exactly those:
+
+```ts
+await createSynchronizer(components, {
+  // …
+  transferLimits: {
+    requestTimeoutInMs: 15_000, // inactivity deadline on a JSON body read, refreshed per chunk
+    maxDownloadedFileSizeInBytes: 1024 * 1024 * 1024, // 1 GiB ceiling per content file, after gunzip
+    minTransferRateInBytesPerSecond: 4096, // floor a transfer must average to continue
+    transferRateGracePeriodInMs: 60_000 // how long before the rate is judged at all
+  }
+})
+```
+
+`minTransferRateInBytesPerSecond` is what stops a peer holding a slot by trickling bytes: the timeout
+above is an *inactivity* deadline refreshed on every chunk, so it only asks whether bytes are still
+arriving, never whether they add up to progress. Lower it on a constrained link, and raise
+`transferRateGracePeriodInMs` alongside it if your peers are slow to get going. **Setting it to `0`
+disables the check**, restoring the pre-`3.0.0` behaviour where an arbitrarily slow transfer continued
+as long as it kept sending something.
+
+`createSynchronizer` validates these up front, so a bad value is rejected at construction rather than
+surfacing as a puzzling failure on one download later. Every field must be an integer; the two rate
+fields accept `0`, the timeout and size cap require `>= 1`.
+
+The same object is accepted by `getDeployedEntitiesStreamFromSnapshot`,
+`getDeployedEntitiesStreamFromPointerChanges` (on their options) and `downloadEntityAndContentFiles` (as
+its last argument). `DEFAULT_TRANSFER_LIMITS` and `resolveTransferLimits` are exported if you want to
+read or derive from the defaults.
+
 The `deployer` implements `IDeployerComponent`. Its `scheduleEntityDeployment` may return before the
 entity is actually deployed; calling the entity's `markAsDeployed()` once it is, is what allows the
 snapshot it came from to be recorded as processed.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,16 +1,11 @@
 module.exports = {
-  globals: {
-    'ts-jest': {
-      tsconfig: 'test/tsconfig.json',
-    },
-  },
   moduleFileExtensions: ['ts', 'js'],
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: 'test/tsconfig.json' }]
   },
   testTimeout: 60000,
   coverageDirectory: 'coverage',
   verbose: true,
   testMatch: ['**/*.spec.(ts)'],
-  testEnvironment: 'node',
+  testEnvironment: 'node'
 }

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
   "dependencies": {
     "@dcl/catalyst-storage": "^4.5.1",
     "@dcl/core-commons": "^0.10.1",
-    "@dcl/fetch-component": "^1.1.1",
     "@dcl/hashing": "^3.0.3",
     "@dcl/metrics": "^1.0.1",
     "@dcl/schemas": "^9.1.1",
     "@well-known-components/interfaces": "^1.5.2",
+    "fp-future": "^1.0.1",
     "p-queue": "^6.6.2"
   },
   "engines": {
@@ -41,17 +41,18 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@dcl/eslint-config": "^1.1.1",
+    "@dcl/fetch-component": "^1.1.1",
     "@dcl/http-server": "^2.2.1",
     "@dcl/test-helpers": "^0.2.0",
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^22.10.0",
     "@well-known-components/env-config-provider": "^1.1.1",
     "@well-known-components/logger": "^3.0.0",
     "babel-plugin-module-resolver": "^5.0.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.5.0",
-    "typescript": "^4.5.5"
+    "typescript": "^5.7.2"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dcl/snapshots-fetcher",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -25,7 +25,7 @@
     "tabWidth": 2
   },
   "dependencies": {
-    "@dcl/catalyst-storage": "^4.5.1",
+    "@dcl/catalyst-storage": "^5.0.0",
     "@dcl/core-commons": "^0.10.1",
     "@dcl/hashing": "^3.0.3",
     "@dcl/metrics": "^1.0.1",
@@ -35,7 +35,7 @@
     "p-queue": "^6.6.2"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "engineStrict": true,
   "devDependencies": {
@@ -45,7 +45,7 @@
     "@dcl/http-server": "^2.2.1",
     "@dcl/test-helpers": "^0.2.0",
     "@types/jest": "^29.5.0",
-    "@types/node": "^22.10.0",
+    "@types/node": "^24.0.0",
     "@well-known-components/env-config-provider": "^1.1.1",
     "@well-known-components/logger": "^3.0.0",
     "babel-plugin-module-resolver": "^5.0.0",

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,16 +29,34 @@ const MAX_PAGES_PER_PAGINATED_CALL = 10_000
 // Conventional URL length ceiling. Bounds what a server can make us retain per page.
 const MAX_PAGINATION_LINK_LENGTH = 2048
 
+/**
+ * A remote timestamp we are willing to do arithmetic with.
+ *
+ * `typeof x === 'number'` is not enough. A JSON body cannot carry NaN — `{"a":NaN}` is a syntax error —
+ * but it CAN carry Infinity, because the JSON number grammar has no range limit and a large exponent
+ * (`1e999`) parses to it. An infinite endTimestamp becomes the server's high-water mark, which
+ * `Math.max` can then never advance past, so it polls `from=Infinity` for the rest of the process's
+ * life. Negative values are nonsense for an epoch timestamp.
+ *
+ * Deliberately not requiring an integer: fractional milliseconds would be odd but harmless, and
+ * rejecting an entry drops the whole snapshot — which silently stops us syncing from that server.
+ */
+function isUsableTimestamp(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
 // Snapshot metadata comes from untrusted servers; keep only entries with the shape we rely on
-// (valid content hash + numeric time range) so a malformed response can't break downstream logic.
+// (valid content hash + usable time range) so a malformed response can't break downstream logic.
 function isValidSnapshotMetadata(snapshot: any): snapshot is SnapshotMetadata {
   return (
     !!snapshot &&
     typeof snapshot.hash === 'string' &&
     isValidContentHash(snapshot.hash) &&
     !!snapshot.timeRange &&
-    typeof snapshot.timeRange.initTimestamp === 'number' &&
-    typeof snapshot.timeRange.endTimestamp === 'number' &&
+    isUsableTimestamp(snapshot.timeRange.initTimestamp) &&
+    isUsableTimestamp(snapshot.timeRange.endTimestamp) &&
+    // An inverted range is malformed, and it is handed straight to the deployer's warm-up.
+    snapshot.timeRange.initTimestamp <= snapshot.timeRange.endTimestamp &&
     (snapshot.replacedSnapshotHashes === undefined ||
       (Array.isArray(snapshot.replacedSnapshotHashes) &&
         snapshot.replacedSnapshotHashes.every((hash: any) => isValidContentHash(hash))))

--- a/src/client.ts
+++ b/src/client.ts
@@ -94,11 +94,24 @@ function isValidSnapshotMetadata(snapshot: any): snapshot is SnapshotMetadata {
   // Validating a field we never use can only cause harm here.
 }
 
+/**
+ * A server's snapshot list, together with whether we had to discard anything from it.
+ *
+ * The count matters as much as the list. Each snapshot stands for a whole time range, so a discarded
+ * entry is a range nothing else covers: treating the surviving subset as the server's complete history
+ * would advance it past those entities and never revisit them. Callers that record sync progress must
+ * check this rather than only reading `snapshots`.
+ */
+export type SnapshotsFromServer = {
+  snapshots: SnapshotMetadata[]
+  discardedEntries: number
+}
+
 export async function getSnapshots(
   components: SnapshotsFetcherComponents,
   server: string,
   retries: number
-): Promise<SnapshotMetadata[]> {
+): Promise<SnapshotsFromServer> {
   const logger = components.logs.getLogger('getSnapshots')
   const incrementalSnapshotsUrl = new URL(`${server}/snapshots`).toString()
   const response = await components.downloadQueue.scheduleJobWithRetries(
@@ -132,8 +145,11 @@ export async function getSnapshots(
     })
   }
 
-  // newest first
-  return validSnapshots.sort((s1, s2) => s2.timeRange.endTimestamp - s1.timeRange.endTimestamp)
+  return {
+    // newest first
+    snapshots: validSnapshots.sort((s1, s2) => s2.timeRange.endTimestamp - s1.timeRange.endTimestamp),
+    discardedEntries: invalidSnapshots
+  }
 }
 
 export async function* fetchJsonPaginated<T>(
@@ -247,14 +263,31 @@ export async function* fetchPointerChanges(
     ($) => $.deltas,
     'dcl_catalysts_pointer_changes_response_time_seconds'
   )) {
-    if (PointerChangesSyncDeployment.validate(deployment)) {
-      yield deployment
-    } else {
+    if (!PointerChangesSyncDeployment.validate(deployment)) {
       logger.error('ERROR: Invalid entity deployment from /pointer-changes', {
         deployment: JSON.stringify(deployment),
         error: JSON.stringify(PointerChangesSyncDeployment.validate.errors)
       })
+      continue
     }
+    // The schema is not enough. It rejects Infinity and negatives but bounds nothing above, so a
+    // far-future, 1e308, above-2^53 or fractional localTimestamp is schema-valid — and localTimestamp is
+    // exactly what markAsDeployed feeds to increaseLastTimestamp. One such delta permanently pins the
+    // server's high-water mark at a point no real deployment can exceed, and it then polls from an
+    // impossible `from=` forever. Same hazard the snapshot time ranges are checked for.
+    //
+    // Skipped rather than fatal, unlike a malformed snapshot: a delta is one entity, and failing the
+    // stream on it would let a single permanently-broken record stall every later deployment from that
+    // server. A snapshot covers a whole range, so there dropping it silently is the worse trade.
+    if (!isUsableTimestamp(deployment.localTimestamp) || !isUsableTimestamp(deployment.entityTimestamp)) {
+      logger.error('ERROR: Implausible timestamp in entity deployment from /pointer-changes', {
+        deployment: JSON.stringify(deployment),
+        localTimestamp: String(deployment.localTimestamp),
+        entityTimestamp: String(deployment.entityTimestamp)
+      })
+      continue
+    }
+    yield deployment
   }
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,6 +29,16 @@ const MAX_PAGES_PER_PAGINATED_CALL = 10_000
 // Conventional URL length ceiling. Bounds what a server can make us retain per page.
 const MAX_PAGINATION_LINK_LENGTH = 2048
 
+// Ceiling on the snapshots one snapshot may claim to replace. Every entry ends up in the batched
+// processed-snapshots lookup — one large `IN` clause against the consumer's storage — so an entry with a
+// pathological list sizes that query. Real snapshots replace tens (a daily replaces its hours, a monthly
+// its days), so this only trips on a broken or hostile server.
+//
+// Note this bounds a single entry, not the aggregate: a server can still spread hashes across many
+// snapshots, and the real ceiling on the total is MAX_JSON_RESPONSE_SIZE_IN_BYTES. Chunking the lookup is
+// what would bound the query itself.
+const MAX_REPLACED_SNAPSHOT_HASHES = 1000
+
 /**
  * A remote timestamp we are willing to do arithmetic with.
  *
@@ -59,6 +69,7 @@ function isValidSnapshotMetadata(snapshot: any): snapshot is SnapshotMetadata {
     snapshot.timeRange.initTimestamp <= snapshot.timeRange.endTimestamp &&
     (snapshot.replacedSnapshotHashes === undefined ||
       (Array.isArray(snapshot.replacedSnapshotHashes) &&
+        snapshot.replacedSnapshotHashes.length <= MAX_REPLACED_SNAPSHOT_HASHES &&
         snapshot.replacedSnapshotHashes.every((hash: any) => isValidContentHash(hash))))
   )
   // Deliberately NOT validating numberOfEntities / generationTimestamp. Nothing in this package reads

--- a/src/client.ts
+++ b/src/client.ts
@@ -99,6 +99,9 @@ export async function* fetchJsonPaginated<T>(
 ): AsyncIterable<T> {
   // Perform the different queries
   let currentUrl = url
+  // Parsed once, and every `next` is validated against THIS rather than against the previous page, so
+  // no chain of individually-permitted hops can walk away from the endpoint the call started from.
+  const requestUrl = new URL(url)
   // Every page a paginated call has already fetched. A server that points `next` back at a page it
   // already served would otherwise cycle forever; this catches that immediately instead of waiting
   // for the page cap.
@@ -154,15 +157,27 @@ export async function* fetchJsonPaginated<T>(
       } catch {
         throw new Error(`Invalid pagination link while fetching ${url}: ${JSON.stringify(nextRelative)}`)
       }
-      // `next` is chosen by the remote server, so an absolute URL here would let it steer our
-      // requests at any host it likes — internal addresses and cloud metadata endpoints included —
-      // using this process as the client. Pagination never legitimately leaves the server that
-      // issued it, so anything cross-origin is rejected rather than followed.
-      if (nextUrl.origin !== new URL(currentUrl).origin) {
+      // `next` is chosen by the remote server, and this process is the client that would follow it, so
+      // it is pinned to the endpoint the call started from and may vary only the query string — which
+      // is all pagination legitimately needs (catalysts return `?from=…&entityId=…`).
+      //
+      // Rejecting cross-origin links stops it naming another host outright. That alone is not the whole
+      // story: a URL origin is a hostname, not an address, so a hostile host can serve page 1 from a
+      // public IP and rebind the name to loopback or 169.254.169.254 before page 2 while the origin
+      // still matches. That rebinding cannot be closed here — `IFetchComponent` exposes no DNS `lookup`
+      // hook, the same reason fetchJson refuses redirects outright — and it applies to the first request
+      // of every poll regardless of pagination. What holding the path fixed removes is the part that IS
+      // ours to control: without it a rebound request would carry a server-chosen path (an internal
+      // admin endpoint); with it, the most a rebound address can be asked for is the very endpoint we
+      // were going to request anyway.
+      if (nextUrl.origin !== requestUrl.origin) {
         throw new Error(
-          `Refusing to follow a cross-origin pagination link while fetching ${url}: ${nextUrl.origin} does not match ${
-            new URL(currentUrl).origin
-          }`
+          `Refusing to follow a cross-origin pagination link while fetching ${url}: ${nextUrl.origin} does not match ${requestUrl.origin}`
+        )
+      }
+      if (nextUrl.pathname !== requestUrl.pathname) {
+        throw new Error(
+          `Refusing to follow a pagination link that changes the path while fetching ${url}: ${nextUrl.pathname} does not match ${requestUrl.pathname}`
         )
       }
       currentUrl = nextUrl.toString()

--- a/src/client.ts
+++ b/src/client.ts
@@ -137,6 +137,16 @@ export async function* fetchJsonPaginated<T>(
   // Parsed once, and every `next` is validated against THIS rather than against the previous page, so
   // no chain of individually-permitted hops can walk away from the endpoint the call started from.
   const requestUrl = new URL(url)
+  // The initial url is normalised exactly as every `next` is below, so the visited-URL rule reads the
+  // same for page 1 as for the rest: a caller-supplied fragment is just as meaningless to the server,
+  // and leaving one on would let page 1 and a fragmentless `next` to the same resource count as two
+  // distinct pages. Re-serialised only when there is a fragment to drop, so a url without one is passed
+  // through byte for byte. Internal callers build fragmentless urls, so today this is consistency
+  // rather than a live bug.
+  if (requestUrl.hash) {
+    requestUrl.hash = ''
+    currentUrl = requestUrl.toString()
+  }
   // Every page a paginated call has already fetched. A server that points `next` back at a page it
   // already served would otherwise cycle forever; this catches that immediately instead of waiting
   // for the page cap.

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,12 +7,17 @@ import {
   fetchJson,
   isUsableTimestamp,
   isValidContentHash,
+  truncateForLog,
   saveContentFileToDisk as saveContentFile
 } from './utils'
 
 // Cap how many invalid snapshot entries we log per response, so a server returning many of them
 // (the body can be up to MAX_JSON_RESPONSE_SIZE_IN_BYTES) can't flood the logs.
 const MAX_INVALID_SNAPSHOT_LOGS = 100
+
+// The same bound for deltas we refuse from /pointer-changes. A server can put one on every page, and
+// MAX_PAGES_PER_PAGINATED_CALL is 10,000.
+const MAX_REJECTED_DELTA_LOGS = 100
 
 // Every request this module makes must be bounded. The fetch component applies no default timeout,
 // so without an explicit one a server that accepts the connection and then stops responding leaves
@@ -103,7 +108,7 @@ export async function getSnapshots(
     if (invalidSnapshots <= MAX_INVALID_SNAPSHOT_LOGS) {
       logger.error('Ignoring invalid snapshot metadata received from server', {
         server,
-        snapshot: JSON.stringify(snapshot)
+        snapshot: truncateForLog(JSON.stringify(snapshot))
       })
     }
   }
@@ -226,6 +231,24 @@ export async function* fetchPointerChanges(
   const url = new URL(
     `${server}/pointer-changes?sortingOrder=ASC&sortingField=local_timestamp&from=${encodeURIComponent(fromTimestamp)}`
   ).toString()
+  // Bounded like the snapshot-file reader's, and for the same reason: a server can put a rejectable delta
+  // on every page, and the page cap is 10,000. Truncating each entry is not enough on its own when the
+  // number of entries is also attacker-chosen.
+  let rejectedDeltasLogged = 0
+  function reportRejectedDelta(message: string, buildExtra: () => Record<string, string>) {
+    if (rejectedDeltasLogged >= MAX_REJECTED_DELTA_LOGS) {
+      return
+    }
+    rejectedDeltasLogged++
+    logger.error(message, buildExtra())
+    if (rejectedDeltasLogged === MAX_REJECTED_DELTA_LOGS) {
+      logger.error('Too many rejected deltas from /pointer-changes, suppressing further ones', {
+        server,
+        suppressedAfter: String(MAX_REJECTED_DELTA_LOGS)
+      })
+    }
+  }
+
   for await (const deployment of fetchJsonPaginated(
     components,
     url,
@@ -233,10 +256,10 @@ export async function* fetchPointerChanges(
     'dcl_catalysts_pointer_changes_response_time_seconds'
   )) {
     if (!PointerChangesSyncDeployment.validate(deployment)) {
-      logger.error('ERROR: Invalid entity deployment from /pointer-changes', {
-        deployment: JSON.stringify(deployment),
+      reportRejectedDelta('ERROR: Invalid entity deployment from /pointer-changes', () => ({
+        deployment: truncateForLog(JSON.stringify(deployment)),
         error: JSON.stringify(PointerChangesSyncDeployment.validate.errors)
-      })
+      }))
       continue
     }
     // The schema is not enough. It rejects Infinity and negatives but bounds nothing above, so a
@@ -249,11 +272,11 @@ export async function* fetchPointerChanges(
     // stream on it would let a single permanently-broken record stall every later deployment from that
     // server. A snapshot covers a whole range, so there dropping it silently is the worse trade.
     if (!isUsableTimestamp(deployment.localTimestamp) || !isUsableTimestamp(deployment.entityTimestamp)) {
-      logger.error('ERROR: Implausible timestamp in entity deployment from /pointer-changes', {
-        deployment: JSON.stringify(deployment),
+      reportRejectedDelta('ERROR: Implausible timestamp in entity deployment from /pointer-changes', () => ({
+        deployment: truncateForLog(JSON.stringify(deployment)),
         localTimestamp: String(deployment.localTimestamp),
         entityTimestamp: String(deployment.entityTimestamp)
-      })
+      }))
       continue
     }
     yield deployment

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,6 +8,7 @@ import {
   isUsableTimestamp,
   isValidContentHash,
   resolveTransferLimits,
+  sanitizeUrlForLog,
   truncateForLog,
   saveContentFileToDisk as saveContentFile
 } from './utils'
@@ -163,10 +164,14 @@ export async function* fetchJsonPaginated<T>(
 
   while (currentUrl) {
     if (visitedUrls.has(currentUrl)) {
-      throw new Error(`Pagination loop while fetching ${url}: ${currentUrl} was already fetched`)
+      throw new Error(
+        `Pagination loop while fetching ${sanitizeUrlForLog(url)}: ${sanitizeUrlForLog(currentUrl)} was already fetched`
+      )
     }
     if (visitedUrls.size >= MAX_PAGES_PER_PAGINATED_CALL) {
-      throw new Error(`Too many pages while fetching ${url}: stopped after ${MAX_PAGES_PER_PAGINATED_CALL}`)
+      throw new Error(
+        `Too many pages while fetching ${sanitizeUrlForLog(url)}: stopped after ${MAX_PAGES_PER_PAGINATED_CALL}`
+      )
     }
     visitedUrls.add(currentUrl)
 
@@ -223,7 +228,11 @@ export async function* fetchJsonPaginated<T>(
       // links all throw. A server that says "there is more" in a way we cannot read should not have that
       // read as "there is no more".
       if (typeof nextRelative !== 'string') {
-        throw new Error(`Invalid pagination link while fetching ${url}: expected a string, got ${typeof nextRelative}`)
+        throw new Error(
+          `Invalid pagination link while fetching ${sanitizeUrlForLog(
+            url
+          )}: expected a string, got ${typeof nextRelative}`
+        )
       }
       // `next` is remote text: an unparseable value would otherwise surface as an opaque TypeError
       // from the URL constructor, and an enormous one would be retained in visitedUrls for the rest of
@@ -237,7 +246,11 @@ export async function* fetchJsonPaginated<T>(
       try {
         nextUrl = new URL(nextRelative, currentUrl)
       } catch {
-        throw new Error(`Invalid pagination link while fetching ${url}: ${JSON.stringify(nextRelative)}`)
+        throw new Error(
+          `Invalid pagination link while fetching ${sanitizeUrlForLog(url)}: ${truncateForLog(
+            JSON.stringify(nextRelative)
+          )}`
+        )
       }
       // `next` is chosen by the remote server, and this process is the client that would follow it, so
       // it is pinned to the endpoint the call started from and may vary only the query string — which
@@ -254,12 +267,14 @@ export async function* fetchJsonPaginated<T>(
       // were going to request anyway.
       if (nextUrl.origin !== requestUrl.origin) {
         throw new Error(
-          `Refusing to follow a cross-origin pagination link while fetching ${url}: ${nextUrl.origin} does not match ${requestUrl.origin}`
+          `Refusing to follow a cross-origin pagination link while fetching ${sanitizeUrlForLog(url)}: ` +
+            `${nextUrl.origin} does not match ${requestUrl.origin}`
         )
       }
       if (nextUrl.pathname !== requestUrl.pathname) {
         throw new Error(
-          `Refusing to follow a pagination link that changes the path while fetching ${url}: ${nextUrl.pathname} does not match ${requestUrl.pathname}`
+          `Refusing to follow a pagination link that changes the path while fetching ${sanitizeUrlForLog(url)}: ` +
+            `${truncateForLog(nextUrl.pathname)} does not match ${requestUrl.pathname}`
         )
       }
       // Fragments are never sent to a server, so two links differing only by `#…` address the same

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
 import { PointerChangesSyncDeployment } from '@dcl/schemas'
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import { metricsDefinitions } from './metrics'
+import { assertPointerChangesDeploymentWithinStructuralLimits } from './pointer-changes-limits'
 import { SnapshotMetadata, SnapshotsFetcherComponents, TransferLimits } from './types'
 import {
   contentServerMetricLabels,
@@ -332,6 +333,11 @@ export async function* fetchPointerChanges(
       }))
       continue
     }
+    // The schema has minItems but no maximum counts or string lengths. These fields are later sorted
+    // and hashed for inclusive-boundary de-duplication, so one schema-valid row must not be allowed to
+    // size that work up to the whole paginated-response cap. Throwing fails the poll before its
+    // high-water mark is committed; skipping would silently advance past the rejected deployment.
+    assertPointerChangesDeploymentWithinStructuralLimits(deployment)
     // The schema is not enough. It rejects Infinity and negatives but bounds nothing above, so a
     // far-future, 1e308, above-2^53 or fractional localTimestamp is schema-valid — and localTimestamp is
     // exactly what markAsDeployed feeds to increaseLastTimestamp. One such delta permanently pins the

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,20 +39,36 @@ const MAX_PAGINATION_LINK_LENGTH = 2048
 // what would bound the query itself.
 const MAX_REPLACED_SNAPSHOT_HASHES = 1000
 
+// How far ahead of our own clock a remote timestamp may sit. Snapshots describe history that already
+// happened, so anything beyond this is either the server's clock being wrong or a value we should not
+// adopt as sync state.
+const MAX_TIMESTAMP_CLOCK_SKEW_IN_MS = 24 * 60 * 60 * 1000
+
 /**
- * A remote timestamp we are willing to do arithmetic with.
+ * A remote timestamp we are willing to adopt as sync state.
  *
- * `typeof x === 'number'` is not enough. A JSON body cannot carry NaN — `{"a":NaN}` is a syntax error —
- * but it CAN carry Infinity, because the JSON number grammar has no range limit and a large exponent
- * (`1e999`) parses to it. An infinite endTimestamp becomes the server's high-water mark, which
- * `Math.max` can then never advance past, so it polls `from=Infinity` for the rest of the process's
- * life. Negative values are nonsense for an epoch timestamp.
+ * These values become a server's high-water mark, and `increaseLastTimestamp` only ever moves it forward,
+ * so a single bad one is permanent for the life of the process: the server then polls `/pointer-changes`
+ * from a point nothing can ever reach and silently stops syncing.
  *
- * Deliberately not requiring an integer: fractional milliseconds would be odd but harmless, and
- * rejecting an entry drops the whole snapshot — which silently stops us syncing from that server.
+ * `typeof x === 'number'` does not begin to cover it, and neither does finiteness:
+ *
+ * - A JSON body cannot carry NaN (`{"a":NaN}` is a syntax error) but it CAN carry Infinity, because the
+ *   number grammar has no range limit and `1e999` parses to it.
+ * - `1e308` is finite, non-negative, and every bit as poisonous — it is not a date any deployment can
+ *   exceed. Finiteness was the wrong test; being a plausible instant is the right one.
+ * - Past 2^53 integer arithmetic silently stops being exact, so `Number.isSafeInteger` is the floor for a
+ *   value we do `Math.max` on. It also rejects fractions, which epoch milliseconds never legitimately are
+ *   — an earlier version of this deliberately allowed them, but the upper bound below makes that leniency
+ *   pointless and a fractional timestamp only ever indicates a malformed server.
  */
 function isUsableTimestamp(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+  return (
+    typeof value === 'number' &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= Date.now() + MAX_TIMESTAMP_CLOCK_SKEW_IN_MS
+  )
 }
 
 // Snapshot metadata comes from untrusted servers; keep only entries with the shape we rely on

--- a/src/client.ts
+++ b/src/client.ts
@@ -135,7 +135,19 @@ export async function* fetchJsonPaginated<T>(
     if (partialHistory.pagination) {
       const nextRelative: unknown = partialHistory.pagination.next
       if (!nextRelative || typeof nextRelative !== 'string') break
-      currentUrl = new URL(nextRelative, currentUrl).toString()
+      const nextUrl = new URL(nextRelative, currentUrl)
+      // `next` is chosen by the remote server, so an absolute URL here would let it steer our
+      // requests at any host it likes — internal addresses and cloud metadata endpoints included —
+      // using this process as the client. Pagination never legitimately leaves the server that
+      // issued it, so anything cross-origin is rejected rather than followed.
+      if (nextUrl.origin !== new URL(currentUrl).origin) {
+        throw new Error(
+          `Refusing to follow a cross-origin pagination link while fetching ${url}: ${nextUrl.origin} does not match ${
+            new URL(currentUrl).origin
+          }`
+        )
+      }
+      currentUrl = nextUrl.toString()
     } else {
       break
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,6 +5,7 @@ import { SnapshotMetadata, SnapshotsFetcherComponents } from './types'
 import {
   contentServerMetricLabels,
   fetchJson,
+  isUsableTimestamp,
   isValidContentHash,
   saveContentFileToDisk as saveContentFile
 } from './utils'
@@ -38,38 +39,6 @@ const MAX_PAGINATION_LINK_LENGTH = 2048
 // snapshots, and the real ceiling on the total is MAX_JSON_RESPONSE_SIZE_IN_BYTES. Chunking the lookup is
 // what would bound the query itself.
 const MAX_REPLACED_SNAPSHOT_HASHES = 1000
-
-// How far ahead of our own clock a remote timestamp may sit. Snapshots describe history that already
-// happened, so anything beyond this is either the server's clock being wrong or a value we should not
-// adopt as sync state.
-const MAX_TIMESTAMP_CLOCK_SKEW_IN_MS = 24 * 60 * 60 * 1000
-
-/**
- * A remote timestamp we are willing to adopt as sync state.
- *
- * These values become a server's high-water mark, and `increaseLastTimestamp` only ever moves it forward,
- * so a single bad one is permanent for the life of the process: the server then polls `/pointer-changes`
- * from a point nothing can ever reach and silently stops syncing.
- *
- * `typeof x === 'number'` does not begin to cover it, and neither does finiteness:
- *
- * - A JSON body cannot carry NaN (`{"a":NaN}` is a syntax error) but it CAN carry Infinity, because the
- *   number grammar has no range limit and `1e999` parses to it.
- * - `1e308` is finite, non-negative, and every bit as poisonous — it is not a date any deployment can
- *   exceed. Finiteness was the wrong test; being a plausible instant is the right one.
- * - Past 2^53 integer arithmetic silently stops being exact, so `Number.isSafeInteger` is the floor for a
- *   value we do `Math.max` on. It also rejects fractions, which epoch milliseconds never legitimately are
- *   — an earlier version of this deliberately allowed them, but the upper bound below makes that leniency
- *   pointless and a fractional timestamp only ever indicates a malformed server.
- */
-function isUsableTimestamp(value: unknown): value is number {
-  return (
-    typeof value === 'number' &&
-    Number.isSafeInteger(value) &&
-    value >= 0 &&
-    value <= Date.now() + MAX_TIMESTAMP_CLOCK_SKEW_IN_MS
-  )
-}
 
 // Snapshot metadata comes from untrusted servers; keep only entries with the shape we rely on
 // (valid content hash + usable time range) so a malformed response can't break downstream logic.

--- a/src/client.ts
+++ b/src/client.ts
@@ -240,6 +240,11 @@ export async function* fetchJsonPaginated<T>(
           `Refusing to follow a pagination link that changes the path while fetching ${url}: ${nextUrl.pathname} does not match ${requestUrl.pathname}`
         )
       }
+      // Fragments are never sent to a server, so two links differing only by `#…` address the same
+      // network resource — but as distinct strings they slipped past the visited-URL check, letting a feed
+      // re-fetch one page up to MAX_PAGES_PER_PAGINATED_CALL times. Cleared rather than rejected: a
+      // fragment is meaningless here rather than malformed, and normalising costs nothing.
+      nextUrl.hash = ''
       currentUrl = nextUrl.toString()
     } else {
       break

--- a/src/client.ts
+++ b/src/client.ts
@@ -175,8 +175,22 @@ export async function* fetchJsonPaginated<T>(
       yield elem
     }
 
-    if (partialHistory.pagination) {
-      const nextRelative: unknown = partialHistory.pagination.next
+    const pagination: unknown = partialHistory.pagination
+    // Absent or null means an unpaginated response, which is a legitimate way for a feed to end.
+    if (pagination !== undefined && pagination !== null) {
+      // A truthy non-object was previously waved through by the `if`: reading `.next` off `true` or
+      // `"more"` yields undefined, which then ended the feed as though the server had said there was
+      // nothing more. Same hazard as a wrong-typed `next` — a container we cannot read must not be read
+      // as an ending — so the shape is checked before the link inside it. An array is not a container
+      // either, despite being typeof 'object'.
+      if (typeof pagination !== 'object' || Array.isArray(pagination)) {
+        throw new Error(
+          `Invalid pagination while fetching ${url}: expected an object, got ${
+            Array.isArray(pagination) ? 'an array' : typeof pagination
+          }`
+        )
+      }
+      const nextRelative: unknown = (pagination as { next?: unknown }).next
       // Absent, null or empty means "no next page", which is how a feed legitimately ends.
       if (nextRelative === undefined || nextRelative === null || nextRelative === '') {
         break

--- a/src/client.ts
+++ b/src/client.ts
@@ -41,11 +41,12 @@ function isValidSnapshotMetadata(snapshot: any): snapshot is SnapshotMetadata {
     typeof snapshot.timeRange.endTimestamp === 'number' &&
     (snapshot.replacedSnapshotHashes === undefined ||
       (Array.isArray(snapshot.replacedSnapshotHashes) &&
-        snapshot.replacedSnapshotHashes.every((hash: any) => isValidContentHash(hash)))) &&
-    // Optional and unused by this package, but a present value must still have the declared type.
-    (snapshot.numberOfEntities === undefined || typeof snapshot.numberOfEntities === 'number') &&
-    (snapshot.generationTimestamp === undefined || typeof snapshot.generationTimestamp === 'number')
+        snapshot.replacedSnapshotHashes.every((hash: any) => isValidContentHash(hash))))
   )
+  // Deliberately NOT validating numberOfEntities / generationTimestamp. Nothing in this package reads
+  // them, so a wrong type cannot hurt us — but rejecting the entry over one would drop the whole
+  // snapshot, and a server that reports `numberOfEntities: "5"` would silently stop being synced from.
+  // Validating a field we never use can only cause harm here.
 }
 
 export async function getSnapshots(

--- a/src/client.ts
+++ b/src/client.ts
@@ -177,7 +177,18 @@ export async function* fetchJsonPaginated<T>(
 
     if (partialHistory.pagination) {
       const nextRelative: unknown = partialHistory.pagination.next
-      if (!nextRelative || typeof nextRelative !== 'string') break
+      // Absent, null or empty means "no next page", which is how a feed legitimately ends.
+      if (nextRelative === undefined || nextRelative === null || nextRelative === '') {
+        break
+      }
+      // Anything else that is not a string is a malformed response, not an ending. Treating it as an
+      // ending made a truncated feed indistinguishable from a complete one, and it was the only
+      // malformed shape here that did not fail: too long, unparseable, cross-origin and path-changing
+      // links all throw. A server that says "there is more" in a way we cannot read should not have that
+      // read as "there is no more".
+      if (typeof nextRelative !== 'string') {
+        throw new Error(`Invalid pagination link while fetching ${url}: expected a string, got ${typeof nextRelative}`)
+      }
       // `next` is remote text: an unparseable value would otherwise surface as an opaque TypeError
       // from the URL constructor, and an enormous one would be retained in visitedUrls for the rest of
       // the call.

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,12 +1,13 @@
 import { PointerChangesSyncDeployment } from '@dcl/schemas'
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import { metricsDefinitions } from './metrics'
-import { SnapshotMetadata, SnapshotsFetcherComponents } from './types'
+import { SnapshotMetadata, SnapshotsFetcherComponents, TransferLimits } from './types'
 import {
   contentServerMetricLabels,
   fetchJson,
   isUsableTimestamp,
   isValidContentHash,
+  resolveTransferLimits,
   truncateForLog,
   saveContentFileToDisk as saveContentFile
 } from './utils'
@@ -19,11 +20,11 @@ const MAX_INVALID_SNAPSHOT_LOGS = 100
 // MAX_PAGES_PER_PAGINATED_CALL is 10,000.
 const MAX_REJECTED_DELTA_LOGS = 100
 
-// Every request this module makes must be bounded. The fetch component applies no default timeout,
-// so without an explicit one a server that accepts the connection and then stops responding leaves
-// the promise pending forever — and a pending promise never reaches the exponential-falloff retry
-// that is supposed to reconnect, so the whole sync stream for that server stalls silently.
-const REQUEST_TIMEOUT_IN_MS = 15_000
+// Every request this module makes must be bounded. The fetch component applies no default timeout, so
+// without an explicit one a server that accepts the connection and then stops responding leaves the
+// promise pending forever — and a pending promise never reaches the exponential-falloff retry that is
+// supposed to reconnect, so the whole sync stream for that server stalls silently. The bound itself is
+// `transferLimits.requestTimeoutInMs`, defaulting to the 15s this module always used.
 
 // Backstop on how many pages a single paginated call will follow. A server that keeps advertising a
 // `next` link makes the loop run forever (measured: ~670 requests/second), which silently pins the
@@ -84,12 +85,18 @@ export type SnapshotsFromServer = {
 export async function getSnapshots(
   components: SnapshotsFetcherComponents,
   server: string,
-  retries: number
+  retries: number,
+  transferLimits?: TransferLimits
 ): Promise<SnapshotsFromServer> {
   const logger = components.logs.getLogger('getSnapshots')
+  const limits = resolveTransferLimits(transferLimits)
   const incrementalSnapshotsUrl = new URL(`${server}/snapshots`).toString()
   const response = await components.downloadQueue.scheduleJobWithRetries(
-    () => fetchJson(incrementalSnapshotsUrl, components.fetcher, { timeout: REQUEST_TIMEOUT_IN_MS }),
+    () =>
+      fetchJson(incrementalSnapshotsUrl, components.fetcher, {
+        timeout: limits.requestTimeoutInMs,
+        transferLimits
+      }),
     retries
   )
 
@@ -130,7 +137,8 @@ export async function* fetchJsonPaginated<T>(
   components: Pick<SnapshotsFetcherComponents, 'fetcher'> & { metrics?: SnapshotsFetcherComponents['metrics'] },
   url: string,
   selector: (responseBody: any) => T[],
-  responseTimeMetric: keyof typeof metricsDefinitions
+  responseTimeMetric: keyof typeof metricsDefinitions,
+  transferLimits?: TransferLimits
 ): AsyncIterable<T> {
   // Perform the different queries
   let currentUrl = url
@@ -151,6 +159,7 @@ export async function* fetchJsonPaginated<T>(
   // already served would otherwise cycle forever; this catches that immediately instead of waiting
   // for the page cap.
   const visitedUrls = new Set<string>()
+  const limits = resolveTransferLimits(transferLimits)
 
   while (currentUrl) {
     if (visitedUrls.has(currentUrl)) {
@@ -165,7 +174,10 @@ export async function* fetchJsonPaginated<T>(
     const { end: stopTimer } = components.metrics?.startTimer(responseTimeMetric) || { end: () => {} }
     let partialHistory: any
     try {
-      partialHistory = await fetchJson(currentUrl, components.fetcher, { timeout: REQUEST_TIMEOUT_IN_MS })
+      partialHistory = await fetchJson(currentUrl, components.fetcher, {
+        timeout: limits.requestTimeoutInMs,
+        transferLimits
+      })
     } finally {
       // Stop the timer even when the request fails, so a failed page can't leak a running timer.
       stopTimer({ ...metricLabels })
@@ -266,7 +278,8 @@ export async function* fetchPointerChanges(
   components: Pick<SnapshotsFetcherComponents, 'fetcher'> & { metrics?: SnapshotsFetcherComponents['metrics'] },
   server: string,
   fromTimestamp: number,
-  logger: ILoggerComponent.ILogger
+  logger: ILoggerComponent.ILogger,
+  transferLimits?: TransferLimits
 ): AsyncIterable<PointerChangesSyncDeployment> {
   const url = new URL(
     `${server}/pointer-changes?sortingOrder=ASC&sortingField=local_timestamp&from=${encodeURIComponent(fromTimestamp)}`
@@ -293,7 +306,8 @@ export async function* fetchPointerChanges(
     components,
     url,
     ($) => $.deltas,
-    'dcl_catalysts_pointer_changes_response_time_seconds'
+    'dcl_catalysts_pointer_changes_response_time_seconds',
+    transferLimits
   )) {
     if (!PointerChangesSyncDeployment.validate(deployment)) {
       reportRejectedDelta('ERROR: Invalid entity deployment from /pointer-changes', () => ({
@@ -327,9 +341,10 @@ export async function saveContentFileToDisk(
   components: Pick<SnapshotsFetcherComponents, 'storage'> & { metrics?: SnapshotsFetcherComponents['metrics'] },
   server: string,
   hash: string,
-  destinationFilename: string
+  destinationFilename: string,
+  transferLimits?: TransferLimits
 ) {
   const url = new URL(`${server}/contents/${hash}`).toString()
 
-  return saveContentFile(components, url, destinationFilename, hash)
+  return saveContentFile(components, url, destinationFilename, hash, true, transferLimits)
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,7 +23,11 @@ const REQUEST_TIMEOUT_IN_MS = 15_000
 // `next` link makes the loop run forever (measured: ~670 requests/second), which silently pins the
 // sync stream on one server. Set far above any legitimate page count so it only ever trips on a
 // server that is broken or hostile.
-const MAX_PAGES_PER_PAGINATED_CALL = 50_000
+// Still far above any legitimate page count (at ~1000 entries per page this is 10M deployments in one
+// poll) but low enough that the visited-URL set stays small even against deliberately long links.
+const MAX_PAGES_PER_PAGINATED_CALL = 10_000
+// Conventional URL length ceiling. Bounds what a server can make us retain per page.
+const MAX_PAGINATION_LINK_LENGTH = 2048
 
 // Snapshot metadata comes from untrusted servers; keep only entries with the shape we rely on
 // (valid content hash + numeric time range) so a malformed response can't break downstream logic.
@@ -135,7 +139,20 @@ export async function* fetchJsonPaginated<T>(
     if (partialHistory.pagination) {
       const nextRelative: unknown = partialHistory.pagination.next
       if (!nextRelative || typeof nextRelative !== 'string') break
-      const nextUrl = new URL(nextRelative, currentUrl)
+      // `next` is remote text: an unparseable value would otherwise surface as an opaque TypeError
+      // from the URL constructor, and an enormous one would be retained in visitedUrls for the rest of
+      // the call.
+      if (nextRelative.length > MAX_PAGINATION_LINK_LENGTH) {
+        throw new Error(
+          `Invalid pagination link while fetching ${url}: longer than ${MAX_PAGINATION_LINK_LENGTH} characters`
+        )
+      }
+      let nextUrl: URL
+      try {
+        nextUrl = new URL(nextRelative, currentUrl)
+      } catch {
+        throw new Error(`Invalid pagination link while fetching ${url}: ${JSON.stringify(nextRelative)}`)
+      }
       // `next` is chosen by the remote server, so an absolute URL here would let it steer our
       // requests at any host it likes — internal addresses and cloud metadata endpoints included —
       // using this process as the client. Pagination never legitimately leaves the server that

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,6 +13,18 @@ import {
 // (the body can be up to MAX_JSON_RESPONSE_SIZE_IN_BYTES) can't flood the logs.
 const MAX_INVALID_SNAPSHOT_LOGS = 100
 
+// Every request this module makes must be bounded. The fetch component applies no default timeout,
+// so without an explicit one a server that accepts the connection and then stops responding leaves
+// the promise pending forever — and a pending promise never reaches the exponential-falloff retry
+// that is supposed to reconnect, so the whole sync stream for that server stalls silently.
+const REQUEST_TIMEOUT_IN_MS = 15_000
+
+// Backstop on how many pages a single paginated call will follow. A server that keeps advertising a
+// `next` link makes the loop run forever (measured: ~670 requests/second), which silently pins the
+// sync stream on one server. Set far above any legitimate page count so it only ever trips on a
+// server that is broken or hostile.
+const MAX_PAGES_PER_PAGINATED_CALL = 50_000
+
 // Snapshot metadata comes from untrusted servers; keep only entries with the shape we rely on
 // (valid content hash + numeric time range) so a malformed response can't break downstream logic.
 function isValidSnapshotMetadata(snapshot: any): snapshot is SnapshotMetadata {
@@ -25,7 +37,10 @@ function isValidSnapshotMetadata(snapshot: any): snapshot is SnapshotMetadata {
     typeof snapshot.timeRange.endTimestamp === 'number' &&
     (snapshot.replacedSnapshotHashes === undefined ||
       (Array.isArray(snapshot.replacedSnapshotHashes) &&
-        snapshot.replacedSnapshotHashes.every((hash: any) => isValidContentHash(hash))))
+        snapshot.replacedSnapshotHashes.every((hash: any) => isValidContentHash(hash)))) &&
+    // Optional and unused by this package, but a present value must still have the declared type.
+    (snapshot.numberOfEntities === undefined || typeof snapshot.numberOfEntities === 'number') &&
+    (snapshot.generationTimestamp === undefined || typeof snapshot.generationTimestamp === 'number')
   )
 }
 
@@ -37,7 +52,7 @@ export async function getSnapshots(
   const logger = components.logs.getLogger('getSnapshots')
   const incrementalSnapshotsUrl = new URL(`${server}/snapshots`).toString()
   const response = await components.downloadQueue.scheduleJobWithRetries(
-    () => fetchJson(incrementalSnapshotsUrl, components.fetcher, { timeout: 15000 }),
+    () => fetchJson(incrementalSnapshotsUrl, components.fetcher, { timeout: REQUEST_TIMEOUT_IN_MS }),
     retries
   )
 
@@ -79,19 +94,47 @@ export async function* fetchJsonPaginated<T>(
 ): AsyncIterable<T> {
   // Perform the different queries
   let currentUrl = url
+  // Every page a paginated call has already fetched. A server that points `next` back at a page it
+  // already served would otherwise cycle forever; this catches that immediately instead of waiting
+  // for the page cap.
+  const visitedUrls = new Set<string>()
+
   while (currentUrl) {
+    if (visitedUrls.has(currentUrl)) {
+      throw new Error(`Pagination loop while fetching ${url}: ${currentUrl} was already fetched`)
+    }
+    if (visitedUrls.size >= MAX_PAGES_PER_PAGINATED_CALL) {
+      throw new Error(`Too many pages while fetching ${url}: stopped after ${MAX_PAGES_PER_PAGINATED_CALL}`)
+    }
+    visitedUrls.add(currentUrl)
+
     const metricLabels = contentServerMetricLabels(currentUrl)
     const { end: stopTimer } = components.metrics?.startTimer(responseTimeMetric) || { end: () => {} }
-    const partialHistory: any = await fetchJson(currentUrl, components.fetcher)
-    stopTimer({ ...metricLabels })
+    let partialHistory: any
+    try {
+      partialHistory = await fetchJson(currentUrl, components.fetcher, { timeout: REQUEST_TIMEOUT_IN_MS })
+    } finally {
+      // Stop the timer even when the request fails, so a failed page can't leak a running timer.
+      stopTimer({ ...metricLabels })
+    }
 
-    for (const elem of selector(partialHistory)) {
+    // The body is remote and untrusted: a bare `null` document, or a page whose element list is not an
+    // array, would otherwise surface as an opaque TypeError from the destructuring below.
+    if (!partialHistory || typeof partialHistory !== 'object') {
+      throw new Error(`Invalid paginated response from ${currentUrl}: expected a JSON object`)
+    }
+    const elements = selector(partialHistory)
+    if (!Array.isArray(elements)) {
+      throw new Error(`Invalid paginated response from ${currentUrl}: expected an array of elements`)
+    }
+
+    for (const elem of elements) {
       yield elem
     }
 
     if (partialHistory.pagination) {
-      const nextRelative: string | void = partialHistory.pagination.next
-      if (!nextRelative) break
+      const nextRelative: unknown = partialHistory.pagination.next
+      if (!nextRelative || typeof nextRelative !== 'string') break
       currentUrl = new URL(nextRelative, currentUrl).toString()
     } else {
       break

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,7 +18,7 @@ import {
 const MAX_INVALID_SNAPSHOT_LOGS = 100
 
 // The same bound for deltas we refuse from /pointer-changes. A server can put one on every page, and
-// MAX_PAGES_PER_PAGINATED_CALL is 10,000.
+// the page cap (transferLimits.maxPagesPerPaginatedCall) is 10,000 by default.
 const MAX_REJECTED_DELTA_LOGS = 100
 
 // Every request this module makes must be bounded. The fetch component applies no default timeout, so
@@ -29,11 +29,10 @@ const MAX_REJECTED_DELTA_LOGS = 100
 
 // Backstop on how many pages a single paginated call will follow. A server that keeps advertising a
 // `next` link makes the loop run forever (measured: ~670 requests/second), which silently pins the
-// sync stream on one server. Set far above any legitimate page count so it only ever trips on a
-// server that is broken or hostile.
-// Still far above any legitimate page count (at ~1000 entries per page this is 10M deployments in one
-// poll) but low enough that the visited-URL set stays small even against deliberately long links.
-const MAX_PAGES_PER_PAGINATED_CALL = 10_000
+// sync stream on one server. The bound is `transferLimits.maxPagesPerPaginatedCall`, defaulting to the
+// 10,000 this module always used: far above any legitimate page count (at ~1000 entries per page that is
+// 10M deployments in one poll) but low enough that the visited-URL set stays small even against
+// deliberately long links. Lower it to cap the amplification one poll can produce more tightly.
 // Conventional URL length ceiling. Bounds what a server can make us retain per page.
 const MAX_PAGINATION_LINK_LENGTH = 2048
 
@@ -168,9 +167,9 @@ export async function* fetchJsonPaginated<T>(
         `Pagination loop while fetching ${sanitizeUrlForLog(url)}: ${sanitizeUrlForLog(currentUrl)} was already fetched`
       )
     }
-    if (visitedUrls.size >= MAX_PAGES_PER_PAGINATED_CALL) {
+    if (visitedUrls.size >= limits.maxPagesPerPaginatedCall) {
       throw new Error(
-        `Too many pages while fetching ${sanitizeUrlForLog(url)}: stopped after ${MAX_PAGES_PER_PAGINATED_CALL}`
+        `Too many pages while fetching ${sanitizeUrlForLog(url)}: stopped after ${limits.maxPagesPerPaginatedCall}`
       )
     }
     visitedUrls.add(currentUrl)
@@ -191,11 +190,11 @@ export async function* fetchJsonPaginated<T>(
     // The body is remote and untrusted: a bare `null` document, or a page whose element list is not an
     // array, would otherwise surface as an opaque TypeError from the destructuring below.
     if (!partialHistory || typeof partialHistory !== 'object') {
-      throw new Error(`Invalid paginated response from ${currentUrl}: expected a JSON object`)
+      throw new Error(`Invalid paginated response from ${sanitizeUrlForLog(currentUrl)}: expected a JSON object`)
     }
     const elements = selector(partialHistory)
     if (!Array.isArray(elements)) {
-      throw new Error(`Invalid paginated response from ${currentUrl}: expected an array of elements`)
+      throw new Error(`Invalid paginated response from ${sanitizeUrlForLog(currentUrl)}: expected an array of elements`)
     }
 
     for (const elem of elements) {
@@ -212,7 +211,7 @@ export async function* fetchJsonPaginated<T>(
       // either, despite being typeof 'object'.
       if (typeof pagination !== 'object' || Array.isArray(pagination)) {
         throw new Error(
-          `Invalid pagination while fetching ${url}: expected an object, got ${
+          `Invalid pagination while fetching ${sanitizeUrlForLog(url)}: expected an object, got ${
             Array.isArray(pagination) ? 'an array' : typeof pagination
           }`
         )
@@ -239,7 +238,9 @@ export async function* fetchJsonPaginated<T>(
       // the call.
       if (nextRelative.length > MAX_PAGINATION_LINK_LENGTH) {
         throw new Error(
-          `Invalid pagination link while fetching ${url}: longer than ${MAX_PAGINATION_LINK_LENGTH} characters`
+          `Invalid pagination link while fetching ${sanitizeUrlForLog(
+            url
+          )}: longer than ${MAX_PAGINATION_LINK_LENGTH} characters`
         )
       }
       let nextUrl: URL
@@ -279,7 +280,7 @@ export async function* fetchJsonPaginated<T>(
       }
       // Fragments are never sent to a server, so two links differing only by `#…` address the same
       // network resource — but as distinct strings they slipped past the visited-URL check, letting a feed
-      // re-fetch one page up to MAX_PAGES_PER_PAGINATED_CALL times. Cleared rather than rejected: a
+      // re-fetch one page up to the page cap. Cleared rather than rejected: a
       // fragment is meaningless here rather than malformed, and normalising costs nothing.
       nextUrl.hash = ''
       currentUrl = nextUrl.toString()

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -232,19 +232,49 @@ const PROCESSED_SNAPSHOT_LOOKUP_CHUNK_SIZE = 1000
  *
  * Serial rather than concurrent on purpose: the point is to bound the load a single pass puts on the
  * consumer's storage, and issuing every chunk at once would keep the peak it is meant to remove.
+ *
+ * @param hashes - Any iterable. Taking an iterable rather than an array is what lets a caller avoid
+ *   materialising its whole input first: a Set can be passed as-is, and nested groups can be walked by a
+ *   generator, so the largest allocation is one chunk. Note that it is consumed lazily *across* the
+ *   awaits below, so pass something that will not be mutated while the lookup runs.
+ *
+ *   Duplicates are not filtered — they only cost slots in a batch, never correctness, and the `Set` of
+ *   everything seen that de-duplication would need is exactly the allocation this signature avoids.
  */
 export async function filterProcessedSnapshotsInChunks(
   components: Pick<SnapshotsFetcherComponents, 'processedSnapshotStorage'>,
-  hashes: string[]
+  hashes: Iterable<string>
 ): Promise<Set<string>> {
   const processed = new Set<string>()
-  for (let start = 0; start < hashes.length; start += PROCESSED_SNAPSHOT_LOOKUP_CHUNK_SIZE) {
-    const chunk = hashes.slice(start, start + PROCESSED_SNAPSHOT_LOOKUP_CHUNK_SIZE)
+  let chunk: string[] = []
+
+  async function lookUpChunk() {
     for (const hash of await components.processedSnapshotStorage.filterProcessedSnapshotsFrom(chunk)) {
       processed.add(hash)
     }
+    chunk = []
+  }
+
+  for (const hash of hashes) {
+    chunk.push(hash)
+    if (chunk.length === PROCESSED_SNAPSHOT_LOOKUP_CHUNK_SIZE) {
+      await lookUpChunk()
+    }
+  }
+  if (chunk.length > 0) {
+    await lookUpChunk()
   }
   return processed
+}
+
+/** Walks a snapshot and its replaced groups without building the flattened array. */
+function* snapshotWithReplacedHashes(snapshotHash: string, replacedSnapshotHashes: string[][]): Generator<string> {
+  yield snapshotHash
+  for (const group of replacedSnapshotHashes) {
+    for (const replacedHash of group) {
+      yield replacedHash
+    }
+  }
 }
 
 export async function shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
@@ -254,10 +284,13 @@ export async function shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded
   greatestEndTimestamp: number,
   replacedSnapshotHashes: string[][]
 ): Promise<boolean> {
-  const processedSnapshots = await filterProcessedSnapshotsInChunks(components, [
-    snapshotHash,
-    ...replacedSnapshotHashes.flat()
-  ])
+  // Walked by a generator rather than flattened into one array first: this helper is exported, so a
+  // direct caller can hand it groups far larger than anything a /snapshots response could produce, and
+  // `.flat()` would pay the whole memory and copy cost before any chunking began.
+  const processedSnapshots = await filterProcessedSnapshotsInChunks(
+    components,
+    snapshotWithReplacedHashes(snapshotHash, replacedSnapshotHashes)
+  )
 
   return decideSnapshotDeploymentFromProcessedSet(
     components,

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -1,4 +1,5 @@
 import { getDeployedEntitiesStreamFromPointerChanges, getDeployedEntitiesStreamFromSnapshot } from '.'
+import { contentServerMetricLabels } from './utils'
 import {
   IDeployerComponent,
   PointerChangesDeployedEntityStreamOptions,
@@ -21,6 +22,7 @@ export async function deployEntitiesFromPointerChanges(
   increaseLastTimestamp: (contentServer: string, ...newTimestamps: number[]) => void
 ) {
   const logger = components.logs.getLogger('deployEntitiesFromPointerChanges')
+  const metricsLabels = contentServerMetricLabels(contentServer)
   // The predicate goes into the stream too: checking it only in the loop below cannot end a polling
   // stream whose latest poll returned no deployments at all.
   const deployments = getDeployedEntitiesStreamFromPointerChanges(components, options, contentServer, shouldStopStream)
@@ -36,7 +38,10 @@ export async function deployEntitiesFromPointerChanges(
       {
         ...deployment,
         markAsDeployed: async function () {
-          components.metrics.increment('dcl_entities_deployments_processed_total', { source: 'pointer-changes' })
+          components.metrics.increment('dcl_entities_deployments_processed_total', {
+            ...metricsLabels,
+            source: 'pointer-changes'
+          })
           // update greatest processed timestamp
           increaseLastTimestamp(contentServer, deployment.localTimestamp)
         }
@@ -97,7 +102,11 @@ export async function deployEntitiesFromSnapshot(
       {
         ...entity,
         markAsDeployed: async function () {
-          components.metrics.increment('dcl_entities_deployments_processed_total', { source: 'snapshots' })
+          // Empty remote_server, matching the streamed counter: a snapshot has no single origin.
+          components.metrics.increment('dcl_entities_deployments_processed_total', {
+            remote_server: '',
+            source: 'snapshots'
+          })
           numberOfProcessedEntities++
           await saveIfStreamEndedAndAllEntitiesWereProcessed()
         },

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -70,10 +70,20 @@ export async function deployEntitiesFromPointerChanges(
     if (report) {
       report.scheduled++
     }
+    // Idempotent per scheduled deployment. The counts are what decide whether progress is safe to
+    // record, so they have to count *entities acknowledged*, not calls: a deployer that invoked this
+    // twice for one entity would otherwise have the second call cover for an entity that was never
+    // acknowledged at all, making acknowledged === scheduled with a hole in the middle. It would also
+    // double-count the processed metric.
+    let alreadyAcknowledged = false
     await components.deployer.scheduleEntityDeployment(
       {
         ...deployment,
         markAsDeployed: async function () {
+          if (alreadyAcknowledged) {
+            return
+          }
+          alreadyAcknowledged = true
           components.metrics.increment('dcl_entities_deployments_processed_total', {
             ...metricsLabels,
             source: 'pointer-changes'
@@ -128,8 +138,12 @@ export async function deployEntitiesFromSnapshot(
   let numberOfProcessedEntities = 0
   let snapshotWasMarkedAsProcessed = false
   async function saveIfStreamEndedAndAllEntitiesWereProcessed() {
-    // >= (not ===) so an extra markAsDeployed call can't leave the snapshot unmarked forever; the
-    // flag (set synchronously before any await) ensures we still mark only once.
+    // markAsDeployed is idempotent per entity (below), so numberOfProcessedEntities counts entities
+    // acknowledged rather than calls received and can never run ahead of numberOfStreamedEntities. That
+    // is what makes this comparison mean "all of them": it previously used >= to tolerate a duplicate
+    // call, which is precisely how a duplicate could cover for an entity that never deployed and get the
+    // snapshot marked processed with a hole in it. >= is kept only as a belt-and-braces guard against
+    // ever being left unmarked; the flag (set synchronously before any await) still marks only once.
     if (
       !snapshotWasMarkedAsProcessed &&
       snapshotWasCompletelyStreamed &&
@@ -150,10 +164,18 @@ export async function deployEntitiesFromSnapshot(
     // schedule the deployment in the deployer. the await DOES NOT mean that the entity was deployed entirely
     // if the deployer is not synchronous. For example, the batchDeployer used in the catalyst just add it in a queue.
     // Once the entity is truly deployed, it should call the method 'markAsDeployed'
+    // Idempotent per scheduled entity, for the same reason as the pointer-changes path: the count is
+    // what decides whether the snapshot is complete, so a second call for one entity must not stand in
+    // for an entity that was never acknowledged.
+    let alreadyAcknowledged = false
     await components.deployer.scheduleEntityDeployment(
       {
         ...entity,
         markAsDeployed: async function () {
+          if (alreadyAcknowledged) {
+            return
+          }
+          alreadyAcknowledged = true
           // Empty remote_server, matching the streamed counter: a snapshot has no single origin.
           components.metrics.increment('dcl_entities_deployments_processed_total', {
             remote_server: '',

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -1,4 +1,5 @@
 import { getDeployedEntitiesStreamFromPointerChanges, getDeployedEntitiesStreamFromSnapshot } from '.'
+import { SnapshotStreamReport } from './file-processor'
 import { contentServerMetricLabels } from './utils'
 import {
   IDeployerComponent,
@@ -71,7 +72,19 @@ export async function deployEntitiesFromSnapshot(
   const logger = components.logs.getLogger('deployEntitiesFromSnapshot')
   // Passed down so the snapshot download abandons its retry ladder on shutdown rather than making
   // whoever called stop() wait it out.
-  const stream = getDeployedEntitiesStreamFromSnapshot(components, options, snapshotHash, servers, shouldStopStream)
+  // Lines the parser could not turn into deployments. Marking a snapshot as processed retires it
+  // permanently, so it must only happen when the whole file was actually read: a truncated line or a
+  // batch of schema-invalid entities otherwise ends the stream normally and looks identical to an
+  // empty snapshot, silently dropping every entity behind those lines.
+  const streamReport: SnapshotStreamReport = { unusableLines: 0 }
+  const stream = getDeployedEntitiesStreamFromSnapshot(
+    components,
+    options,
+    snapshotHash,
+    servers,
+    shouldStopStream,
+    streamReport
+  )
   let snapshotWasCompletelyStreamed = false
   let numberOfStreamedEntities = 0
   let numberOfProcessedEntities = 0
@@ -82,6 +95,7 @@ export async function deployEntitiesFromSnapshot(
     if (
       !snapshotWasMarkedAsProcessed &&
       snapshotWasCompletelyStreamed &&
+      streamReport.unusableLines === 0 &&
       numberOfProcessedEntities >= numberOfStreamedEntities
     ) {
       snapshotWasMarkedAsProcessed = true
@@ -118,6 +132,16 @@ export async function deployEntitiesFromSnapshot(
   snapshotWasCompletelyStreamed = true
   components.metrics.increment('dcl_processed_snapshots_total', { state: 'stream_end' })
   logger.info('Stream ended.', { snapshotHash })
+  if (streamReport.unusableLines > 0) {
+    // Deliberately left unmarked so a later sync re-downloads and re-streams it. That costs a repeated
+    // pass per sync cycle for a snapshot the server keeps serving broken, which is the cheaper of the
+    // two failure modes: marking it would drop those entities for good, with nothing to retry.
+    components.metrics.increment('dcl_processed_snapshots_total', { state: 'incomplete' })
+    logger.error('Snapshot had lines that could not be read as deployments; leaving it unprocessed to retry later.', {
+      snapshotHash,
+      unusableLines: String(streamReport.unusableLines)
+    })
+  }
   await saveIfStreamEndedAndAllEntitiesWereProcessed()
 }
 

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -29,6 +29,9 @@ export type PointerChangesDeploymentReport = {
  *
  * @param report - Optional tally of scheduled versus acknowledged deployments. Callers that record sync
  *   progress from this run must pass one and require `acknowledged >= scheduled` before doing so.
+ * @param onPollEnd - Awaited at the end of every poll, before the next one begins. For a polling stream
+ *   this is the only checkpoint there is, so it is where a caller settles its deployer and decides what
+ *   progress is safe to record.
  * @public
  */
 export async function deployEntitiesFromPointerChanges(
@@ -39,13 +42,20 @@ export async function deployEntitiesFromPointerChanges(
   contentServer: string,
   shouldStopStream: () => boolean,
   increaseLastTimestamp: (contentServer: string, ...newTimestamps: number[]) => void,
-  report?: PointerChangesDeploymentReport
+  report?: PointerChangesDeploymentReport,
+  onPollEnd?: () => Promise<void>
 ) {
   const logger = components.logs.getLogger('deployEntitiesFromPointerChanges')
   const metricsLabels = contentServerMetricLabels(contentServer)
   // The predicate goes into the stream too: checking it only in the loop below cannot end a polling
   // stream whose latest poll returned no deployments at all.
-  const deployments = getDeployedEntitiesStreamFromPointerChanges(components, options, contentServer, shouldStopStream)
+  const deployments = getDeployedEntitiesStreamFromPointerChanges(
+    components,
+    options,
+    contentServer,
+    shouldStopStream,
+    onPollEnd
+  )
 
   for await (const deployment of deployments) {
     // if the stream is closed then we should not process more deployments

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -64,7 +64,9 @@ export async function deployEntitiesFromSnapshot(
   shouldStopStream: () => boolean
 ) {
   const logger = components.logs.getLogger('deployEntitiesFromSnapshot')
-  const stream = getDeployedEntitiesStreamFromSnapshot(components, options, snapshotHash, servers)
+  // Passed down so the snapshot download abandons its retry ladder on shutdown rather than making
+  // whoever called stop() wait it out.
+  const stream = getDeployedEntitiesStreamFromSnapshot(components, options, snapshotHash, servers, shouldStopStream)
   let snapshotWasCompletelyStreamed = false
   let numberOfStreamedEntities = 0
   let numberOfProcessedEntities = 0

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -21,7 +21,9 @@ export async function deployEntitiesFromPointerChanges(
   increaseLastTimestamp: (contentServer: string, ...newTimestamps: number[]) => void
 ) {
   const logger = components.logs.getLogger('deployEntitiesFromPointerChanges')
-  const deployments = getDeployedEntitiesStreamFromPointerChanges(components, options, contentServer)
+  // The predicate goes into the stream too: checking it only in the loop below cannot end a polling
+  // stream whose latest poll returned no deployments at all.
+  const deployments = getDeployedEntitiesStreamFromPointerChanges(components, options, contentServer, shouldStopStream)
 
   for await (const deployment of deployments) {
     // if the stream is closed then we should not process more deployments
@@ -115,10 +117,7 @@ export async function deployEntitiesFromSnapshot(
  * @public
  */
 export async function shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
-  components: Pick<
-    SnapshotsFetcherComponents,
-    'processedSnapshotStorage' | 'snapshotStorage' | 'metrics' | 'logs' | 'storage'
-  >,
+  components: Pick<SnapshotsFetcherComponents, 'processedSnapshotStorage' | 'snapshotStorage'>,
   genesisTimestamp: number,
   snapshotHash: string,
   greatestEndTimestamp: number,

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -9,8 +9,26 @@ import {
 } from './types'
 
 /**
+ * What a pointer-changes run handed to the deployer, against what the deployer confirmed.
+ *
+ * `deployer.onIdle()` proves the deployer's queue drained, not that every entity in it reported back
+ * through `markAsDeployed`. The two counts are how a caller tells those apart: because the resume point
+ * is a maximum over acknowledged timestamps, a deployer that drops an entity at t=100 and confirms one
+ * at t=200 leaves a mark past the dropped one. Only a caller that knows the run was incomplete can
+ * refuse to adopt that mark.
+ * @public
+ */
+export type PointerChangesDeploymentReport = {
+  scheduled: number
+  acknowledged: number
+}
+
+/**
  * This function streams and deploys the entities of pointer-changes of a server. It calls 'increaseLastTimestamp'
  * for each entity deployed.
+ *
+ * @param report - Optional tally of scheduled versus acknowledged deployments. Callers that record sync
+ *   progress from this run must pass one and require `acknowledged >= scheduled` before doing so.
  * @public
  */
 export async function deployEntitiesFromPointerChanges(
@@ -20,7 +38,8 @@ export async function deployEntitiesFromPointerChanges(
   options: PointerChangesDeployedEntityStreamOptions,
   contentServer: string,
   shouldStopStream: () => boolean,
-  increaseLastTimestamp: (contentServer: string, ...newTimestamps: number[]) => void
+  increaseLastTimestamp: (contentServer: string, ...newTimestamps: number[]) => void,
+  report?: PointerChangesDeploymentReport
 ) {
   const logger = components.logs.getLogger('deployEntitiesFromPointerChanges')
   const metricsLabels = contentServerMetricLabels(contentServer)
@@ -35,6 +54,12 @@ export async function deployEntitiesFromPointerChanges(
       return
     }
 
+    // Counted before the await, not after: a synchronous deployer calls markAsDeployed from inside
+    // scheduleEntityDeployment, so incrementing afterwards would let acknowledged briefly exceed
+    // scheduled and make an incomplete run look complete.
+    if (report) {
+      report.scheduled++
+    }
     await components.deployer.scheduleEntityDeployment(
       {
         ...deployment,
@@ -43,6 +68,9 @@ export async function deployEntitiesFromPointerChanges(
             ...metricsLabels,
             source: 'pointer-changes'
           })
+          if (report) {
+            report.acknowledged++
+          }
           // update greatest processed timestamp
           increaseLastTimestamp(contentServer, deployment.localTimestamp)
         }

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -177,6 +177,12 @@ export async function shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded
  * Same decision as shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded, but operating on an
  * already-fetched set of processed snapshot hashes. This lets a caller batch the (potentially
  * expensive) filterProcessedSnapshotsFrom lookup for many snapshots into a single storage call.
+ *
+ * @param processedSnapshots - Hashes already known to be processed. **Mutated**: when this call marks
+ *   `snapshotHash` as processed, it is added here so the set keeps describing storage. A caller reusing
+ *   one set across decisions must also re-run those that came back `true`, since a mark can make a
+ *   snapshot that replaces the marked one skippable in turn — see the fixed-point loop in
+ *   `syncFromSnapshots`.
  */
 export async function decideSnapshotDeploymentFromProcessedSet(
   components: Pick<SnapshotsFetcherComponents, 'processedSnapshotStorage' | 'snapshotStorage'>,
@@ -197,6 +203,10 @@ export async function decideSnapshotDeploymentFromProcessedSet(
       return greatestEndTimestamp > genesisTimestamp && !(await components.snapshotStorage.has(snapshotHash))
     } else {
       await components.processedSnapshotStorage.markSnapshotAsProcessed(snapshotHash)
+      // Record it in the caller's set too. A batching caller reuses one set across many decisions, and
+      // a snapshot marked here is exactly what makes the snapshot that REPLACES it skippable; leaving
+      // the set stale meant the next link in a replacement chain was deployed for nothing.
+      processedSnapshots.add(snapshotHash)
     }
   }
   return false

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -215,6 +215,38 @@ export async function deployEntitiesFromSnapshot(
  * of the replaced ones.
  * @public
  */
+// Hashes per processed-snapshots lookup. The aggregate list is not bounded by anything this package
+// controls: individual entries cap their replacedSnapshotHashes, but a /snapshots response can carry as
+// many entries as fits the 50 MiB body limit — roughly 845,000 hashes — and the synchronizer batches
+// every server's entries into one list before looking them up. One oversized `IN` clause is worse than
+// slow: Postgres refuses a statement with more than 65,535 bind parameters, so a single server
+// advertising enough hashes could make the lookup throw for the whole decision pass, and with it the
+// sync from every well-behaved server in the same pass.
+//
+// 1000 is far under any such limit while keeping the number of round trips small for realistic
+// responses, where the whole list fits in one chunk.
+const PROCESSED_SNAPSHOT_LOOKUP_CHUNK_SIZE = 1000
+
+/**
+ * Looks up processed snapshots in bounded batches, merging the results.
+ *
+ * Serial rather than concurrent on purpose: the point is to bound the load a single pass puts on the
+ * consumer's storage, and issuing every chunk at once would keep the peak it is meant to remove.
+ */
+export async function filterProcessedSnapshotsInChunks(
+  components: Pick<SnapshotsFetcherComponents, 'processedSnapshotStorage'>,
+  hashes: string[]
+): Promise<Set<string>> {
+  const processed = new Set<string>()
+  for (let start = 0; start < hashes.length; start += PROCESSED_SNAPSHOT_LOOKUP_CHUNK_SIZE) {
+    const chunk = hashes.slice(start, start + PROCESSED_SNAPSHOT_LOOKUP_CHUNK_SIZE)
+    for (const hash of await components.processedSnapshotStorage.filterProcessedSnapshotsFrom(chunk)) {
+      processed.add(hash)
+    }
+  }
+  return processed
+}
+
 export async function shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
   components: Pick<SnapshotsFetcherComponents, 'processedSnapshotStorage' | 'snapshotStorage'>,
   genesisTimestamp: number,
@@ -222,7 +254,7 @@ export async function shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded
   greatestEndTimestamp: number,
   replacedSnapshotHashes: string[][]
 ): Promise<boolean> {
-  const processedSnapshots = await components.processedSnapshotStorage.filterProcessedSnapshotsFrom([
+  const processedSnapshots = await filterProcessedSnapshotsInChunks(components, [
     snapshotHash,
     ...replacedSnapshotHashes.flat()
   ])
@@ -240,7 +272,8 @@ export async function shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded
 /**
  * Same decision as shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded, but operating on an
  * already-fetched set of processed snapshot hashes. This lets a caller batch the (potentially
- * expensive) filterProcessedSnapshotsFrom lookup for many snapshots into a single storage call.
+ * expensive) processed-snapshots lookup for many snapshots into as few storage calls as
+ * {@link filterProcessedSnapshotsInChunks} needs, rather than one per decision.
  *
  * @param processedSnapshots - Hashes already known to be processed. **Mutated**: when this call marks
  *   `snapshotHash` as processed, it is added here so the set keeps describing storage. A caller reusing

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -137,10 +137,14 @@ export async function deployEntitiesFromSnapshot(
     // pass per sync cycle for a snapshot the server keeps serving broken, which is the cheaper of the
     // two failure modes: marking it would drop those entities for good, with nothing to retry.
     components.metrics.increment('dcl_processed_snapshots_total', { state: 'incomplete' })
-    logger.error('Snapshot had lines that could not be read as deployments; leaving it unprocessed to retry later.', {
-      snapshotHash,
-      unusableLines: String(streamReport.unusableLines)
-    })
+    // Thrown rather than only logged. The caller treats a rejection as "this server's bootstrap is
+    // incomplete", which is what holds its last-entity timestamp back and keeps it in snapshot
+    // bootstrap. Returning normally left the snapshot unmarked — so it would be retried — but still let
+    // the servers advertising it advance past the range it covers and move on to pointer-changes,
+    // skipping the very entities leaving it unmarked was meant to preserve.
+    throw new Error(
+      `Snapshot ${snapshotHash} had ${streamReport.unusableLines} line(s) that could not be read as deployments; leaving it unprocessed to retry later.`
+    )
   }
   await saveIfStreamEndedAndAllEntitiesWereProcessed()
 }

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -131,14 +131,24 @@ export async function downloadFileWithRetries(
   const finalFileName = path.resolve(targetTempFolder, hashToDownload)
   const inflightForStorage = inflightJobsFor(components.storage)
 
-  const inflightJob = inflightForStorage.get(hashToDownload)
-  if (inflightJob) {
+  // Joining loop, not a single check. When a shared job fails, every waiter wakes at once — and if each
+  // simply fell through to start its own, N waiters would start N parallel transfers of the same hash and
+  // clobber each other's map entry. Re-reading after the failure lets all but the first join the
+  // replacement instead. Bounded by the loop condition: a caller only keeps going while it finds a
+  // *different* job than the one it just watched fail.
+  let alreadyWatched: ReturnType<typeof downloadFileWithRetries> | undefined
+  for (;;) {
+    const inflightJob = inflightForStorage.get(hashToDownload)
+    if (!inflightJob || inflightJob === alreadyWatched) {
+      break
+    }
     try {
       return await inflightJob
     } catch {
       // The shared job failed against *its* candidate servers. This caller may have been given a
-      // different set, so fall through and make its own attempt instead of inheriting a failure it
-      // might not have suffered.
+      // different set, so it does not inherit a failure it might not have suffered — but if some other
+      // waiter has already registered a replacement, join that rather than adding another transfer.
+      alreadyWatched = inflightJob
     }
   }
 

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -39,6 +39,8 @@ async function downloadJob(
   maxRetries: number,
   waitTimeBetweenRetries: number,
   shouldStop?: () => boolean,
+  /** Bounds for this transfer. **Shared, not per-caller, when a download is already in flight** — see the
+   * de-duplication note below. */
   transferLimits?: TransferLimits
 ): Promise<void> {
   if (shouldStop?.()) {
@@ -128,6 +130,8 @@ export async function downloadFileWithRetries(
   /** Consulted before the first attempt and between retries, so a shutdown does not have to wait out
    * the whole retry ladder. */
   shouldStop?: () => boolean,
+  /** Bounds for this transfer. **Shared, not per-caller, when a download is already in flight** — see the
+   * de-duplication note below. */
   transferLimits?: TransferLimits
 ): Promise<void> {
   // Reject untrusted hashes that are not plain content addresses before using them to build a
@@ -146,6 +150,14 @@ export async function downloadFileWithRetries(
   // clobber each other's map entry. Re-reading after the failure lets all but the first join the
   // replacement instead. Bounded by the loop condition: a caller only keeps going while it finds a
   // *different* job than the one it just watched fail.
+  // Keyed by hash alone, deliberately not by the resolved transferLimits: a caller that joins an
+  // in-flight download inherits the bounds of the caller that started it. Keying on limits too would give
+  // callers with differing bounds a transfer each, which is real duplicated bandwidth to reach a byte-
+  // identical result — the hash is a content address, so both transfers produce the same file, and the
+  // file lands in the same shared storage whichever caller asked for it. Bounds are policy about how much
+  // to tolerate from a peer, not a property of the content, and the bounds that actually governed the
+  // bytes on the wire are the first caller's. In synchronizer usage every caller threads the same options
+  // object, so this only arises for direct callers of the public download helpers.
   let alreadyWatched: ReturnType<typeof downloadFileWithRetries> | undefined
   for (;;) {
     const inflightJob = inflightForStorage.get(hashToDownload)

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,7 +1,13 @@
 import * as path from 'path'
 import { saveContentFileToDisk } from './client'
 import { SnapshotsFetcherComponents } from './types'
-import { isValidContentHash, isVerifiableContentHash, pickRandomServer, sleepUnlessStopped } from './utils'
+import {
+  isValidContentHash,
+  isVerifiableContentHash,
+  pickRandomServer,
+  sleepUnlessStopped,
+  truncateForLog
+} from './utils'
 
 // In-flight downloads, per storage component and then per content hash.
 //
@@ -125,7 +131,9 @@ export async function downloadFileWithRetries(
   // Reject untrusted hashes that are not plain content addresses before using them to build a
   // filesystem path. Without this, a value like "../../etc/x" would escape targetTempFolder.
   if (!isValidContentHash(hashToDownload)) {
-    throw new Error(`Invalid content hash: ${JSON.stringify(hashToDownload)}`)
+    // Truncated: this is the path where the hash failed validation, so its length is the server's
+    // choice, not ours — the bounded shapes are only guaranteed after this check passes.
+    throw new Error(`Invalid content hash: ${truncateForLog(String(JSON.stringify(hashToDownload)))}`)
   }
 
   const finalFileName = path.resolve(targetTempFolder, hashToDownload)

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -3,10 +3,27 @@ import { saveContentFileToDisk } from './client'
 import { SnapshotsFetcherComponents } from './types'
 import { isValidContentHash, pickRandomServer, sleep } from './utils'
 
-// Keyed by content hash, not by the resolved temp path: storage is content-addressed, so two callers
-// asking for the same hash into different targetTempFolders are the same download and must share one
-// job. Keying by path let them run concurrently, duplicating the transfer.
-const downloadFileJobsMap = new Map<string, ReturnType<typeof downloadFileWithRetries>>()
+// In-flight downloads, per storage component and then per content hash.
+//
+// Keyed by hash rather than by the resolved temp path because storage is content-addressed: two
+// callers asking for the same hash into different targetTempFolders are the same download and should
+// share one job (keying by path let them run concurrently and duplicate the transfer).
+//
+// Scoped *per storage component* because sharing is only sound when both callers end up with the
+// file. A job stores into the storage of whoever started it, so two callers holding different storage
+// instances must not share: the joiner would be told the download succeeded while its own storage
+// stayed empty. A WeakMap so a discarded storage component takes its entry with it.
+const inflightDownloadsByStorage = new WeakMap<object, Map<string, ReturnType<typeof downloadFileWithRetries>>>()
+
+function inflightJobsFor(storage: object): Map<string, ReturnType<typeof downloadFileWithRetries>> {
+  const existing = inflightDownloadsByStorage.get(storage)
+  if (existing) {
+    return existing
+  }
+  const created = new Map<string, ReturnType<typeof downloadFileWithRetries>>()
+  inflightDownloadsByStorage.set(storage, created)
+  return created
+}
 
 async function downloadJob(
   components: Pick<SnapshotsFetcherComponents, 'storage'> & { metrics?: SnapshotsFetcherComponents['metrics'] },
@@ -77,10 +94,17 @@ export async function downloadFileWithRetries(
   }
 
   const finalFileName = path.resolve(targetTempFolder, hashToDownload)
+  const inflightForStorage = inflightJobsFor(components.storage)
 
-  const inflightJob = downloadFileJobsMap.get(hashToDownload)
+  const inflightJob = inflightForStorage.get(hashToDownload)
   if (inflightJob) {
-    return inflightJob
+    try {
+      return await inflightJob
+    } catch {
+      // The shared job failed against *its* candidate servers. This caller may have been given a
+      // different set, so fall through and make its own attempt instead of inheriting a failure it
+      // might not have suffered.
+    }
   }
 
   try {
@@ -92,11 +116,13 @@ export async function downloadFileWithRetries(
       maxRetries,
       waitTimeBetweenRetries
     )
-    downloadFileJobsMap.set(hashToDownload, downloadWithRetriesJob)
+    inflightForStorage.set(hashToDownload, downloadWithRetriesJob)
 
     await downloadWithRetriesJob
     return
   } finally {
-    downloadFileJobsMap.delete(hashToDownload)
+    if (inflightForStorage.get(hashToDownload) !== undefined) {
+      inflightForStorage.delete(hashToDownload)
+    }
   }
 }

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 import { saveContentFileToDisk } from './client'
-import { SnapshotsFetcherComponents } from './types'
+import { SnapshotsFetcherComponents, TransferLimits } from './types'
 import {
   isValidContentHash,
   isVerifiableContentHash,
@@ -38,7 +38,8 @@ async function downloadJob(
   presentInServers: string[],
   maxRetries: number,
   waitTimeBetweenRetries: number,
-  shouldStop?: () => boolean
+  shouldStop?: () => boolean,
+  transferLimits?: TransferLimits
 ): Promise<void> {
   if (shouldStop?.()) {
     throw new Error(`Not downloading ${hashToDownload}: the caller asked to stop`)
@@ -81,7 +82,7 @@ async function downloadJob(
 
     const serverToUse = pickRandomServer(serversToPickFrom)
     try {
-      await saveContentFileToDisk(components, serverToUse, hashToDownload, finalFileName)
+      await saveContentFileToDisk(components, serverToUse, hashToDownload, finalFileName, transferLimits)
       components.metrics?.observe('dcl_content_download_job_succeed_retries', {}, retries)
 
       return
@@ -126,7 +127,8 @@ export async function downloadFileWithRetries(
   waitTimeBetweenRetries: number,
   /** Consulted before the first attempt and between retries, so a shutdown does not have to wait out
    * the whole retry ladder. */
-  shouldStop?: () => boolean
+  shouldStop?: () => boolean,
+  transferLimits?: TransferLimits
 ): Promise<void> {
   // Reject untrusted hashes that are not plain content addresses before using them to build a
   // filesystem path. Without this, a value like "../../etc/x" would escape targetTempFolder.
@@ -167,7 +169,8 @@ export async function downloadFileWithRetries(
     presentInServers,
     maxRetries,
     waitTimeBetweenRetries,
-    shouldStop
+    shouldStop,
+    transferLimits
   )
   inflightForStorage.set(hashToDownload, downloadWithRetriesJob)
 

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,9 +1,12 @@
 import * as path from 'path'
 import { saveContentFileToDisk } from './client'
-import { Path, SnapshotsFetcherComponents } from './types'
+import { SnapshotsFetcherComponents } from './types'
 import { isValidContentHash, pickRandomServer, sleep } from './utils'
 
-const downloadFileJobsMap = new Map<Path, ReturnType<typeof downloadFileWithRetries>>()
+// Keyed by content hash, not by the resolved temp path: storage is content-addressed, so two callers
+// asking for the same hash into different targetTempFolders are the same download and must share one
+// job. Keying by path let them run concurrently, duplicating the transfer.
+const downloadFileJobsMap = new Map<string, ReturnType<typeof downloadFileWithRetries>>()
 
 async function downloadJob(
   components: Pick<SnapshotsFetcherComponents, 'storage'> & { metrics?: SnapshotsFetcherComponents['metrics'] },
@@ -24,9 +27,18 @@ async function downloadJob(
 
   for (;;) {
     retries++
+    // Re-check the store only from the second attempt onwards. On the first one nothing is awaited
+    // between here and the check above, so it can never see a different answer — and for a remote
+    // (e.g. S3-backed) storage component that redundant call is a second network round trip on every
+    // single content file. From a retry it is worth paying: another process writing to the same
+    // content-addressed storage may have stored the file while this job was failing.
+    if (retries > 1 && (await components.storage.exist(hashToDownload))) {
+      return
+    }
+
     const serverToUse = pickRandomServer(serversToPickFrom)
     try {
-      await downloadContentFile(components, hashToDownload, finalFileName, serverToUse)
+      await saveContentFileToDisk(components, serverToUse, hashToDownload, finalFileName)
       components.metrics?.observe('dcl_content_download_job_succeed_retries', {}, retries)
 
       return
@@ -66,8 +78,9 @@ export async function downloadFileWithRetries(
 
   const finalFileName = path.resolve(targetTempFolder, hashToDownload)
 
-  if (downloadFileJobsMap.has(finalFileName)) {
-    return downloadFileJobsMap.get(finalFileName)!
+  const inflightJob = downloadFileJobsMap.get(hashToDownload)
+  if (inflightJob) {
+    return inflightJob
   }
 
   try {
@@ -79,24 +92,11 @@ export async function downloadFileWithRetries(
       maxRetries,
       waitTimeBetweenRetries
     )
-    downloadFileJobsMap.set(finalFileName, downloadWithRetriesJob)
+    downloadFileJobsMap.set(hashToDownload, downloadWithRetriesJob)
 
     await downloadWithRetriesJob
     return
   } finally {
-    downloadFileJobsMap.delete(finalFileName)
-  }
-}
-
-async function downloadContentFile(
-  components: Pick<SnapshotsFetcherComponents, 'storage'> & { metrics?: SnapshotsFetcherComponents['metrics'] },
-  hash: string,
-  finalFileName: string,
-  serverToUse: string
-): Promise<void> {
-  // Storage is keyed by content hash, not by the filesystem path. Checking the hash lets a
-  // concurrent download that targets a different folder short-circuit this one.
-  if (!(await components.storage.exist(hash))) {
-    return saveContentFileToDisk(components, serverToUse, hash, finalFileName)
+    downloadFileJobsMap.delete(hashToDownload)
   }
 }

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -31,8 +31,13 @@ async function downloadJob(
   finalFileName: string,
   presentInServers: string[],
   maxRetries: number,
-  waitTimeBetweenRetries: number
+  waitTimeBetweenRetries: number,
+  shouldStop?: () => boolean
 ): Promise<void> {
+  if (shouldStop?.()) {
+    throw new Error(`Not downloading ${hashToDownload}: the caller asked to stop`)
+  }
+
   // cancel early if the file is already downloaded
   if (await components.storage.exist(hashToDownload)) return
 
@@ -60,6 +65,12 @@ async function downloadJob(
 
       return
     } catch (e: any) {
+      // Give up the remaining attempts once the caller is shutting down. Without this the ladder runs
+      // to completion — maxRetries multiplied by the per-download inactivity timeout — while whoever
+      // called stop() waits for this job to return.
+      if (shouldStop?.()) {
+        throw e
+      }
       if (retries < maxRetries) {
         serversToPickFrom =
           serversToPickFrom.length > 1
@@ -85,7 +96,10 @@ export async function downloadFileWithRetries(
   presentInServers: string[],
   _serverMapLRU: Map<string, number>,
   maxRetries: number,
-  waitTimeBetweenRetries: number
+  waitTimeBetweenRetries: number,
+  /** Consulted before the first attempt and between retries, so a shutdown does not have to wait out
+   * the whole retry ladder. */
+  shouldStop?: () => boolean
 ): Promise<void> {
   // Reject untrusted hashes that are not plain content addresses before using them to build a
   // filesystem path. Without this, a value like "../../etc/x" would escape targetTempFolder.
@@ -107,21 +121,25 @@ export async function downloadFileWithRetries(
     }
   }
 
-  try {
-    const downloadWithRetriesJob = downloadJob(
-      components,
-      hashToDownload,
-      finalFileName,
-      presentInServers,
-      maxRetries,
-      waitTimeBetweenRetries
-    )
-    inflightForStorage.set(hashToDownload, downloadWithRetriesJob)
+  const downloadWithRetriesJob = downloadJob(
+    components,
+    hashToDownload,
+    finalFileName,
+    presentInServers,
+    maxRetries,
+    waitTimeBetweenRetries,
+    shouldStop
+  )
+  inflightForStorage.set(hashToDownload, downloadWithRetriesJob)
 
+  try {
     await downloadWithRetriesJob
     return
   } finally {
-    if (inflightForStorage.get(hashToDownload) !== undefined) {
+    // Only clear our own entry. Since a caller whose shared job rejected falls through and registers
+    // a replacement, the slot may already hold someone else's in-flight job — evicting that would
+    // un-deduplicate it and let the next caller start a second transfer of the same file.
+    if (inflightForStorage.get(hashToDownload) === downloadWithRetriesJob) {
       inflightForStorage.delete(hashToDownload)
     }
   }

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import { saveContentFileToDisk } from './client'
 import { SnapshotsFetcherComponents } from './types'
-import { isValidContentHash, pickRandomServer, sleep } from './utils'
+import { isValidContentHash, pickRandomServer, sleepUnlessStopped } from './utils'
 
 // In-flight downloads, per storage component and then per content hash.
 //
@@ -76,7 +76,13 @@ async function downloadJob(
           serversToPickFrom.length > 1
             ? serversToPickFrom.filter((server) => server !== serverToUse)
             : serversToPickFrom
-        await sleep(waitTimeBetweenRetries)
+        // Interruptible, and re-checked afterwards: a stop that lands during the backoff would
+        // otherwise fall straight into another attempt, and the wait itself would be added to the
+        // caller's shutdown time.
+        await sleepUnlessStopped(waitTimeBetweenRetries, shouldStop)
+        if (shouldStop?.()) {
+          throw e
+        }
         continue
       } else {
         throw e

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import { saveContentFileToDisk } from './client'
 import { SnapshotsFetcherComponents } from './types'
-import { isValidContentHash, pickRandomServer, sleepUnlessStopped } from './utils'
+import { isValidContentHash, isVerifiableContentHash, pickRandomServer, sleepUnlessStopped } from './utils'
 
 // In-flight downloads, per storage component and then per content hash.
 //
@@ -40,6 +40,21 @@ async function downloadJob(
 
   // cancel early if the file is already downloaded
   if (await components.storage.exist(hashToDownload)) return
+
+  // Refuse a hash whose bytes could never be verified, before spending a request on it. isValidContentHash
+  // only makes a hash safe to use as a path and a storage key; assertHash is what proves the bytes, and it
+  // can only do that for the Qm/ba CID shapes. Without this an alphanumeric-but-unverifiable hash from a
+  // hostile or corrupt manifest is downloaded in full, once per retry per server, and then discarded by
+  // assertHash — bounded work, but work we can know up front is wasted.
+  //
+  // Checked *after* the storage short-circuit deliberately: a file already present under an unverifiable id
+  // keeps being served exactly as before, so this only ever removes a download that was going to fail.
+  if (!isVerifiableContentHash(hashToDownload)) {
+    throw new Error(
+      `Refusing to download ${JSON.stringify(hashToDownload)}: unknown hashing algorithm, so its bytes could ` +
+        `never be verified against it`
+    )
+  }
 
   // Sample the number of candidate servers once per job, not once per retry (which would skew the histogram).
   components.metrics?.observe('dcl_available_servers_histogram', {}, presentInServers.length)

--- a/src/exponential-fallof-retry.ts
+++ b/src/exponential-fallof-retry.ts
@@ -53,12 +53,27 @@ export function createExponentialFallofRetry(
   // Terminal once stop() is called, so the component can never be restarted into an unstoppable loop.
   let stopped: boolean = false
 
+  if (options.maxInterval !== undefined && !Number.isFinite(options.maxInterval)) {
+    throw new Error('options.maxInterval must be a finite number')
+  }
   if (options.maxInterval && options.maxInterval < 0) throw new Error('options.maxInterval must be >= 0')
   // A negative retryTime passes the `!options.retryTime` guard below and then makes every retry sleep
   // resolve immediately, turning the loop into a busy spin. Zero is allowed: it means "do not retry".
+  if (!Number.isFinite(options.retryTime)) throw new Error('options.retryTime must be a finite number')
   if (options.retryTime < 0) throw new Error('options.retryTime must be >= 0')
-  if (options.healthyRunTime !== undefined && options.healthyRunTime < 0) {
-    throw new Error('options.healthyRunTime must be >= 0')
+  if (
+    options.retryTimeExponent !== undefined &&
+    (!Number.isFinite(options.retryTimeExponent) || options.retryTimeExponent < 1)
+  ) {
+    throw new Error('options.retryTimeExponent must be a finite number >= 1')
+  }
+  if (options.healthyRunTime !== undefined) {
+    if (!Number.isFinite(options.healthyRunTime)) {
+      throw new Error('options.healthyRunTime must be a finite number')
+    }
+    if (options.healthyRunTime < 0) {
+      throw new Error('options.healthyRunTime must be >= 0')
+    }
   }
 
   const exitOnSuccess = options.exitOnSuccess || false

--- a/src/exponential-fallof-retry.ts
+++ b/src/exponential-fallof-retry.ts
@@ -134,11 +134,12 @@ export function createExponentialFallofRetry(
         return
       }
 
-      if (options.maxInterval) {
-        reconnectionTime = Math.min(reconnectionTime, options.maxInterval)
-      } else {
-        reconnectionTime = Math.min(reconnectionTime, 86_400_000 /* one day */)
-      }
+      // The ceiling bounds how far the exponential growth can run, so it must never pull the interval
+      // *below* the configured base: `retryTime` is an explicit statement of how often the action
+      // should run. Clamping it made a `retryTime` longer than the ceiling unreachable — the
+      // synchronizer asks for a 14-day snapshot re-sync and silently got a daily one.
+      const growthCeiling = options.maxInterval || 86_400_000 /* one day */
+      reconnectionTime = Math.min(reconnectionTime, Math.max(growthCeiling, options.retryTime))
 
       logs.info('Retrying in ' + reconnectionTime.toFixed(1) + 'ms')
       await interruptibleSleep(reconnectionTime)

--- a/src/exponential-fallof-retry.ts
+++ b/src/exponential-fallof-retry.ts
@@ -50,6 +50,8 @@ export function createExponentialFallofRetry(
   options: ExponentialFallofRetryOptions
 ): ExponentialFallofRetryComponent {
   let started: boolean = false
+  // Terminal once stop() is called, so the component can never be restarted into an unstoppable loop.
+  let stopped: boolean = false
 
   if (options.maxInterval && options.maxInterval < 0) throw new Error('options.maxInterval must be >= 0')
   // A negative retryTime passes the `!options.retryTime` guard below and then makes every retry sleep
@@ -140,6 +142,13 @@ export function createExponentialFallofRetry(
 
       logs.info('Retrying in ' + reconnectionTime.toFixed(1) + 'ms')
       await interruptibleSleep(reconnectionTime)
+
+      // stop() interrupts the sleep, so re-check before running the action again. Without this the
+      // action always runs one extra time after a stop.
+      if (!started) {
+        logs.info('Breaking iteration after the retry sleep, started == false')
+        return
+      }
     }
   }
 
@@ -151,6 +160,11 @@ export function createExponentialFallofRetry(
       return !started
     },
     async start() {
+      // stop() is terminal. `started` alone cannot express that: it is false both before a first start
+      // and after a stop, so without this flag a start() that races or follows a stop() would spin up
+      // a loop whose `if (!started) return` exit can never be reached — an unstoppable job, and a
+      // second concurrent loop clobbering the shared cancelCurrentSleep.
+      if (stopped) return
       if (started === true) return
       started = true
       try {
@@ -162,6 +176,7 @@ export function createExponentialFallofRetry(
       }
     },
     async stop() {
+      stopped = true
       started = false
       if (cancelCurrentSleep) {
         cancelCurrentSleep()

--- a/src/exponential-fallof-retry.ts
+++ b/src/exponential-fallof-retry.ts
@@ -25,6 +25,18 @@ export type ExponentialFallofRetryOptions = {
    */
   maxInterval?: number
   exitOnSuccess?: boolean
+  /**
+   * When the action fails *after* running for at least this many milliseconds, the run is treated as
+   * healthy and the retry interval goes back to `retryTime` instead of growing.
+   *
+   * Set this for long-lived actions that only ever return by failing (e.g. a polling stream). Without
+   * it, such an action inherits the interval grown by failures from hours or days earlier and
+   * reconnects at the maxed-out delay even though it had been perfectly healthy in between.
+   *
+   * When unset, only a clean completion resets the interval — which is the right default for
+   * short actions whose normal duration may exceed `retryTime`.
+   */
+  healthyRunTime?: number
 }
 
 /**
@@ -40,6 +52,12 @@ export function createExponentialFallofRetry(
   let started: boolean = false
 
   if (options.maxInterval && options.maxInterval < 0) throw new Error('options.maxInterval must be >= 0')
+  // A negative retryTime passes the `!options.retryTime` guard below and then makes every retry sleep
+  // resolve immediately, turning the loop into a busy spin. Zero is allowed: it means "do not retry".
+  if (options.retryTime < 0) throw new Error('options.retryTime must be >= 0')
+  if (options.healthyRunTime !== undefined && options.healthyRunTime < 0) {
+    throw new Error('options.healthyRunTime must be >= 0')
+  }
 
   const exitOnSuccess = options.exitOnSuccess || false
 
@@ -75,6 +93,9 @@ export function createExponentialFallofRetry(
       logs.info('Starting...')
       reconnectionCount++
 
+      const actionStartedAt = Date.now()
+      let actionFailed = false
+
       try {
         await options.action()
         if (exitOnSuccess) {
@@ -83,11 +104,20 @@ export function createExponentialFallofRetry(
         }
       } catch (e: any) {
         logs.error(e)
-        // increment reconnection time
+        actionFailed = true
+      }
+
+      // A run counts as healthy when the action completed without throwing, or when it stayed up for
+      // at least healthyRunTime before failing. Only an unhealthy run grows the interval; otherwise
+      // the backoff would never come back down after a recovery.
+      const runWasHealthy =
+        !actionFailed ||
+        (options.healthyRunTime !== undefined && Date.now() - actionStartedAt >= options.healthyRunTime)
+
+      if (runWasHealthy) {
+        reconnectionTime = options.retryTime
+      } else {
         reconnectionTime = reconnectionTime * (options.retryTimeExponent ?? 1.1)
-        if (options.maxInterval) {
-          reconnectionTime = Math.min(reconnectionTime, options.maxInterval)
-        }
       }
 
       if (!started) {

--- a/src/file-processor.ts
+++ b/src/file-processor.ts
@@ -28,15 +28,40 @@ export type SnapshotStreamReport = {
 const MAX_SNAPSHOT_LINE_LENGTH_IN_BYTES = 10 * 1024 * 1024 // 10 MiB
 
 /**
- * Fails the pipeline once more than maxBytes have flowed through it without a newline.
+ * Fails the pipeline once any single line exceeds maxBytes.
+ *
+ * Every line is measured, including ones that begin and end inside one chunk. An earlier version tracked
+ * only the bytes after the LAST newline in each chunk, which measured the trailing partial line and
+ * nothing else: a chunk holding a 12 MiB line followed by a newline reset the counter to the short tail
+ * and forwarded the oversized line untouched. The same blind spot swallowed a line made of carried-over
+ * bytes plus the start of a chunk that happened to contain a later newline.
  */
 function createLineLengthLimiter(maxBytes: number): Transform {
+  // Bytes of the current line seen so far, carried across chunks until its newline arrives.
   let bytesSinceNewline = 0
   return new Transform({
     transform(chunk, _encoding, callback) {
       const buffer: Buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk))
-      const lastNewline = buffer.lastIndexOf(LINE_FEED)
-      bytesSinceNewline = lastNewline === -1 ? bytesSinceNewline + buffer.length : buffer.length - lastNewline - 1
+      let searchFrom = 0
+      for (;;) {
+        const newlineAt = buffer.indexOf(LINE_FEED, searchFrom)
+        if (newlineAt === -1) {
+          // No more newlines: the rest of the chunk continues the current line into the next one.
+          bytesSinceNewline += buffer.length - searchFrom
+          break
+        }
+        // A line ends here, so its full length is knowable: whatever carried over plus the bytes up to
+        // this newline.
+        if (bytesSinceNewline + (newlineAt - searchFrom) > maxBytes) {
+          callback(new Error(`Snapshot line exceeds the maximum allowed length of ${maxBytes} bytes`))
+          return
+        }
+        bytesSinceNewline = 0
+        searchFrom = newlineAt + 1
+      }
+      // The trailing partial line is checked too, so a single endless line fails without waiting for a
+      // newline that may never come. Each indexOf resumes where the last stopped, so a chunk is still
+      // scanned once in total.
       if (bytesSinceNewline > maxBytes) {
         callback(new Error(`Snapshot line exceeds the maximum allowed length of ${maxBytes} bytes`))
         return

--- a/src/file-processor.ts
+++ b/src/file-processor.ts
@@ -3,7 +3,7 @@ import { createInterface } from 'readline'
 import { Transform } from 'stream'
 import { SnapshotSyncDeployment, SyncDeployment } from '@dcl/schemas'
 import { ILoggerComponent } from '@well-known-components/interfaces'
-import { isUsableTimestamp } from './utils'
+import { isUsableTimestamp, truncateForLog } from './utils'
 
 const CURLY_OPEN = 0x7b // {
 const CURLY_CLOSE = 0x7d // }
@@ -95,22 +95,6 @@ export async function* processDeploymentsInFile(
 // flood the logs.
 const MAX_LINE_ERRORS_TO_LOG = 100
 
-// How much of an offending line is worth keeping in a log entry.
-const LINE_PREVIEW_LENGTH = 512
-
-/**
- * A log-safe rendering of remote text.
- *
- * The line cap is MAX_SNAPSHOT_LINE_LENGTH_IN_BYTES and up to MAX_LINE_ERRORS_TO_LOG lines are reported,
- * so logging offending lines whole let one corrupt snapshot push ~1 GiB of attacker-chosen text into the
- * log pipeline. The prefix is what identifies the problem; the length is what tells you it was truncated.
- */
-function preview(text: string): string {
-  return text.length <= LINE_PREVIEW_LENGTH
-    ? text
-    : `${text.slice(0, LINE_PREVIEW_LENGTH)}… (truncated, original length ${text.length})`
-}
-
 /**
  * Reads line by line from a stream.
  * Parses every line and yields RemoteEntityDeployment.
@@ -158,7 +142,7 @@ export async function* processDeploymentsInStream(
         // A truncated final line, or a snapshot framed differently than we expect, used to be dropped
         // here without a trace — indistinguishable from a genuinely empty snapshot.
         if (!isSnapshotFraming(theLine)) {
-          reportUnusableLine('ERROR: Unrecognized line in snapshot file', () => ({ line: preview(theLine) }))
+          reportUnusableLine('ERROR: Unrecognized line in snapshot file', () => ({ line: truncateForLog(theLine) }))
         }
         continue
       }
@@ -169,7 +153,7 @@ export async function* processDeploymentsInStream(
       } catch (error: any) {
         // A single malformed line should not abort processing of the whole snapshot file.
         reportUnusableLine('ERROR: Could not parse line in snapshot file', () => ({
-          line: preview(theLine),
+          line: truncateForLog(theLine),
           error: error?.message ?? JSON.stringify(error)
         }))
         continue
@@ -184,7 +168,7 @@ export async function* processDeploymentsInStream(
       // `else if (PointerChangesSyncDeployment.validate(...))` could therefore never be reached.
       if (!SnapshotSyncDeployment.validate(parsedLine)) {
         reportUnusableLine('ERROR: Invalid entity deployment in snapshot file', () => ({
-          deployment: preview(JSON.stringify(parsedLine)),
+          deployment: truncateForLog(JSON.stringify(parsedLine)),
           errors: JSON.stringify(SnapshotSyncDeployment.validate.errors)
         }))
         continue
@@ -200,7 +184,7 @@ export async function* processDeploymentsInStream(
         (lineLocalTimestamp !== undefined && !isUsableTimestamp(lineLocalTimestamp))
       ) {
         reportUnusableLine('ERROR: Implausible timestamp in entity deployment in snapshot file', () => ({
-          deployment: preview(JSON.stringify(parsedLine)),
+          deployment: truncateForLog(JSON.stringify(parsedLine)),
           entityTimestamp: String(lineEntityTimestamp),
           localTimestamp: String(lineLocalTimestamp)
         }))

--- a/src/file-processor.ts
+++ b/src/file-processor.ts
@@ -1,13 +1,18 @@
 import { SnapshotsFetcherComponents } from './types'
 import { createInterface } from 'readline'
-import { PointerChangesSyncDeployment, SnapshotSyncDeployment, SyncDeployment } from '@dcl/schemas'
+import { SnapshotSyncDeployment, SyncDeployment } from '@dcl/schemas'
 import { ILoggerComponent } from '@well-known-components/interfaces'
 
-async function* processLineByLine(input: NodeJS.ReadableStream) {
-  yield* createInterface({
-    input,
-    crlfDelay: Infinity
-  })
+const CURLY_OPEN = 0x7b // {
+const CURLY_CLOSE = 0x7d // }
+
+/**
+ * True when the string already looks like a JSON object literal. charCodeAt instead of
+ * startsWith/endsWith because this runs once or twice per line of a snapshot that can hold millions
+ * of them.
+ */
+function isBraceDelimited(line: string): boolean {
+  return line.length > 1 && line.charCodeAt(0) === CURLY_OPEN && line.charCodeAt(line.length - 1) === CURLY_CLOSE
 }
 
 /**
@@ -62,9 +67,15 @@ export async function* processDeploymentsInStream(
     }
   }
 
-  for await (const line of processLineByLine(stream)) {
-    const theLine = line.trim()
-    if (theLine.startsWith('{') && theLine.endsWith('}')) {
+  // Iterate the readline interface directly. Wrapping it in an extra async generator added a promise
+  // and a microtask per line, which on a multi-million-entity snapshot is pure overhead.
+  const lines = createInterface({ input: stream, crlfDelay: Infinity })
+
+  for await (const line of lines) {
+    // trim() allocates a new string for every line. Snapshot lines are written without padding, so
+    // only pay for it when the raw line is not already a JSON object literal.
+    const theLine = isBraceDelimited(line) ? line : line.trim()
+    if (isBraceDelimited(theLine)) {
       let parsedLine: any
       try {
         parsedLine = JSON.parse(theLine)
@@ -76,15 +87,16 @@ export async function* processDeploymentsInStream(
         })
         continue
       }
+      // One check accepts both shapes. PointerChangesSyncDeployment requires everything
+      // SnapshotSyncDeployment requires plus localTimestamp, and neither forbids extra properties, so
+      // every valid pointer-changes deployment is also a valid snapshot deployment. A follow-up
+      // `else if (PointerChangesSyncDeployment.validate(...))` could therefore never be reached.
       if (SnapshotSyncDeployment.validate(parsedLine)) {
-        yield parsedLine
-      } else if (PointerChangesSyncDeployment.validate(parsedLine)) {
         yield parsedLine
       } else {
         logLineError('ERROR: Invalid entity deployment in snapshot file', {
           deployment: JSON.stringify(parsedLine),
-          snapshotErrors: JSON.stringify(SnapshotSyncDeployment.validate.errors),
-          pointerChangesErrors: JSON.stringify(PointerChangesSyncDeployment.validate.errors)
+          errors: JSON.stringify(SnapshotSyncDeployment.validate.errors)
         })
       }
     }

--- a/src/file-processor.ts
+++ b/src/file-processor.ts
@@ -1,10 +1,50 @@
 import { SnapshotsFetcherComponents } from './types'
 import { createInterface } from 'readline'
+import { Transform } from 'stream'
 import { SnapshotSyncDeployment, SyncDeployment } from '@dcl/schemas'
 import { ILoggerComponent } from '@well-known-components/interfaces'
 
 const CURLY_OPEN = 0x7b // {
 const CURLY_CLOSE = 0x7d // }
+const LINE_FEED = 0x0a // \n
+
+/**
+ * Tally of the lines a snapshot file could not contribute as deployments.
+ *
+ * A snapshot with a non-zero count is incomplete: those entities were never streamed, so recording
+ * the snapshot as processed would retire it permanently with entities missing.
+ * @public
+ */
+export type SnapshotStreamReport = {
+  unusableLines: number
+}
+
+/**
+ * A snapshot line is a single deployment; the largest legitimate ones are a few KB. readline imposes
+ * no line bound, so a file that contains no newline at all is accumulated into one string until the
+ * heap is exhausted (V8 hard-fails past ~512 MB anyway). Fail the snapshot instead of the process.
+ */
+const MAX_SNAPSHOT_LINE_LENGTH_IN_BYTES = 10 * 1024 * 1024 // 10 MiB
+
+/**
+ * Fails the pipeline once more than maxBytes have flowed through it without a newline.
+ */
+function createLineLengthLimiter(maxBytes: number): Transform {
+  let bytesSinceNewline = 0
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      const buffer: Buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk))
+      const lastNewline = buffer.lastIndexOf(LINE_FEED)
+      bytesSinceNewline = lastNewline === -1 ? bytesSinceNewline + buffer.length : buffer.length - lastNewline - 1
+      if (bytesSinceNewline > maxBytes) {
+        callback(new Error(`Snapshot line exceeds the maximum allowed length of ${maxBytes} bytes`))
+        return
+      }
+      // Forward the original chunk so the downstream encoding is untouched.
+      callback(null, chunk)
+    }
+  })
+}
 
 /**
  * True when the string already looks like a JSON object literal. charCodeAt instead of
@@ -16,6 +56,15 @@ function isBraceDelimited(line: string): boolean {
 }
 
 /**
+ * Lines that carry no deployment but are part of the format: the `### Decentraland json snapshot`
+ * header, and blank padding. Anything else that is not a deployment is a line we failed to read, and
+ * must be counted as such rather than skipped in silence.
+ */
+function isSnapshotFraming(line: string): boolean {
+  return line.length === 0 || line.startsWith('###')
+}
+
+/**
  * Reads line by line from a file in the disk.
  * Parses every line and yields RemoteEntityDeployment.
  * @public
@@ -23,7 +72,8 @@ function isBraceDelimited(line: string): boolean {
 export async function* processDeploymentsInFile(
   file: string,
   components: Pick<SnapshotsFetcherComponents, 'storage'>,
-  logger: ILoggerComponent.ILogger
+  logger: ILoggerComponent.ILogger,
+  report?: SnapshotStreamReport
 ): AsyncIterable<SyncDeployment> {
   const fileContent = await components.storage.retrieve(file)
 
@@ -34,32 +84,42 @@ export async function* processDeploymentsInFile(
   const stream = await fileContent!.asStream()
 
   try {
-    yield* processDeploymentsInStream(stream, logger)
+    yield* processDeploymentsInStream(stream, logger, report)
   } finally {
     stream.destroy()
   }
 }
 
-/**
- * Reads line by line from a stream.
- * Parses every line and yields RemoteEntityDeployment.
- * @public
- */
 // Maximum number of invalid-line errors logged per snapshot file, so a single corrupt file can't
 // flood the logs.
 const MAX_LINE_ERRORS_TO_LOG = 100
 
+/**
+ * Reads line by line from a stream.
+ * Parses every line and yields RemoteEntityDeployment.
+ *
+ * @param report - Optional tally, incremented for every line that could not be read as a deployment.
+ *   Callers that record snapshots as processed must pass one and check it.
+ * @public
+ */
 export async function* processDeploymentsInStream(
   stream: NodeJS.ReadableStream,
-  logger: ILoggerComponent.ILogger
+  logger: ILoggerComponent.ILogger,
+  report?: SnapshotStreamReport
 ): AsyncIterable<SyncDeployment> {
   let lineErrorsLogged = 0
-  function logLineError(message: string, extra: Record<string, string>) {
+  // The payload is built by a callback rather than passed in: the JSON.stringify calls that make up
+  // these entries are the expensive part, and evaluating them as arguments meant a snapshot on an
+  // incompatible schema paid for millions of them to emit MAX_LINE_ERRORS_TO_LOG lines.
+  function reportUnusableLine(message: string, buildExtra: () => Record<string, string>) {
+    if (report) {
+      report.unusableLines++
+    }
     if (lineErrorsLogged >= MAX_LINE_ERRORS_TO_LOG) {
       return
     }
     lineErrorsLogged++
-    logger.error(message, extra)
+    logger.error(message, buildExtra())
     if (lineErrorsLogged === MAX_LINE_ERRORS_TO_LOG) {
       logger.error('Too many invalid lines in snapshot file, suppressing further line errors', {
         suppressedAfter: String(MAX_LINE_ERRORS_TO_LOG)
@@ -67,24 +127,34 @@ export async function* processDeploymentsInStream(
     }
   }
 
+  const lineLengthLimiter = createLineLengthLimiter(MAX_SNAPSHOT_LINE_LENGTH_IN_BYTES)
   // Iterate the readline interface directly. Wrapping it in an extra async generator added a promise
   // and a microtask per line, which on a multi-million-entity snapshot is pure overhead.
-  const lines = createInterface({ input: stream, crlfDelay: Infinity })
+  const lines = createInterface({ input: stream.pipe(lineLengthLimiter), crlfDelay: Infinity })
 
-  for await (const line of lines) {
-    // trim() allocates a new string for every line. Snapshot lines are written without padding, so
-    // only pay for it when the raw line is not already a JSON object literal.
-    const theLine = isBraceDelimited(line) ? line : line.trim()
-    if (isBraceDelimited(theLine)) {
+  try {
+    for await (const line of lines) {
+      // trim() allocates a new string for every line. Snapshot lines are written without padding, so
+      // only pay for it when the raw line is not already a JSON object literal.
+      const theLine = isBraceDelimited(line) ? line : line.trim()
+      if (!isBraceDelimited(theLine)) {
+        // A truncated final line, or a snapshot framed differently than we expect, used to be dropped
+        // here without a trace — indistinguishable from a genuinely empty snapshot.
+        if (!isSnapshotFraming(theLine)) {
+          reportUnusableLine('ERROR: Unrecognized line in snapshot file', () => ({ line: theLine }))
+        }
+        continue
+      }
+
       let parsedLine: any
       try {
         parsedLine = JSON.parse(theLine)
       } catch (error: any) {
         // A single malformed line should not abort processing of the whole snapshot file.
-        logLineError('ERROR: Could not parse line in snapshot file', {
+        reportUnusableLine('ERROR: Could not parse line in snapshot file', () => ({
           line: theLine,
           error: error?.message ?? JSON.stringify(error)
-        })
+        }))
         continue
       }
       // One check accepts both shapes. PointerChangesSyncDeployment requires everything
@@ -94,11 +164,14 @@ export async function* processDeploymentsInStream(
       if (SnapshotSyncDeployment.validate(parsedLine)) {
         yield parsedLine
       } else {
-        logLineError('ERROR: Invalid entity deployment in snapshot file', {
+        reportUnusableLine('ERROR: Invalid entity deployment in snapshot file', () => ({
           deployment: JSON.stringify(parsedLine),
           errors: JSON.stringify(SnapshotSyncDeployment.validate.errors)
-        })
+        }))
       }
     }
+  } finally {
+    lines.close()
+    lineLengthLimiter.destroy()
   }
 }

--- a/src/file-processor.ts
+++ b/src/file-processor.ts
@@ -133,9 +133,8 @@ export async function* processDeploymentsInStream(
   // failing storage read from becoming an unhandled 'error' event — i.e. a process crash — instead of a
   // rejected snapshot. readline used to sit directly on the source and got this for free; inserting the
   // limiter is what took it away, so it has to be put back explicitly.
-  stream.on('error', (error: Error) => {
-    lineLengthLimiter.destroy(error)
-  })
+  const forwardSourceError = (error: Error) => lineLengthLimiter.destroy(error)
+  stream.on('error', forwardSourceError)
   // Iterate the readline interface directly. Wrapping it in an extra async generator added a promise
   // and a microtask per line, which on a multi-million-entity snapshot is pure overhead.
   const lines = createInterface({ input: stream.pipe(lineLengthLimiter), crlfDelay: Infinity })
@@ -200,6 +199,10 @@ export async function* processDeploymentsInStream(
       yield parsedLine
     }
   } finally {
+    // Detached explicitly: the stream belongs to the caller — processDeploymentsInFile owns one, but this
+    // is @public and a consumer may hand in a long-lived stream of its own — so leaving a listener on it
+    // would outlive this call.
+    stream.off('error', forwardSourceError)
     lines.close()
     lineLengthLimiter.destroy()
   }

--- a/src/file-processor.ts
+++ b/src/file-processor.ts
@@ -129,6 +129,13 @@ export async function* processDeploymentsInStream(
   }
 
   const lineLengthLimiter = createLineLengthLimiter(MAX_SNAPSHOT_LINE_LENGTH_IN_BYTES)
+  // pipe() does NOT forward the source's errors to the destination, so this bridge is what keeps a
+  // failing storage read from becoming an unhandled 'error' event — i.e. a process crash — instead of a
+  // rejected snapshot. readline used to sit directly on the source and got this for free; inserting the
+  // limiter is what took it away, so it has to be put back explicitly.
+  stream.on('error', (error: Error) => {
+    lineLengthLimiter.destroy(error)
+  })
   // Iterate the readline interface directly. Wrapping it in an extra async generator added a promise
   // and a microtask per line, which on a multi-million-entity snapshot is pure overhead.
   const lines = createInterface({ input: stream.pipe(lineLengthLimiter), crlfDelay: Infinity })

--- a/src/file-processor.ts
+++ b/src/file-processor.ts
@@ -3,6 +3,7 @@ import { createInterface } from 'readline'
 import { Transform } from 'stream'
 import { SnapshotSyncDeployment, SyncDeployment } from '@dcl/schemas'
 import { ILoggerComponent } from '@well-known-components/interfaces'
+import { isUsableTimestamp } from './utils'
 
 const CURLY_OPEN = 0x7b // {
 const CURLY_CLOSE = 0x7d // }
@@ -94,6 +95,22 @@ export async function* processDeploymentsInFile(
 // flood the logs.
 const MAX_LINE_ERRORS_TO_LOG = 100
 
+// How much of an offending line is worth keeping in a log entry.
+const LINE_PREVIEW_LENGTH = 512
+
+/**
+ * A log-safe rendering of remote text.
+ *
+ * The line cap is MAX_SNAPSHOT_LINE_LENGTH_IN_BYTES and up to MAX_LINE_ERRORS_TO_LOG lines are reported,
+ * so logging offending lines whole let one corrupt snapshot push ~1 GiB of attacker-chosen text into the
+ * log pipeline. The prefix is what identifies the problem; the length is what tells you it was truncated.
+ */
+function preview(text: string): string {
+  return text.length <= LINE_PREVIEW_LENGTH
+    ? text
+    : `${text.slice(0, LINE_PREVIEW_LENGTH)}… (truncated, original length ${text.length})`
+}
+
 /**
  * Reads line by line from a stream.
  * Parses every line and yields RemoteEntityDeployment.
@@ -141,7 +158,7 @@ export async function* processDeploymentsInStream(
         // A truncated final line, or a snapshot framed differently than we expect, used to be dropped
         // here without a trace — indistinguishable from a genuinely empty snapshot.
         if (!isSnapshotFraming(theLine)) {
-          reportUnusableLine('ERROR: Unrecognized line in snapshot file', () => ({ line: theLine }))
+          reportUnusableLine('ERROR: Unrecognized line in snapshot file', () => ({ line: preview(theLine) }))
         }
         continue
       }
@@ -152,23 +169,44 @@ export async function* processDeploymentsInStream(
       } catch (error: any) {
         // A single malformed line should not abort processing of the whole snapshot file.
         reportUnusableLine('ERROR: Could not parse line in snapshot file', () => ({
-          line: theLine,
+          line: preview(theLine),
           error: error?.message ?? JSON.stringify(error)
         }))
         continue
       }
+      // Read while parsedLine is still untyped: the schema guard below narrows it to the snapshot shape,
+      // which does not declare localTimestamp — only pointer-changes-shaped lines carry one.
+      const lineEntityTimestamp: unknown = parsedLine.entityTimestamp
+      const lineLocalTimestamp: unknown = parsedLine.localTimestamp
       // One check accepts both shapes. PointerChangesSyncDeployment requires everything
       // SnapshotSyncDeployment requires plus localTimestamp, and neither forbids extra properties, so
       // every valid pointer-changes deployment is also a valid snapshot deployment. A follow-up
       // `else if (PointerChangesSyncDeployment.validate(...))` could therefore never be reached.
-      if (SnapshotSyncDeployment.validate(parsedLine)) {
-        yield parsedLine
-      } else {
+      if (!SnapshotSyncDeployment.validate(parsedLine)) {
         reportUnusableLine('ERROR: Invalid entity deployment in snapshot file', () => ({
-          deployment: JSON.stringify(parsedLine),
+          deployment: preview(JSON.stringify(parsedLine)),
           errors: JSON.stringify(SnapshotSyncDeployment.validate.errors)
         }))
+        continue
       }
+      // The schema bounds these no more than it does on /pointer-changes: it rejects Infinity and
+      // negatives, but 1e308, an above-2^53 value, a fraction or a far-future instant are all schema-valid.
+      // Unlike the other paths this one does not feed our own high-water mark, but the entity is handed
+      // to the consumer's deployer with that timestamp on it, and a deployer treating it as the entity's
+      // version would let one poisoned line shadow every later legitimate update to those pointers.
+      // Counted as unusable, so the snapshot stays unmarked and is retried rather than half-applied.
+      if (
+        !isUsableTimestamp(lineEntityTimestamp) ||
+        (lineLocalTimestamp !== undefined && !isUsableTimestamp(lineLocalTimestamp))
+      ) {
+        reportUnusableLine('ERROR: Implausible timestamp in entity deployment in snapshot file', () => ({
+          deployment: preview(JSON.stringify(parsedLine)),
+          entityTimestamp: String(lineEntityTimestamp),
+          localTimestamp: String(lineLocalTimestamp)
+        }))
+        continue
+      }
+      yield parsedLine
     }
   } finally {
     lines.close()

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,13 +191,13 @@ async function evictCorruptEntityFile(
  * shape-checked: a single malformed profile must not abort the download of an otherwise valid
  * entity. Unexpected shapes contribute no hashes rather than throwing.
  */
-function avatarSnapshotHashesFrom(entityMetadata: {
-  metadata?: any
-  content?: ContentMapping[] | undefined
-}): string[] {
+function avatarSnapshotHashesFrom(entityMetadata: { metadata?: any; content?: ContentMapping[] | undefined }): {
+  hashes: string[]
+  truncated: boolean
+} {
   const allAvatars: unknown = entityMetadata.metadata?.avatars
   if (!Array.isArray(allAvatars)) {
-    return []
+    return { hashes: [], truncated: false }
   }
 
   const declaredContentHashes = new Set(
@@ -210,9 +210,13 @@ function avatarSnapshotHashesFrom(entityMetadata: {
   // only then discarded it. Stopping at the cap means the intermediate never exceeds it either.
   const hashes: string[] = []
   const alreadyCollected = new Set<string>()
+  // Reported rather than swallowed, so an operator can tell "this profile had no missing snapshots" from
+  // "this profile declared more than we are willing to fetch, and the rest were dropped".
+  let truncated = false
 
   for (const avatar of allAvatars) {
     if (hashes.length >= MAX_AVATAR_SNAPSHOTS_PER_ENTITY) {
+      truncated = true
       break
     }
     const snapshots: unknown = avatar?.avatar?.snapshots
@@ -225,6 +229,7 @@ function avatarSnapshotHashesFrom(entityMetadata: {
     }
     for (const declared of Object.values(snapshots)) {
       if (hashes.length >= MAX_AVATAR_SNAPSHOTS_PER_ENTITY) {
+        truncated = true
         break
       }
       if (typeof declared !== 'string' || declared.length === 0) {
@@ -242,7 +247,7 @@ function avatarSnapshotHashesFrom(entityMetadata: {
     }
   }
 
-  return hashes
+  return { hashes, truncated }
 }
 
 async function downloadProfileAvatars(
@@ -261,7 +266,13 @@ async function downloadProfileAvatars(
     content?: ContentMapping[] | undefined
   }
 ) {
-  const snapshots = avatarSnapshotHashesFrom(entityMetadata)
+  const { hashes: snapshots, truncated } = avatarSnapshotHashesFrom(entityMetadata)
+  if (truncated) {
+    logger.warn('Profile declared more avatar snapshots than will be fetched; the rest were dropped.', {
+      entityId,
+      limit: String(MAX_AVATAR_SNAPSHOTS_PER_ENTITY)
+    })
+  }
   if (snapshots.length === 0) {
     return
   }
@@ -398,6 +409,12 @@ export async function downloadEntityAndContentFiles(
     )
   }
 
+  // Resolved before any download work, including the profile-avatar fallback below. Validation lives in
+  // here, so computing it late meant a manifest with one unusable content hash could spend the whole
+  // bounded avatar budget first and only then be rejected — work for an entity that was never going to
+  // be accepted.
+  const hashesToDownload = Array.isArray(declaredContent) ? contentHashesToDownload(declaredContent, entityId) : []
+
   if (entityMetadata.type === 'profile' && entityMetadata.metadata) {
     /*
      * Profiles can have some images referenced in the avatar snapshots that are not included in content section.
@@ -422,10 +439,7 @@ export async function downloadEntityAndContentFiles(
     )
   }
 
-  // Array.isArray (not a truthiness check): content[] is remote and untrusted, and a non-array
-  // value would make .map throw a TypeError instead of yielding a diagnosable error.
-  if (Array.isArray(entityMetadata.content)) {
-    const hashesToDownload = contentHashesToDownload(entityMetadata.content, entityId)
+  if (hashesToDownload.length > 0) {
     const downloadQueue = new PQueue({ concurrency: contentFilesConcurrency })
     await Promise.all(
       hashesToDownload.map((hash) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -360,6 +360,18 @@ export async function downloadEntityAndContentFiles(
     throw new Error(`Failed to parse the downloaded entity file for ${entityId}; ${kept}. Cause: ${cause}`)
   }
 
+  // Checked before any download work, because the alternative is worse than a TypeError: every consumer
+  // of content[] guards with Array.isArray and falls back to "no content", so an entity declaring an
+  // object or a string here would be reported as fully downloaded while its dependencies were never
+  // fetched — and then deployed as complete. null and undefined are genuinely "no content declared";
+  // anything else is a manifest we cannot read and must not silently treat as empty.
+  const declaredContent: unknown = entityMetadata.content
+  if (declaredContent !== undefined && declaredContent !== null && !Array.isArray(declaredContent)) {
+    throw new Error(
+      `Entity ${entityId} declares a content field that is not an array: ${typeof declaredContent}. Refusing to treat it as having no content files.`
+    )
+  }
+
   if (entityMetadata.type === 'profile' && entityMetadata.metadata) {
     /*
      * Profiles can have some images referenced in the avatar snapshots that are not included in content section.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { hashV0, hashV1 } from '@dcl/hashing'
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import PQueue from 'p-queue'
 import { downloadFileWithRetries } from './downloader'
-import { ContentMapping, EntityHash, Server, SnapshotsFetcherComponents } from './types'
+import { ContentMapping, EntityHash, Server, SnapshotsFetcherComponents, TransferLimits } from './types'
 import { isValidContentHash, streamToBuffer, truncateForLog } from './utils'
 
 // Guard the runtime before anything else in the package is evaluated. The name is inlined rather than
@@ -22,6 +22,7 @@ export { getDeployedEntitiesStreamFromSnapshot, getDeployedEntitiesStreamFromPoi
 // has to be reachable from the package root. Without this, callers had to deep-import
 // '@dcl/snapshots-fetcher/dist/job-queue-port' or reimplement IJobQueue themselves.
 export { createJobQueue, IJobQueue } from './job-queue-port'
+export { DEFAULT_TRANSFER_LIMITS, resolveTransferLimits } from './utils'
 // Tagged @public but previously reachable only through a deep import into dist/.
 export {
   decideSnapshotDeploymentFromProcessedSet,
@@ -38,6 +39,8 @@ export {
   ISnapshotStorageComponent,
   Path,
   PointerChangesDeployedEntityStreamOptions,
+  ResolvedTransferLimits,
+  TransferLimits,
   ReconnectionOptions,
   Server,
   SnapshotDeployedEntityStreamOptions,
@@ -259,6 +262,7 @@ async function downloadProfileAvatars(
   maxRetries: number,
   waitTimeBetweenRetries: number,
   concurrency: number,
+  transferLimits: TransferLimits | undefined,
   entityId: EntityHash,
   entityMetadata: {
     type: string
@@ -294,7 +298,9 @@ async function downloadProfileAvatars(
           presentInServers,
           _serverMapLRU,
           maxRetries,
-          waitTimeBetweenRetries
+          waitTimeBetweenRetries,
+          undefined,
+          transferLimits
         ).catch(() =>
           // Truncated: the value comes from remote profile metadata, and this path is reached precisely
           // when it was unusable, so its length is the manifest's choice.
@@ -327,7 +333,8 @@ export async function downloadEntityAndContentFiles(
   targetFolder: string,
   maxRetries: number,
   waitTimeBetweenRetries: number,
-  contentFilesConcurrency: number = DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY
+  contentFilesConcurrency: number = DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY,
+  transferLimits?: TransferLimits
 ): Promise<unknown> {
   const logger = components.logs.getLogger(`downloadEntityAndContentFiles)`)
 
@@ -339,7 +346,9 @@ export async function downloadEntityAndContentFiles(
     presentInServers,
     _serverMapLRU,
     maxRetries,
-    waitTimeBetweenRetries
+    waitTimeBetweenRetries,
+    undefined,
+    transferLimits
   )
 
   const content = await components.storage.retrieve(entityId)
@@ -434,6 +443,7 @@ export async function downloadEntityAndContentFiles(
       maxRetries,
       waitTimeBetweenRetries,
       contentFilesConcurrency,
+      transferLimits,
       entityId,
       entityMetadata
     )
@@ -451,7 +461,9 @@ export async function downloadEntityAndContentFiles(
             presentInServers,
             _serverMapLRU,
             maxRetries,
-            waitTimeBetweenRetries
+            waitTimeBetweenRetries,
+            undefined,
+            transferLimits
           )
         )
       )

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,12 @@ const DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY = 10
 // (a handful per avatar), so it only bounds hostile or corrupt metadata.
 const MAX_AVATAR_SNAPSHOTS_PER_ENTITY = 1000
 
+// Ceiling on an entity file read fully into memory. Entity documents are JSON manifests measured in
+// KB, but the download cap alone permits a single file of 1 GiB and entities are read concurrently —
+// the eviction path holds two copies of one at a time. Far above any real entity, so it only bounds
+// a hostile or corrupt file.
+const MAX_ENTITY_FILE_SIZE_IN_BYTES = 50 * 1024 * 1024 // 50 MiB
+
 /**
  * Verifies stored bytes against the content-addressed id that claims them. 'mismatch' proves the
  * local copy is not the content the id addresses (a truncated/partial or mis-keyed write); 'match'
@@ -123,7 +129,7 @@ async function evictCorruptEntityFile(
         // A concurrent eviction already removed it.
         return 'the corrupt local copy was already removed; a later retry will re-download it'
       }
-      const currentBuffer = await streamToBuffer(await current.asStream())
+      const currentBuffer = await streamToBuffer(await current.asStream(), MAX_ENTITY_FILE_SIZE_IN_BYTES)
       if ((await verifyBufferHash(currentBuffer, entityId)) !== 'mismatch') {
         return 'the local copy has since been replaced by a hash-valid one, which was kept'
       }
@@ -270,7 +276,7 @@ export async function downloadEntityAndContentFiles(
   // Read the bytes outside any destructive path. A failure here is a transient storage/read error,
   // not proof the stored bytes are corrupt, so it must not trigger an eviction.
   const stream = await content.asStream()
-  const buffer = await streamToBuffer(stream)
+  const buffer = await streamToBuffer(stream, MAX_ENTITY_FILE_SIZE_IN_BYTES)
 
   // Enforce the content-addressed invariant BEFORE trusting the bytes at all. `downloadJob` skips
   // the download when `storage.exist(entityId)` is true, so a truncated/partial or mis-keyed local

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { ILoggerComponent } from '@well-known-components/interfaces'
 import PQueue from 'p-queue'
 import { downloadFileWithRetries } from './downloader'
 import { ContentMapping, EntityHash, Server, SnapshotsFetcherComponents } from './types'
-import { streamToBuffer } from './utils'
+import { isValidContentHash, streamToBuffer } from './utils'
 
 // Guard the runtime before anything else in the package is evaluated. The name is inlined rather than
 // read from package.json so this stays a plain import-time check with no filesystem access.
@@ -57,6 +57,39 @@ const DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY = 10
 // Ceiling on the avatar snapshots a single profile can ask us to fetch. Far above any real profile
 // (a handful per avatar), so it only bounds hostile or corrupt metadata.
 const MAX_AVATAR_SNAPSHOTS_PER_ENTITY = 1000
+
+// Ceiling on the content files one entity may ask us to download. content[] is remote, and every entry
+// becomes a queued job in a single pass, so without a bound one entity sizes the work. Far above any real
+// entity (scenes run to hundreds of assets), so it only trips on a hostile or corrupt manifest.
+const MAX_CONTENT_FILES_PER_ENTITY = 25_000
+
+/**
+ * The distinct, valid hashes to fetch for an entity's content[].
+ *
+ * Deduplicated because a manifest may name the same hash repeatedly: the download layer already collapses
+ * concurrent duplicates, but each one still costs a queue slot and a closure here.
+ *
+ * Invalid entries are rejected rather than skipped. Every file in content[] is part of the entity, so
+ * quietly dropping one would report success for an entity we did not fully fetch — the download call
+ * already refused these, this just fails earlier and names the entity. Exceeding the cap is refused for
+ * the same reason: truncating would silently leave files behind.
+ */
+function contentHashesToDownload(content: unknown[], entityId: EntityHash): string[] {
+  if (content.length > MAX_CONTENT_FILES_PER_ENTITY) {
+    throw new Error(
+      `Entity ${entityId} declares ${content.length} content files, above the maximum of ${MAX_CONTENT_FILES_PER_ENTITY}`
+    )
+  }
+  const hashes = new Set<string>()
+  for (const entry of content) {
+    const hash = (entry as ContentMapping | undefined | null)?.hash
+    if (typeof hash !== 'string' || !isValidContentHash(hash)) {
+      throw new Error(`Entity ${entityId} declares an invalid content file hash: ${JSON.stringify(hash)}`)
+    }
+    hashes.add(hash)
+  }
+  return Array.from(hashes)
+}
 
 // Ceiling on an entity file read fully into memory. Entity documents are JSON manifests measured in
 // KB, but the download cap alone permits a single file of 1 GiB and entities are read concurrently —
@@ -186,6 +219,9 @@ function avatarSnapshotHashesFrom(entityMetadata: {
         return matches ? matches[1] : snapshot
       })
       .filter((snapshot) => !declaredContentHashes.has(snapshot))
+      // Deduplicated before the cap, for the same reason content[] is: a profile naming one snapshot
+      // repeatedly would otherwise spend the whole budget on jobs for a single hash.
+      .filter((snapshot, index, all) => all.indexOf(snapshot) === index)
       // Even well-shaped metadata is remote and unbounded (avatars[] has no declared limit), so cap the
       // extra work one entity can create.
       .slice(0, MAX_AVATAR_SNAPSHOTS_PER_ENTITY)
@@ -351,15 +387,14 @@ export async function downloadEntityAndContentFiles(
   // Array.isArray (not a truthiness check): content[] is remote and untrusted, and a non-array
   // value would make .map throw a TypeError instead of yielding a diagnosable error.
   if (Array.isArray(entityMetadata.content)) {
+    const hashesToDownload = contentHashesToDownload(entityMetadata.content, entityId)
     const downloadQueue = new PQueue({ concurrency: contentFilesConcurrency })
     await Promise.all(
-      entityMetadata.content.map((content) =>
+      hashesToDownload.map((hash) =>
         downloadQueue.add(() =>
           downloadFileWithRetries(
             components,
-            // Optional chaining so a null entry surfaces the descriptive "Invalid content hash"
-            // rejection from downloadFileWithRetries rather than a bare TypeError.
-            content?.hash,
+            hash,
             targetFolder,
             presentInServers,
             _serverMapLRU,

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,11 @@ async function downloadProfileAvatars(
           _serverMapLRU,
           maxRetries,
           waitTimeBetweenRetries
-        ).catch(() => logger.info(`File ${snapshot} not available for download.`))
+        ).catch(() =>
+          // Truncated: the value comes from remote profile metadata, and this path is reached precisely
+          // when it was unusable, so its length is the manifest's choice.
+          logger.info('Avatar snapshot not available for download.', { entityId, snapshot: truncateForLog(snapshot) })
+        )
       )
     )
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -362,13 +362,18 @@ export async function downloadEntityAndContentFiles(
 
   // Checked before any download work, because the alternative is worse than a TypeError: every consumer
   // of content[] guards with Array.isArray and falls back to "no content", so an entity declaring an
-  // object or a string here would be reported as fully downloaded while its dependencies were never
-  // fetched — and then deployed as complete. null and undefined are genuinely "no content declared";
-  // anything else is a manifest we cannot read and must not silently treat as empty.
+  // object, a string or an explicit null here would be reported as fully downloaded while its
+  // dependencies were never fetched — and then deployed as complete.
+  //
+  // null is rejected along with the rest: @dcl/schemas declares content as a required array on Entity, so
+  // a present-but-null field is not something a conforming server sends. Only its absence means "no
+  // content declared", and absence is the one case we can read as empty without guessing.
   const declaredContent: unknown = entityMetadata.content
-  if (declaredContent !== undefined && declaredContent !== null && !Array.isArray(declaredContent)) {
+  if (declaredContent !== undefined && !Array.isArray(declaredContent)) {
     throw new Error(
-      `Entity ${entityId} declares a content field that is not an array: ${typeof declaredContent}. Refusing to treat it as having no content files.`
+      `Entity ${entityId} declares a content field that is not an array: ${
+        declaredContent === null ? 'null' : typeof declaredContent
+      }. Refusing to treat it as having no content files.`
     )
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { ILoggerComponent } from '@well-known-components/interfaces'
 import PQueue from 'p-queue'
 import { downloadFileWithRetries } from './downloader'
 import { ContentMapping, EntityHash, Server, SnapshotsFetcherComponents } from './types'
-import { isValidContentHash, streamToBuffer } from './utils'
+import { isValidContentHash, streamToBuffer, truncateForLog } from './utils'
 
 // Guard the runtime before anything else in the package is evaluated. The name is inlined rather than
 // read from package.json so this stays a plain import-time check with no filesystem access.
@@ -266,7 +266,7 @@ async function downloadProfileAvatars(
   // serialising the whole document put that in an info-level log line for every affected profile.
   logger.info('Downloading avatar snapshots missing from the entity content', {
     entityId,
-    snapshots: snapshots.join(',')
+    snapshots: truncateForLog(snapshots.join(','))
   })
   const downloadQueue = new PQueue({ concurrency })
   await Promise.all(

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,11 @@ function contentHashesToDownload(content: unknown[], entityId: EntityHash): stri
   for (const entry of content) {
     const hash = (entry as ContentMapping | undefined | null)?.hash
     if (typeof hash !== 'string' || !isValidContentHash(hash)) {
-      throw new Error(`Entity ${entityId} declares an invalid content file hash: ${JSON.stringify(hash)}`)
+      // Truncated for the same reason as the downloader's: an entry that failed validation can be any
+      // length the manifest chose.
+      throw new Error(
+        `Entity ${entityId} declares an invalid content file hash: ${truncateForLog(String(JSON.stringify(hash)))}`
+      )
     }
     hashes.add(hash)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,7 @@ async function downloadProfileAvatars(
   maxRetries: number,
   waitTimeBetweenRetries: number,
   concurrency: number,
+  entityId: EntityHash,
   entityMetadata: {
     type: string
     metadata?: any
@@ -211,7 +212,12 @@ async function downloadProfileAvatars(
     return
   }
 
-  logger.info(`Downloading snapshots ${snapshots} for fixing entity ${JSON.stringify(entityMetadata)}`)
+  // Only the ids, never the metadata: a profile carries the owner's avatar fields and ethAddress, and
+  // serialising the whole document put that in an info-level log line for every affected profile.
+  logger.info('Downloading avatar snapshots missing from the entity content', {
+    entityId,
+    snapshots: snapshots.join(',')
+  })
   const downloadQueue = new PQueue({ concurrency })
   await Promise.all(
     snapshots.map((snapshot) =>
@@ -336,6 +342,7 @@ export async function downloadEntityAndContentFiles(
       maxRetries,
       waitTimeBetweenRetries,
       contentFilesConcurrency,
+      entityId,
       entityMetadata
     )
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,10 @@ export {
 // sockets / file descriptors. Overridable via downloadEntityAndContentFiles's last argument.
 const DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY = 10
 
+// Ceiling on the avatar snapshots a single profile can ask us to fetch. Far above any real profile
+// (a handful per avatar), so it only bounds hostile or corrupt metadata.
+const MAX_AVATAR_SNAPSHOTS_PER_ENTITY = 1000
+
 /**
  * Verifies stored bytes against the content-addressed id that claims them. 'mismatch' proves the
  * local copy is not the content the id addresses (a truncated/partial or mis-keyed write); 'match'
@@ -156,14 +160,29 @@ function avatarSnapshotHashesFrom(entityMetadata: {
     (Array.isArray(entityMetadata.content) ? entityMetadata.content : []).map((content) => content?.hash)
   )
 
-  return allAvatars
-    .flatMap((avatar) => Object.values(avatar?.avatar?.snapshots ?? {}))
-    .filter((snapshot): snapshot is string => typeof snapshot === 'string' && snapshot.length > 0)
-    .map((snapshot) => {
-      const matches = snapshot.match(/^http.*\/content\/contents\/(.*)/)
-      return matches ? matches[1] : snapshot
-    })
-    .filter((snapshot) => !declaredContentHashes.has(snapshot))
+  return (
+    allAvatars
+      .flatMap((avatar) => {
+        const snapshots: unknown = avatar?.avatar?.snapshots
+        // Must be an object of named snapshots. Object.values on a *string* yields one entry per
+        // character, so a long string would expand into a download job per character — a ~50 MB
+        // metadata value is millions of queued jobs and gigabytes of heap, from a profile whose hash the
+        // attacker controls and which therefore passes verification.
+        if (!snapshots || typeof snapshots !== 'object') {
+          return []
+        }
+        return Object.values(snapshots)
+      })
+      .filter((snapshot): snapshot is string => typeof snapshot === 'string' && snapshot.length > 0)
+      .map((snapshot) => {
+        const matches = snapshot.match(/^http.*\/content\/contents\/(.*)/)
+        return matches ? matches[1] : snapshot
+      })
+      .filter((snapshot) => !declaredContentHashes.has(snapshot))
+      // Even well-shaped metadata is remote and unbounded (avatars[] has no declared limit), so cap the
+      // extra work one entity can create.
+      .slice(0, MAX_AVATAR_SNAPSHOTS_PER_ENTITY)
+  )
 }
 
 async function downloadProfileAvatars(

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,52 @@ import { hashV0, hashV1 } from '@dcl/hashing'
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import PQueue from 'p-queue'
 import { downloadFileWithRetries } from './downloader'
-import {
-  ContentMapping,
-  EntityHash,
-  Server,
-  SnapshotsFetcherComponents,
-} from './types'
+import { ContentMapping, EntityHash, Server, SnapshotsFetcherComponents } from './types'
 import { streamToBuffer } from './utils'
 
+// Guard the runtime before anything else in the package is evaluated. The name is inlined rather than
+// read from package.json so this stays a plain import-time check with no filesystem access.
+const MINIMUM_NODE_MAJOR_VERSION = 22
+if (parseInt(process.versions.node.split('.')[0], 10) < MINIMUM_NODE_MAJOR_VERSION) {
+  throw new Error(
+    `In order to work, the package @dcl/snapshots-fetcher needs to run in Node v${MINIMUM_NODE_MAJOR_VERSION} or newer to handle streams properly.`
+  )
+}
+
 export { metricsDefinitions } from './metrics'
-export { IDeployerComponent, SynchronizerComponent } from './types'
 export { createSynchronizer } from './synchronizer'
 export { getDeployedEntitiesStreamFromSnapshot, getDeployedEntitiesStreamFromPointerChanges } from './stream-entities'
+// createSynchronizer requires a full SnapshotsFetcherComponents, so everything needed to build one
+// has to be reachable from the package root. Without this, callers had to deep-import
+// '@dcl/snapshots-fetcher/dist/job-queue-port' or reimplement IJobQueue themselves.
+export { createJobQueue, IJobQueue } from './job-queue-port'
+// Tagged @public but previously reachable only through a deep import into dist/.
+export {
+  decideSnapshotDeploymentFromProcessedSet,
+  shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded
+} from './deploy-entities'
+export {
+  ContentMapping,
+  DeployableEntity,
+  DeployedEntityStreamCommonOptions,
+  EntityHash,
+  IDeployerComponent,
+  IDownloadQueue,
+  IProcessedSnapshotStorageComponent,
+  ISnapshotStorageComponent,
+  Path,
+  PointerChangesDeployedEntityStreamOptions,
+  ReconnectionOptions,
+  Server,
+  SnapshotDeployedEntityStreamOptions,
+  SnapshotMetadata,
+  SnapshotsFetcherComponents,
+  SyncJob,
+  SynchronizerComponent,
+  SynchronizerConcurrencyOptions,
+  SynchronizerOptions,
+  TimeRange
+} from './types'
 
 // Default cap on content files downloaded in parallel per entity, so a huge content[] can't exhaust
 // sockets / file descriptors. Overridable via downloadEntityAndContentFiles's last argument.
@@ -103,9 +137,33 @@ async function evictCorruptEntityFile(
   })
 }
 
-if (parseInt(process.versions.node.split('.')[0], 10) < 22) {
-  const { name } = require('../package.json')
-  throw new Error(`In order to work, the package ${name} needs to run in Node v22 or newer to handle streams properly.`)
+/**
+ * Collects the avatar snapshot hashes that are referenced by a profile but absent from its
+ * content[]. Entity metadata is remote, untrusted and not schema-validated here, so every hop is
+ * shape-checked: a single malformed profile must not abort the download of an otherwise valid
+ * entity. Unexpected shapes contribute no hashes rather than throwing.
+ */
+function avatarSnapshotHashesFrom(entityMetadata: {
+  metadata?: any
+  content?: ContentMapping[] | undefined
+}): string[] {
+  const allAvatars: unknown = entityMetadata.metadata?.avatars
+  if (!Array.isArray(allAvatars)) {
+    return []
+  }
+
+  const declaredContentHashes = new Set(
+    (Array.isArray(entityMetadata.content) ? entityMetadata.content : []).map((content) => content?.hash)
+  )
+
+  return allAvatars
+    .flatMap((avatar) => Object.values(avatar?.avatar?.snapshots ?? {}))
+    .filter((snapshot): snapshot is string => typeof snapshot === 'string' && snapshot.length > 0)
+    .map((snapshot) => {
+      const matches = snapshot.match(/^http.*\/content\/contents\/(.*)/)
+      return matches ? matches[1] : snapshot
+    })
+    .filter((snapshot) => !declaredContentHashes.has(snapshot))
 }
 
 async function downloadProfileAvatars(
@@ -117,36 +175,34 @@ async function downloadProfileAvatars(
   maxRetries: number,
   waitTimeBetweenRetries: number,
   concurrency: number,
-  entityMetadata:
-    {
-      type: string
-      metadata?: any
-      content?: ContentMapping[] | undefined
-    }) {
-  const allAvatars: any[] = entityMetadata.metadata?.avatars ?? []
-  const snapshots = allAvatars.flatMap(avatar => Object.values(avatar.avatar.snapshots ?? {}) as string[])
-    .filter(snapshot => !!snapshot)
-    .map(snapshot => {
-      const matches = snapshot.match(/^http.*\/content\/contents\/(.*)/)
-      return matches ? matches[1] : snapshot
-    })
-    .filter(snapshot => !entityMetadata.content || entityMetadata.content.find(content => content.hash === snapshot) === undefined)
-  if (snapshots.length > 0) {
-    logger.info(`Downloading snapshots ${snapshots} for fixing entity ${JSON.stringify(entityMetadata)}`)
-    const downloadQueue = new PQueue({ concurrency })
-    await Promise.all(
-      snapshots.map(snapshot => downloadQueue.add(() => downloadFileWithRetries(
-        components,
-        snapshot,
-        targetFolder,
-        presentInServers,
-        _serverMapLRU,
-        maxRetries,
-        waitTimeBetweenRetries
-      ).catch(() => logger.info(`File ${snapshot} not available for download.`))
-      ))
-    )
+  entityMetadata: {
+    type: string
+    metadata?: any
+    content?: ContentMapping[] | undefined
   }
+) {
+  const snapshots = avatarSnapshotHashesFrom(entityMetadata)
+  if (snapshots.length === 0) {
+    return
+  }
+
+  logger.info(`Downloading snapshots ${snapshots} for fixing entity ${JSON.stringify(entityMetadata)}`)
+  const downloadQueue = new PQueue({ concurrency })
+  await Promise.all(
+    snapshots.map((snapshot) =>
+      downloadQueue.add(() =>
+        downloadFileWithRetries(
+          components,
+          snapshot,
+          targetFolder,
+          presentInServers,
+          _serverMapLRU,
+          maxRetries,
+          waitTimeBetweenRetries
+        ).catch(() => logger.info(`File ${snapshot} not available for download.`))
+      )
+    )
+  )
 }
 
 /**
@@ -255,17 +311,22 @@ export async function downloadEntityAndContentFiles(
       maxRetries,
       waitTimeBetweenRetries,
       contentFilesConcurrency,
-      entityMetadata)
+      entityMetadata
+    )
   }
 
-  if (entityMetadata.content) {
+  // Array.isArray (not a truthiness check): content[] is remote and untrusted, and a non-array
+  // value would make .map throw a TypeError instead of yielding a diagnosable error.
+  if (Array.isArray(entityMetadata.content)) {
     const downloadQueue = new PQueue({ concurrency: contentFilesConcurrency })
     await Promise.all(
       entityMetadata.content.map((content) =>
         downloadQueue.add(() =>
           downloadFileWithRetries(
             components,
-            content.hash,
+            // Optional chaining so a null entry surfaces the descriptive "Invalid content hash"
+            // rejection from downloadFileWithRetries rather than a bare TypeError.
+            content?.hash,
             targetFolder,
             presentInServers,
             _serverMapLRU,

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,32 +200,45 @@ function avatarSnapshotHashesFrom(entityMetadata: {
     (Array.isArray(entityMetadata.content) ? entityMetadata.content : []).map((content) => content?.hash)
   )
 
-  return (
-    allAvatars
-      .flatMap((avatar) => {
-        const snapshots: unknown = avatar?.avatar?.snapshots
-        // Must be an object of named snapshots. Object.values on a *string* yields one entry per
-        // character, so a long string would expand into a download job per character — a ~50 MB
-        // metadata value is millions of queued jobs and gigabytes of heap, from a profile whose hash the
-        // attacker controls and which therefore passes verification.
-        if (!snapshots || typeof snapshots !== 'object') {
-          return []
-        }
-        return Object.values(snapshots)
-      })
-      .filter((snapshot): snapshot is string => typeof snapshot === 'string' && snapshot.length > 0)
-      .map((snapshot) => {
-        const matches = snapshot.match(/^http.*\/content\/contents\/(.*)/)
-        return matches ? matches[1] : snapshot
-      })
-      .filter((snapshot) => !declaredContentHashes.has(snapshot))
-      // Deduplicated before the cap, for the same reason content[] is: a profile naming one snapshot
-      // repeatedly would otherwise spend the whole budget on jobs for a single hash.
-      .filter((snapshot, index, all) => all.indexOf(snapshot) === index)
-      // Even well-shaped metadata is remote and unbounded (avatars[] has no declared limit), so cap the
-      // extra work one entity can create.
-      .slice(0, MAX_AVATAR_SNAPSHOTS_PER_ENTITY)
-  )
+  // Collected with the cap enforced as we go, rather than expanding everything and slicing at the end.
+  // avatars[] has no declared limit and the entity file may be MAX_ENTITY_FILE_SIZE_IN_BYTES, so a
+  // flatMap over every avatar's snapshots materialised the whole attacker-controlled expansion first and
+  // only then discarded it. Stopping at the cap means the intermediate never exceeds it either.
+  const hashes: string[] = []
+  const alreadyCollected = new Set<string>()
+
+  for (const avatar of allAvatars) {
+    if (hashes.length >= MAX_AVATAR_SNAPSHOTS_PER_ENTITY) {
+      break
+    }
+    const snapshots: unknown = avatar?.avatar?.snapshots
+    // Must be an object of named snapshots. Object.values on a *string* yields one entry per character,
+    // so a long string would expand into a download job per character — a ~50 MB metadata value is
+    // millions of queued jobs and gigabytes of heap, from a profile whose hash the attacker controls and
+    // which therefore passes verification.
+    if (!snapshots || typeof snapshots !== 'object') {
+      continue
+    }
+    for (const declared of Object.values(snapshots)) {
+      if (hashes.length >= MAX_AVATAR_SNAPSHOTS_PER_ENTITY) {
+        break
+      }
+      if (typeof declared !== 'string' || declared.length === 0) {
+        continue
+      }
+      const matches = declared.match(/^http.*\/content\/contents\/(.*)/)
+      const hash = matches ? matches[1] : declared
+      // Deduplicated for the same reason content[] is: a profile naming one snapshot repeatedly would
+      // otherwise spend the whole budget on jobs for a single hash.
+      if (declaredContentHashes.has(hash) || alreadyCollected.has(hash)) {
+        continue
+      }
+      alreadyCollected.add(hash)
+      hashes.push(hash)
+    }
+  }
+
+  return hashes
 }
 
 async function downloadProfileAvatars(

--- a/src/index.ts
+++ b/src/index.ts
@@ -336,6 +336,13 @@ export async function downloadEntityAndContentFiles(
   contentFilesConcurrency: number = DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY,
   transferLimits?: TransferLimits
 ): Promise<unknown> {
+  // Checked before any work, not where the queue is built: p-queue rejects a bad concurrency with its own
+  // TypeError, and by then the entity file and the profile-avatar fallbacks have already been downloaded.
+  // A caller passing 0 deserves to be told in this package's terms, before spending requests.
+  if (!Number.isInteger(contentFilesConcurrency) || contentFilesConcurrency < 1) {
+    throw new Error(`contentFilesConcurrency must be an integer >= 1, got ${contentFilesConcurrency}`)
+  }
+
   const logger = components.logs.getLogger(`downloadEntityAndContentFiles)`)
 
   // download entity file

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,8 @@ import { streamToBuffer } from './utils'
 
 // Guard the runtime before anything else in the package is evaluated. The name is inlined rather than
 // read from package.json so this stays a plain import-time check with no filesystem access.
-const MINIMUM_NODE_MAJOR_VERSION = 22
+// Raised from 22 to 24 by @dcl/catalyst-storage@5, whose own engines field requires >=24.
+const MINIMUM_NODE_MAJOR_VERSION = 24
 if (parseInt(process.versions.node.split('.')[0], 10) < MINIMUM_NODE_MAJOR_VERSION) {
   throw new Error(
     `In order to work, the package @dcl/snapshots-fetcher needs to run in Node v${MINIMUM_NODE_MAJOR_VERSION} or newer to handle streams properly.`

--- a/src/job-lifecycle-manager.ts
+++ b/src/job-lifecycle-manager.ts
@@ -34,6 +34,11 @@ export function createJobLifecycleManagerComponent(
   const logs = components.logs.getLogger(options.jobManagerName)
 
   const createdJobs = new Map<string, IJobWithLifecycle>()
+  // Tracks each name's in-flight run, so a replacement for that name waits for its predecessor to
+  // wind down instead of running alongside it. It keys off start(), which per IJobWithLifecycle is
+  // where a job actually ends — stop() is only the signal to end and can resolve while the job is
+  // still finishing.
+  const runningJobs = new Map<string, Promise<void>>()
 
   return {
     setDesiredJobs(desiredJobNames: Set<string>): void {
@@ -44,6 +49,7 @@ export function createJobLifecycleManagerComponent(
           logs.info('Stopping job', { name })
           job.stop().catch((err) => logs.error(err))
           createdJobs.delete(name)
+          // Its entry in runningJobs stays until start() returns; a replacement chains onto it.
         }
       }
 
@@ -53,16 +59,39 @@ export function createJobLifecycleManagerComponent(
           logs.info('Creating job', { name })
           const job = options.createJob(name)
           createdJobs.set(name, job)
-          job
-            .start()
-            .catch((err) => logs.error(err))
-            .finally(() => {
-              // then remove it from the list of running jobs after it ends
-              if (createdJobs.get(name) === job) {
-                logs.info('Job finished', { name })
-                createdJobs.delete(name)
-              }
-            })
+
+          const startJob = () => {
+            // A newer setDesiredJobs may already have replaced or removed this job while it waited.
+            if (createdJobs.get(name) !== job) {
+              return
+            }
+            return job
+              .start()
+              .catch((err) => logs.error(err))
+              .finally(() => {
+                // then remove it from the list of running jobs after it ends
+                if (createdJobs.get(name) === job) {
+                  logs.info('Job finished', { name })
+                  createdJobs.delete(name)
+                }
+              })
+          }
+
+          // Start synchronously when no previous run of this name is still winding down, so callers
+          // observing the manager right after setDesiredJobs see the job already running.
+          const previousRun = runningJobs.get(name)
+          const run = previousRun ? previousRun.then(startJob) : startJob()
+
+          const settledRun = Promise.resolve(run).then(
+            () => undefined,
+            () => undefined
+          )
+          runningJobs.set(name, settledRun)
+          void settledRun.then(() => {
+            if (runningJobs.get(name) === settledRun) {
+              runningJobs.delete(name)
+            }
+          })
         }
       }
     },

--- a/src/job-lifecycle-manager.ts
+++ b/src/job-lifecycle-manager.ts
@@ -105,12 +105,16 @@ export function createJobLifecycleManagerComponent(
 
       for (const [name, job] of createdJobs) {
         logs.info('Stopping job', { name })
+        // Removed *before* awaiting. `await job.stop()` yields, and a replacement start that is queued
+        // behind another run can fire in that gap; while this entry is still present that deferred
+        // startJob sees itself as current and starts a job we have just stopped, whose run then never
+        // settles — so the Promise.all below would wait forever.
+        createdJobs.delete(name)
         try {
           await job.stop()
         } catch (e: any) {
           logs.error(e)
         }
-        createdJobs.delete(name)
       }
 
       // Signalling is not enough. Per IJobWithLifecycle a job ends when start() returns, so a job

--- a/src/job-lifecycle-manager.ts
+++ b/src/job-lifecycle-manager.ts
@@ -99,6 +99,10 @@ export function createJobLifecycleManagerComponent(
       return new Set(createdJobs.keys())
     },
     async stop() {
+      // Captured before signalling: entries disappear as runs finish, and we want to wait for all of
+      // them.
+      const inFlightRuns = Array.from(runningJobs.values())
+
       for (const [name, job] of createdJobs) {
         logs.info('Stopping job', { name })
         try {
@@ -108,6 +112,12 @@ export function createJobLifecycleManagerComponent(
         }
         createdJobs.delete(name)
       }
+
+      // Signalling is not enough. Per IJobWithLifecycle a job ends when start() returns, so a job
+      // signalled above can still be inside its action — deploying entities, advancing timestamps —
+      // after this resolved. Callers treat a resolved stop() as "quiescent", so wait for the runs
+      // themselves. Each entry already absorbs its own rejection, so this never throws.
+      await Promise.all(inFlightRuns)
     }
   }
 }

--- a/src/job-queue-port.ts
+++ b/src/job-queue-port.ts
@@ -7,8 +7,13 @@ import PQueue from 'p-queue'
  * Lifecycle: `stop()` is terminal. It waits for everything already scheduled to finish, and from the
  * moment it is called the queue refuses new work — `scheduleJob`, `scheduleJobWithPriority` and
  * `scheduleJobWithRetries` throw, and a retry ladder already in flight stops re-enqueueing itself. A
- * stopped queue cannot be restarted; build another. Use `onIdle()` if what you want is "wait for the
- * current work to drain" without ending the queue.
+ * stopped queue cannot be restarted; build another.
+ *
+ * A queue built with `autoStart: false` is started by `stop()` so its queued work can drain — otherwise
+ * shutdown would wait on jobs that never begin. `onIdle()` deliberately does not do this: it is a query
+ * about the current work, not a lifecycle action, so awaiting it on a queue that was never started waits
+ * for something that will not happen. Use `onIdle()` when you want "wait for the current work to drain"
+ * without ending the queue.
  * @public
  */
 export type IJobQueue = {
@@ -189,7 +194,13 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
     },
     async stop() {
       stopped = true
-      // wait until the jobs are finished at stop()
+      // Started before draining, or a paused queue never drains at all: onIdle() resolves on
+      // `pending === 0 && size === 0`, and an autoStart:false queue holds its jobs in `size` without ever
+      // starting them — so stop() waited forever and every scheduled promise stayed pending. IJobQueue
+      // exposes no way to start a paused queue, so a consumer had no way out of that either. Starting it
+      // here is what makes the documented "waits for everything already scheduled to finish" true
+      // regardless of how the queue was constructed, rather than only for an auto-starting one.
+      realQueue.start()
       await waitUntilQuiescent()
     }
   }

--- a/src/job-queue-port.ts
+++ b/src/job-queue-port.ts
@@ -51,6 +51,18 @@ export type IJobQueue = {
 }
 
 export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBaseComponent {
+  // Validated here rather than left to p-queue, whose TypeError names its own option and not this
+  // package's. `concurrency` is required in the type because it was already required in fact: p-queue only
+  // falls back to unbounded concurrency when the key is absent, and this factory always passes it, so
+  // omitting it threw `Expected \`concurrency\` to be a number from 1 and up, got \`undefined\`` — an
+  // optional-looking field that could not actually be omitted.
+  if (!Number.isInteger(options.concurrency) || options.concurrency < 1) {
+    throw new Error(`concurrency must be an integer >= 1, got ${options.concurrency}`)
+  }
+  if (options.timeout !== undefined && (!Number.isInteger(options.timeout) || options.timeout < 1)) {
+    throw new Error(`timeout must be an integer >= 1, got ${options.timeout}`)
+  }
+
   const realQueue = new PQueue({
     concurrency: options.concurrency,
     autoStart: options.autoStart ?? true,
@@ -208,8 +220,21 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
 
 export namespace createJobQueue {
   export type Options = {
+    /**
+     * Start processing as soon as jobs are scheduled. Defaults to true. When false, the queue holds its
+     * jobs until `stop()` drains them — see the lifecycle note on {@link IJobQueue}.
+     */
     autoStart?: boolean
-    concurrency?: number
+    /**
+     * Maximum jobs running at once. Required: an unbounded download or deployment queue is never what a
+     * consumer wants, and p-queue's absent-key default is exactly that. Must be an integer >= 1.
+     */
+    concurrency: number
+    /**
+     * Milliseconds after which a job counts as failed. A timed-out attempt is retried by
+     * `scheduleJobWithRetries`, and **keeps running** — nothing can cancel a promise — so scheduled
+     * functions must be idempotent. Must be an integer >= 1 when given; omit for no timeout.
+     */
     timeout?: number
   }
 }

--- a/src/job-queue-port.ts
+++ b/src/job-queue-port.ts
@@ -2,7 +2,13 @@ import { IBaseComponent } from '@well-known-components/interfaces'
 import PQueue from 'p-queue'
 
 /**
- * Abstract job queue
+ * Abstract job queue.
+ *
+ * Lifecycle: `stop()` is terminal. It waits for everything already scheduled to finish, and from the
+ * moment it is called the queue refuses new work — `scheduleJob`, `scheduleJobWithPriority` and
+ * `scheduleJobWithRetries` throw, and a retry ladder already in flight stops re-enqueueing itself. A
+ * stopped queue cannot be restarted; build another. Use `onIdle()` if what you want is "wait for the
+ * current work to drain" without ending the queue.
  * @public
  */
 export type IJobQueue = {
@@ -69,6 +75,12 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
     }
   }
 
+  // Terminal once stop() begins. The queue is exported from the package root, and a stop() that leaves
+  // the queue accepting work means a consumer that called it can still have jobs start afterwards — the
+  // exact "stop() does not stop" shape this package has been correcting elsewhere. Refusing new work also
+  // makes stop() converge instead of chasing retries that keep re-enqueueing themselves.
+  let stopped = false
+
   // Every scheduled function that has actually started and not yet settled.
   //
   // p-queue cannot cancel a function it has timed out: with `throwOnTimeout` the queue promise rejects
@@ -90,6 +102,12 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
     }
   }
 
+  function assertNotStopped() {
+    if (stopped) {
+      throw new Error('The job queue was stopped and no longer accepts jobs')
+    }
+  }
+
   async function waitUntilQuiescent(): Promise<void> {
     // Looped because draining either side can feed the other: a retry can be queued while we await the
     // executions, and an execution can outlive the queue's own idea of idle.
@@ -104,6 +122,7 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
       return waitUntilQuiescent()
     },
     scheduleJob<T>(fn: () => Promise<T>): Promise<T> {
+      assertNotStopped()
       return realQueue.add(tracked(fn))
     },
     async onSizeLessThan(limit: number): Promise<void> {
@@ -127,6 +146,7 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
       })
     },
     scheduleJobWithPriority<T>(fn: () => Promise<T>, priority: number): Promise<T> {
+      assertNotStopped()
       return realQueue.add(tracked(fn), {
         priority
       })
@@ -140,8 +160,15 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
       if (!Number.isInteger(retries) || retries < 1) {
         throw new Error(`retries must be an integer >= 1, got ${retries}`)
       }
+      assertNotStopped()
       return new Promise<T>((resolve, reject) => {
         function schedule(remainingRetries: number) {
+          // Checked per attempt, not only on entry: a ladder already in flight when stop() lands must
+          // not keep re-enqueueing itself, or stop() would wait for work it is trying to end.
+          if (stopped) {
+            reject(new Error('The job queue was stopped before this job could be retried'))
+            return
+          }
           // The job is added as-is so the queue owns its outcome. Settling inside the queued function
           // instead hid every queue-level rejection — a timeout in particular — from the retry logic,
           // because the function's own try/catch never sees it.
@@ -161,6 +188,7 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
       })
     },
     async stop() {
+      stopped = true
       // wait until the jobs are finished at stop()
       await waitUntilQuiescent()
     }

--- a/src/job-queue-port.ts
+++ b/src/job-queue-port.ts
@@ -107,6 +107,12 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
       return realQueue.add(tracked(fn))
     },
     async onSizeLessThan(limit: number): Promise<void> {
+      // A limit of 0 or below can never be satisfied — the queue size is never negative — so the caller
+      // would wait forever with no indication why. Fail instead of hanging.
+      if (!Number.isInteger(limit) || limit < 1) {
+        throw new Error(`limit must be an integer >= 1, got ${limit}`)
+      }
+
       // Instantly resolve if the queue is already below the limit.
       if (realQueue.size < limit) {
         return
@@ -126,8 +132,13 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
       })
     },
     scheduleJobWithRetries<T>(fn: () => Promise<T>, retries: number): Promise<T> {
-      if (!(retries | 0)) {
-        throw new Error('At least one retry is required')
+      // Plain integer validation, not the bitwise `!(retries | 0)` this used to do. `| 0` coerces to
+      // int32, so it let 2.5 through as 2 and -1 through as -1 (which then rejected on the first failure,
+      // silently behaving like no retries at all), while wrongly refusing anything at or above 2^32
+      // because the coercion wrapped it to 0. Now that the queue is exported from the package root, a
+      // caller passing a bad value deserves to be told rather than to get quiet nonsense.
+      if (!Number.isInteger(retries) || retries < 1) {
+        throw new Error(`retries must be an integer >= 1, got ${retries}`)
       }
       return new Promise<T>((resolve, reject) => {
         function schedule(remainingRetries: number) {

--- a/src/job-queue-port.ts
+++ b/src/job-queue-port.ts
@@ -17,6 +17,11 @@ export type IJobQueue = {
   onSizeLessThan(limit: number): Promise<void>
   /**
    * Schedules a job with retries. If it fails (throws), then the job goes back to the end of the queue to be processed later.
+   *
+   * A configured `timeout` counts as a failure and is retried. Note that nothing can cancel a
+   * JavaScript promise, so a timed-out attempt keeps running while its retry starts: **the scheduled
+   * function must be idempotent and safe to run concurrently with itself.** `onIdle()` and `stop()` do
+   * wait for those abandoned attempts, so quiescence is still accurate.
    */
   scheduleJobWithRetries<T>(fn: () => Promise<T>, retries: number): Promise<T>
   /**
@@ -25,7 +30,11 @@ export type IJobQueue = {
    */
   scheduleJobWithPriority<T>(fn: () => Promise<T>, priority: number): Promise<T>
   /**
-   * All finished
+   * Resolves when nothing is queued and nothing is still executing.
+   *
+   * This waits for the scheduled functions themselves, not just for the queue's own bookkeeping: a job
+   * that hit the configured `timeout` is no longer counted by the queue but is still running, since a
+   * promise cannot be cancelled.
    */
   onIdle(): Promise<void>
 }
@@ -60,12 +69,42 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
     }
   }
 
+  // Every scheduled function that has actually started and not yet settled.
+  //
+  // p-queue cannot cancel a function it has timed out: with `throwOnTimeout` the queue promise rejects
+  // and the queue stops counting the task, but the function keeps running — and may keep mutating
+  // whatever it was mutating. Tracking executions ourselves is what makes onIdle()/stop() mean
+  // "nothing is running" rather than "the queue has stopped waiting".
+  const inFlightExecutions = new Set<Promise<void>>()
+
+  function tracked<T>(fn: () => Promise<T>): () => Promise<T> {
+    return () => {
+      const running = fn()
+      const settled = Promise.resolve(running).then(
+        () => undefined,
+        () => undefined
+      )
+      inFlightExecutions.add(settled)
+      void settled.then(() => inFlightExecutions.delete(settled))
+      return running
+    }
+  }
+
+  async function waitUntilQuiescent(): Promise<void> {
+    // Looped because draining either side can feed the other: a retry can be queued while we await the
+    // executions, and an execution can outlive the queue's own idea of idle.
+    do {
+      await realQueue.onIdle()
+      await Promise.all(Array.from(inFlightExecutions))
+    } while (realQueue.size > 0 || realQueue.pending > 0 || inFlightExecutions.size > 0)
+  }
+
   return {
     onIdle() {
-      return realQueue.onIdle()
+      return waitUntilQuiescent()
     },
     scheduleJob<T>(fn: () => Promise<T>): Promise<T> {
-      return realQueue.add(fn)
+      return realQueue.add(tracked(fn))
     },
     async onSizeLessThan(limit: number): Promise<void> {
       // Instantly resolve if the queue is already below the limit.
@@ -82,7 +121,7 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
       })
     },
     scheduleJobWithPriority<T>(fn: () => Promise<T>, priority: number): Promise<T> {
-      return realQueue.add(fn, {
+      return realQueue.add(tracked(fn), {
         priority
       })
     },
@@ -96,7 +135,7 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
           // instead hid every queue-level rejection — a timeout in particular — from the retry logic,
           // because the function's own try/catch never sees it.
           realQueue
-            .add(fn)
+            .add(tracked(fn))
             .then(resolve)
             .catch((err: any) => {
               if (remainingRetries <= 0) {
@@ -112,7 +151,7 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
     },
     async stop() {
       // wait until the jobs are finished at stop()
-      await realQueue.onIdle()
+      await waitUntilQuiescent()
     }
   }
 }

--- a/src/job-queue-port.ts
+++ b/src/job-queue-port.ts
@@ -34,8 +34,31 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
   const realQueue = new PQueue({
     concurrency: options.concurrency,
     autoStart: options.autoStart ?? true,
-    timeout: options.timeout
+    timeout: options.timeout,
+    // p-queue defaults throwOnTimeout to false, which makes a timed-out job *resolve* as if it had
+    // succeeded while its function keeps running uncancelled. That hid timeouts from
+    // scheduleJobWithRetries and let stop() report the queue drained while jobs were still in flight.
+    throwOnTimeout: options.timeout !== undefined
   })
+
+  // All onSizeLessThan waiters share a single 'next' subscription. One listener per call would grow
+  // with every pending waiter (tripping Node's max-listeners warning) and would stay attached for as
+  // long as a waiter's limit is unmet; here the subscription exists only while someone is waiting.
+  const sizeWaiters = new Set<{ limit: number; resolve: () => void }>()
+  let sizeListenerAttached = false
+
+  function notifySizeWaiters() {
+    for (const waiter of Array.from(sizeWaiters)) {
+      if (realQueue.size < waiter.limit) {
+        sizeWaiters.delete(waiter)
+        waiter.resolve()
+      }
+    }
+    if (sizeWaiters.size === 0 && sizeListenerAttached) {
+      realQueue.off('next', notifySizeWaiters)
+      sizeListenerAttached = false
+    }
+  }
 
   return {
     onIdle() {
@@ -45,20 +68,17 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
       return realQueue.add(fn)
     },
     async onSizeLessThan(limit: number): Promise<void> {
-      // Instantly resolve if the queue is empty.
+      // Instantly resolve if the queue is already below the limit.
       if (realQueue.size < limit) {
         return
       }
 
-      return new Promise((resolve) => {
-        const listener = () => {
-          if (realQueue.size < limit) {
-            realQueue.off('next', listener)
-            resolve()
-          }
+      return new Promise<void>((resolve) => {
+        sizeWaiters.add({ limit, resolve })
+        if (!sizeListenerAttached) {
+          realQueue.on('next', notifySizeWaiters)
+          sizeListenerAttached = true
         }
-
-        realQueue.on('next', listener)
       })
     },
     scheduleJobWithPriority<T>(fn: () => Promise<T>, priority: number): Promise<T> {
@@ -71,20 +91,20 @@ export function createJobQueue(options: createJobQueue.Options): IJobQueue & IBa
         throw new Error('At least one retry is required')
       }
       return new Promise<T>((resolve, reject) => {
-        function schedule(retries: number) {
+        function schedule(remainingRetries: number) {
+          // The job is added as-is so the queue owns its outcome. Settling inside the queued function
+          // instead hid every queue-level rejection — a timeout in particular — from the retry logic,
+          // because the function's own try/catch never sees it.
           realQueue
-            .add(async () => {
-              try {
-                resolve(await fn())
-              } catch (e: any) {
-                if (retries <= 0) {
-                  reject(e)
-                } else {
-                  schedule(retries - 1)
-                }
+            .add(fn)
+            .then(resolve)
+            .catch((err: any) => {
+              if (remainingRetries <= 0) {
+                reject(err)
+              } else {
+                schedule(remainingRetries - 1)
               }
             })
-            .catch(reject)
         }
 
         schedule(retries)

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -99,6 +99,6 @@ export const metricsDefinitions = validateMetricsDeclaration({
   dcl_processed_snapshots_total: {
     help: 'Total number of processed snapshots that started being streamed.',
     type: 'counter',
-    labelNames: ['state'] // state='stream_end'|'saved'
+    labelNames: ['state'] // state='stream_end'|'saved'|'incomplete'
   }
 })

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -94,6 +94,6 @@ export const metricsDefinitions = validateMetricsDeclaration({
   dcl_processed_snapshots_total: {
     help: 'Total number of processed snapshots that started being streamed.',
     type: 'counter',
-    labelNames: ['state'] // state='stream_start'|'stream_end'|'saved'
+    labelNames: ['state'] // state='stream_end'|'saved'
   }
 })

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -35,10 +35,13 @@ export const metricsDefinitions = validateMetricsDeclaration({
     labelNames: []
   },
 
+  // remote_server carries the origin of the server a deployment came from, and is empty for
+  // source=snapshots: a snapshot is content-addressed and commonly advertised by several servers, so
+  // there is no single origin to attribute its entities to.
   dcl_entities_deployments_processed_total: {
     help: 'Entities processed from remote catalysts',
     type: 'counter',
-    labelNames: ['remote_server', 'source']
+    labelNames: ['remote_server', 'source'] // source=snapshots|pointer-changes
   },
 
   dcl_entities_deployments_streamed_total: {
@@ -51,7 +54,9 @@ export const metricsDefinitions = validateMetricsDeclaration({
     help: 'Counts the connection of a deployment stream',
     type: 'histogram',
     buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60],
-    labelNames: ['remote_server', 'status_code']
+    // No status_code: the timer wraps fetchJson, which throws on a non-2xx instead of surfacing the
+    // status, so the label was declared but never populated on any observation.
+    labelNames: ['remote_server']
   },
 
   dcl_deployments_stream_reconnection_count: {

--- a/src/pointer-changes-limits.ts
+++ b/src/pointer-changes-limits.ts
@@ -1,0 +1,55 @@
+import { PointerChangesSyncDeployment } from '@dcl/schemas'
+
+// These are local safety limits, deliberately much larger than real deployments. The schema bounds
+// none of them, while every value is parsed from an untrusted paginated response and boundary rows are
+// subsequently sorted and hashed.
+const MAX_POINTERS_PER_DEPLOYMENT = 10_000
+const MAX_AUTH_LINKS_PER_DEPLOYMENT = 100
+const MAX_BOUNDARY_STRING_SIZE_IN_BYTES = 256 * 1024
+const MAX_BOUNDARY_ROW_SIZE_IN_BYTES = 1024 * 1024
+
+/**
+ * Refuses schema-valid pointer-change rows whose structure is too large to fingerprint safely.
+ *
+ * @throws When a count, individual string, or the aggregate fingerprint material exceeds its limit.
+ * @internal
+ */
+export function assertPointerChangesDeploymentWithinStructuralLimits(deployment: PointerChangesSyncDeployment): void {
+  if (deployment.pointers.length > MAX_POINTERS_PER_DEPLOYMENT) {
+    throw new Error(
+      `Pointer-change deployment has ${deployment.pointers.length} pointers, above the maximum of ${MAX_POINTERS_PER_DEPLOYMENT}`
+    )
+  }
+  if (deployment.authChain.length > MAX_AUTH_LINKS_PER_DEPLOYMENT) {
+    throw new Error(
+      `Pointer-change deployment has ${deployment.authChain.length} auth-chain links, above the maximum of ${MAX_AUTH_LINKS_PER_DEPLOYMENT}`
+    )
+  }
+
+  let totalBytes = 0
+  const includeString = (name: string, value: string): void => {
+    const bytes = Buffer.byteLength(value, 'utf8')
+    if (bytes > MAX_BOUNDARY_STRING_SIZE_IN_BYTES) {
+      throw new Error(
+        `Pointer-change deployment ${name} is ${bytes} bytes, above the maximum of ${MAX_BOUNDARY_STRING_SIZE_IN_BYTES}`
+      )
+    }
+    totalBytes += bytes
+    if (totalBytes > MAX_BOUNDARY_ROW_SIZE_IN_BYTES) {
+      throw new Error(
+        `Pointer-change deployment fingerprint fields exceed the maximum total of ${MAX_BOUNDARY_ROW_SIZE_IN_BYTES} bytes`
+      )
+    }
+  }
+
+  includeString('entityType', deployment.entityType)
+  includeString('entityId', deployment.entityId)
+  for (const pointer of deployment.pointers) {
+    includeString('pointer', pointer)
+  }
+  for (const link of deployment.authChain) {
+    includeString('auth-chain type', link.type)
+    includeString('auth-chain payload', link.payload)
+    includeString('auth-chain signature', link.signature ?? '')
+  }
+}

--- a/src/serial-job-runner.ts
+++ b/src/serial-job-runner.ts
@@ -11,7 +11,7 @@ export type SerialJobRunner = {
   enqueue(job: IJobWithLifecycle): void
   /** Number of jobs queued, including the one currently running. */
   size(): number
-  /** Stop the running job and drop the rest; no further jobs will start. */
+  /** Stop every queued job (the running one included); no further jobs will start. */
   stop(): Promise<void>
 }
 
@@ -49,10 +49,17 @@ export function createSerialJobRunner(logger: ILoggerComponent.ILogger): SerialJ
     },
     async stop() {
       stopped = true
-      const runningJob = jobs[0]
+      // Stop every queued job, not just the running one: a job that is dropped without being
+      // stopped never gets to settle whatever it handed its caller (e.g. a completion future), and
+      // the caller would wait on it forever.
+      const queuedJobs = jobs.slice()
       jobs.length = 0
-      if (runningJob) {
-        await runningJob.stop()
+      for (const job of queuedJobs) {
+        try {
+          await job.stop()
+        } catch (err: any) {
+          logger.error(err)
+        }
       }
     }
   }

--- a/src/serial-job-runner.ts
+++ b/src/serial-job-runner.ts
@@ -18,16 +18,20 @@ export type SerialJobRunner = {
 export function createSerialJobRunner(logger: ILoggerComponent.ILogger): SerialJobRunner {
   const jobs: IJobWithLifecycle[] = []
   let stopped = false
+  // The run of the job currently executing, so stop() can wait for it to actually finish rather than
+  // merely signalling it. Undefined whenever nothing is running.
+  let currentRun: Promise<void> | undefined
 
   function startNext() {
     if (stopped || jobs.length === 0) {
       return
     }
-    jobs[0]
+    currentRun = jobs[0]
       .start()
       .catch((err) => logger.error(err))
       .finally(() => {
         jobs.shift()
+        currentRun = undefined
         startNext()
       })
   }
@@ -61,6 +65,11 @@ export function createSerialJobRunner(logger: ILoggerComponent.ILogger): SerialJ
           logger.error(err)
         }
       }
+
+      // stop() above only raises the signal; the running job ends when its start() returns. Waiting
+      // for it here is what lets a caller treat a resolved stop() as "nothing is running any more".
+      // `stopped` already prevents startNext from picking up anything else.
+      await currentRun
     }
   }
 }

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -23,7 +23,8 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
   },
   options: SnapshotDeployedEntityStreamOptions,
   snapshotHash: string,
-  servers: Set<string>
+  servers: Set<string>,
+  shouldStop: () => boolean = () => false
 ) {
   const genesisTimestamp = options.fromTimestamp || 0
   const logs = components.logs.getLogger('getDeployedEntitiesStreamFromSnapshot')
@@ -40,7 +41,8 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
       serversList,
       new Map(),
       options.requestMaxRetries,
-      options.requestRetryWaitTime
+      options.requestRetryWaitTime,
+      shouldStop
     )
 
     // 2. open the snapshot file and process line by line

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -1,8 +1,9 @@
-import { AuthLink, PointerChangesSyncDeployment } from '@dcl/schemas'
+import { PointerChangesSyncDeployment } from '@dcl/schemas'
 import { createHash } from 'crypto'
 import { fetchPointerChanges } from './client'
 import { downloadFileWithRetries } from './downloader'
 import { processDeploymentsInFile, SnapshotStreamReport } from './file-processor'
+import { assertPointerChangesDeploymentWithinStructuralLimits } from './pointer-changes-limits'
 import {
   PointerChangesDeployedEntityStreamOptions,
   SnapshotDeployedEntityStreamOptions,
@@ -101,26 +102,50 @@ const MAX_BOUNDARY_ROWS_TRACKED = 10_000
  * new row arrives before the replay of the one already delivered, an id-keyed budget spends the allowance
  * on the new row, suppresses it, and then yields the replay: the new pointer-change is silently lost.
  *
- * Fingerprinting every field the schema carries removes that guesswork. The canonical row is reduced to a
- * fixed-size digest before it becomes a retained map key: remote pointer and auth-chain strings are bounded
- * only by the per-page response cap, and retaining their serialized values across many pages would let one
- * timestamp grow this state far beyond that cap. Counts are still kept alongside the digest, because two
- * rows identical in all of these fields are genuinely indistinguishable.
+ * Fingerprinting every field the schema carries removes that guesswork. Each field is streamed into a
+ * fixed-size digest rather than first serializing the whole row: remote pointer and auth-chain strings are
+ * bounded only by the per-page response cap, so retaining or transiently duplicating their canonical form
+ * would let one timestamp consume far more memory than its fixed-size keys require. Length prefixes keep
+ * adjacent variable-length fields unambiguous. Counts are still kept alongside the digest, because two rows
+ * identical in all of these fields are genuinely indistinguishable.
  *
  * @internal
  */
 export function boundaryRowFingerprint(deployment: PointerChangesSyncDeployment): string {
-  const canonicalRow = JSON.stringify([
-    deployment.entityType,
-    deployment.entityId,
-    deployment.entityTimestamp,
-    deployment.localTimestamp,
-    // Sorted so a server listing an equivalent pointer set in another order does not read as a new row.
-    [...deployment.pointers].sort(),
-    deployment.authChain.map((link: AuthLink) => [link.type, link.payload, link.signature ?? ''])
-  ])
+  // Defensive for direct/deep callers. The normal stream path has already applied this before yielding
+  // the deployment, but this function remains a runtime export even when stripInternal removes it from
+  // declarations.
+  assertPointerChangesDeploymentWithinStructuralLimits(deployment)
+  const hash = createHash('sha256')
+  const updateField = (value: string | number): void => {
+    const encoded = String(value)
+    hash.update(String(Buffer.byteLength(encoded, 'utf8')))
+    hash.update(':')
+    hash.update(encoded, 'utf8')
+  }
 
-  return createHash('sha256').update(canonicalRow).digest('base64url')
+  // Domain/version first, so changing the canonical field sequence later cannot silently reuse keys.
+  updateField('pointer-change-boundary-row-v1')
+  updateField(deployment.entityType)
+  updateField(deployment.entityId)
+  updateField(deployment.entityTimestamp)
+  updateField(deployment.localTimestamp)
+
+  // Sorted so a server listing an equivalent pointer set in another order does not read as a new row.
+  const sortedPointers = [...deployment.pointers].sort()
+  updateField(sortedPointers.length)
+  for (const pointer of sortedPointers) {
+    updateField(pointer)
+  }
+
+  updateField(deployment.authChain.length)
+  for (const link of deployment.authChain) {
+    updateField(link.type)
+    updateField(link.payload)
+    updateField(link.signature ?? '')
+  }
+
+  return hash.digest('base64url')
 }
 
 export async function* getDeployedEntitiesStreamFromPointerChanges(
@@ -170,8 +195,6 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
     // Seeded from the previous boundary because the stream is still standing at that timestamp: if this
     // poll never advances past it, the next one must still skip what was already sent there.
     let rowsDeliveredAtGreatestTimestamp = new Map(rowsDeliveredAtPreviousBoundary)
-    let boundaryTrackingCapReported = false
-
     // 1. download pointer changes and yield
     const pointerChanges = fetchPointerChanges(
       components,
@@ -212,6 +235,20 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
 
       // selectively ignore deployments by localTimestamp, and skip only what an earlier poll delivered
       if (localTimestamp >= genesisTimestamp && !alreadyDeliveredBeforeThisPoll) {
+        if (
+          localTimestamp === greatestLocalTimestampProcessed &&
+          fingerprint !== undefined &&
+          !rowsDeliveredAtGreatestTimestamp.has(fingerprint) &&
+          rowsDeliveredAtGreatestTimestamp.size >= MAX_BOUNDARY_ROWS_TRACKED
+        ) {
+          // Failing before yielding the untrackable row means no work from this poll is committed by the
+          // synchronizer's onPollEnd checkpoint. Its retry component then backs off instead of deploying
+          // the overflow rows on every inclusive poll forever.
+          throw new Error(
+            `Too many distinct deployments at local timestamp ${localTimestamp} from ${contentServer}; ` +
+              `the maximum boundary rows tracked per poll is ${MAX_BOUNDARY_ROWS_TRACKED}`
+          )
+        }
         components.metrics?.increment('dcl_entities_deployments_streamed_total', {
           ...pointerChangesMetricLabels,
           source: 'pointer-changes'
@@ -224,13 +261,6 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
               fingerprint,
               (rowsDeliveredAtGreatestTimestamp.get(fingerprint) ?? 0) + 1
             )
-          } else if (!boundaryTrackingCapReported) {
-            boundaryTrackingCapReported = true
-            logs.warn('Too many distinct deployments at one timestamp to track; some may be re-delivered.', {
-              contentServer,
-              localTimestamp,
-              limit: String(MAX_BOUNDARY_ROWS_TRACKED)
-            })
           }
         }
       }

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -1,4 +1,5 @@
 import { AuthLink, PointerChangesSyncDeployment } from '@dcl/schemas'
+import { createHash } from 'crypto'
 import { fetchPointerChanges } from './client'
 import { downloadFileWithRetries } from './downloader'
 import { processDeploymentsInFile, SnapshotStreamReport } from './file-processor'
@@ -100,11 +101,16 @@ const MAX_BOUNDARY_ROWS_TRACKED = 10_000
  * new row arrives before the replay of the one already delivered, an id-keyed budget spends the allowance
  * on the new row, suppresses it, and then yields the replay: the new pointer-change is silently lost.
  *
- * Fingerprinting every field the schema carries removes that guesswork. Counts are still kept alongside,
- * because two rows identical in all of these fields are genuinely indistinguishable.
+ * Fingerprinting every field the schema carries removes that guesswork. The canonical row is reduced to a
+ * fixed-size digest before it becomes a retained map key: remote pointer and auth-chain strings are bounded
+ * only by the per-page response cap, and retaining their serialized values across many pages would let one
+ * timestamp grow this state far beyond that cap. Counts are still kept alongside the digest, because two
+ * rows identical in all of these fields are genuinely indistinguishable.
+ *
+ * @internal
  */
-function boundaryRowFingerprint(deployment: PointerChangesSyncDeployment): string {
-  return JSON.stringify([
+export function boundaryRowFingerprint(deployment: PointerChangesSyncDeployment): string {
+  const canonicalRow = JSON.stringify([
     deployment.entityType,
     deployment.entityId,
     deployment.entityTimestamp,
@@ -113,6 +119,8 @@ function boundaryRowFingerprint(deployment: PointerChangesSyncDeployment): strin
     [...deployment.pointers].sort(),
     deployment.authChain.map((link: AuthLink) => [link.type, link.payload, link.signature ?? ''])
   ])
+
+  return createHash('sha256').update(canonicalRow).digest('base64url')
 }
 
 export async function* getDeployedEntitiesStreamFromPointerChanges(

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -27,14 +27,17 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
 ) {
   const genesisTimestamp = options.fromTimestamp || 0
   const logs = components.logs.getLogger('getDeployedEntitiesStreamFromSnapshot')
-  logs.info('Snapshot to be processed.', { hash: snapshotHash, contentServers: JSON.stringify(Array.from(servers)) })
+  // Materialised once. Every yielded deployment carries this list, and rebuilding it per entity meant
+  // one array allocation per entity in the snapshot.
+  const serversList = Array.from(servers)
+  logs.info('Snapshot to be processed.', { hash: snapshotHash, contentServers: JSON.stringify(serversList) })
   try {
     // 1. download the snapshot file if needed
     await downloadFileWithRetries(
       components,
       snapshotHash,
       options.tmpDownloadFolder,
-      Array.from(servers),
+      serversList,
       new Map(),
       options.requestMaxRetries,
       options.requestRetryWaitTime
@@ -48,7 +51,7 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
         yield {
           ...deployment,
           snapshotHash,
-          servers: Array.from(servers)
+          servers: serversList
         }
       }
     }
@@ -66,6 +69,10 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
 /**
  * Accepts a fromTimestamp option to filter out previous deployments.
  *
+ * @param shouldStop - Consulted before every poll and every yielded deployment. Required to end a
+ *   polling stream (`pointerChangesWaitTime > 0`), which otherwise runs forever: a consumer that
+ *   only breaks out of its own `for await` body never gets to decide anything on a poll that returns
+ *   no deployments at all.
  * @public
  */
 export async function* getDeployedEntitiesStreamFromPointerChanges(
@@ -73,7 +80,8 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
     metrics?: SnapshotsFetcherComponents['metrics']
   },
   options: PointerChangesDeployedEntityStreamOptions,
-  contentServer: string
+  contentServer: string,
+  shouldStop: () => boolean = () => false
 ) {
   const logs = components.logs.getLogger(`pointerChangesStream(${contentServer})`)
   // fetch the /pointer-changes of the remote server using the last timestamp from the previous step with a grace period of 20 min
@@ -87,9 +95,19 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
     timestamp: new Date(genesisTimestamp).toISOString()
   })
   do {
+    if (shouldStop()) {
+      logs.debug('Stopping the Pointer-Changes stream.', { contentServer })
+      return
+    }
+
     // 1. download pointer changes and yield
     const pointerChanges = fetchPointerChanges(components, contentServer, greatestLocalTimestampProcessed, logs)
     for await (const deployment of pointerChanges) {
+      if (shouldStop()) {
+        logs.debug('Stopping the Pointer-Changes stream.', { contentServer })
+        return
+      }
+
       const localTimestamp = deployment.localTimestamp
 
       // when we move past the previous high-water timestamp, reset the per-timestamp dedup set
@@ -113,5 +131,5 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
     }
 
     await sleep(options.pointerChangesWaitTime)
-  } while (options.pointerChangesWaitTime > 0)
+  } while (options.pointerChangesWaitTime > 0 && !shouldStop())
 }

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -1,3 +1,4 @@
+import { AuthLink, PointerChangesSyncDeployment } from '@dcl/schemas'
 import { fetchPointerChanges } from './client'
 import { downloadFileWithRetries } from './downloader'
 import { processDeploymentsInFile, SnapshotStreamReport } from './file-processor'
@@ -84,6 +85,36 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
  *   no deployments at all.
  * @public
  */
+// Bounds the boundary state. Beyond this many distinct rows at a single timestamp the stream stops
+// recording them, which can only cause a re-delivery on the next poll — the deployer is idempotent, so a
+// re-yield costs work rather than correctness, whereas failing to yield a row loses it. Erring towards
+// re-delivery is what makes exceeding this safe.
+const MAX_BOUNDARY_ROWS_TRACKED = 10_000
+
+/**
+ * Identity of a boundary *row*, not of its entity.
+ *
+ * `entityId` is the hash of the entity file and does not cover the authChain, so two rows can legitimately
+ * share an id while being distinct deployments. A budget keyed by id alone therefore cannot tell a replayed
+ * row from a new one — and nothing guarantees a server replays rows in the order it first sent them. If a
+ * new row arrives before the replay of the one already delivered, an id-keyed budget spends the allowance
+ * on the new row, suppresses it, and then yields the replay: the new pointer-change is silently lost.
+ *
+ * Fingerprinting every field the schema carries removes that guesswork. Counts are still kept alongside,
+ * because two rows identical in all of these fields are genuinely indistinguishable.
+ */
+function boundaryRowFingerprint(deployment: PointerChangesSyncDeployment): string {
+  return JSON.stringify([
+    deployment.entityType,
+    deployment.entityId,
+    deployment.entityTimestamp,
+    deployment.localTimestamp,
+    // Sorted so a server listing an equivalent pointer set in another order does not read as a new row.
+    [...deployment.pointers].sort(),
+    deployment.authChain.map((link: AuthLink) => [link.type, link.payload, link.signature ?? ''])
+  ])
+}
+
 export async function* getDeployedEntitiesStreamFromPointerChanges(
   components: Pick<SnapshotsFetcherComponents, 'logs' | 'fetcher'> & {
     metrics?: SnapshotsFetcherComponents['metrics']
@@ -103,20 +134,16 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
   const genesisTimestamp = options.fromTimestamp || 0
   let greatestLocalTimestampProcessed = genesisTimestamp
   // `from` is inclusive, so every poll re-returns the deployments sitting exactly at the high-water
-  // timestamp. This records how many rows *per entity id* earlier polls already delivered at that
-  // timestamp — the only re-yields there are to suppress.
+  // timestamp. This records how many rows earlier polls already delivered there, keyed by
+  // {@link boundaryRowFingerprint} — the only re-yields there are to suppress.
   //
-  // Counts rather than a Set, and read frozen for the duration of a poll rather than consulted as it
-  // grows. Both details exist to avoid resting on the same unverifiable assumption, that one entity id
-  // appears at most once per timestamp:
+  // Three properties, each removing a dependency on the server behaving well:
   //
-  //   - growing during a poll collapses two rows for the same entity in one response, because the first
-  //     yield makes the second look like a re-yield;
-  //   - a Set collapses the case where a later poll shows one row already delivered *plus* a new one, since
-  //     membership cannot tell "seen once" from "seen twice".
-  //
-  // Consuming one allowance per matching row suppresses exactly what was delivered and lets any extra
-  // through. Nothing here needs the remote server to be well-behaved about identifiers.
+  //   - keyed by full-row fingerprint, so a new row cannot spend the allowance belonging to a replayed one
+  //     when the server returns them in a different order than it first did;
+  //   - counted rather than a membership test, so "delivered once" is distinguishable from "delivered
+  //     twice" when a later poll shows a replay plus a new identical row;
+  //   - read frozen for the duration of a poll, so a poll's own rows never suppress each other.
   let rowsDeliveredAtPreviousBoundary = new Map<string, number>()
   logs.debug('Starting to stream entities from Pointer-Changes.', {
     contentServer,
@@ -135,6 +162,7 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
     // Seeded from the previous boundary because the stream is still standing at that timestamp: if this
     // poll never advances past it, the next one must still skip what was already sent there.
     let rowsDeliveredAtGreatestTimestamp = new Map(rowsDeliveredAtPreviousBoundary)
+    let boundaryTrackingCapReported = false
 
     // 1. download pointer changes and yield
     const pointerChanges = fetchPointerChanges(
@@ -158,12 +186,18 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
         rowsDeliveredAtGreatestTimestamp = new Map<string, number>()
       }
 
+      // Computed only where it is needed — to test a boundary row, or to record one at the high-water
+      // timestamp — rather than for every row of every page.
+      const isBoundaryRow = localTimestamp === boundaryTimestamp
+      const isAtGreatestTimestamp = localTimestamp === greatestLocalTimestampProcessed
+      const fingerprint = isBoundaryRow || isAtGreatestTimestamp ? boundaryRowFingerprint(deployment) : undefined
+
       // Spends one allowance per matching row, so a row beyond what was delivered is not suppressed.
       let alreadyDeliveredBeforeThisPoll = false
-      if (localTimestamp === boundaryTimestamp) {
-        const remaining = remainingBoundarySuppressions.get(deployment.entityId) ?? 0
+      if (isBoundaryRow && fingerprint !== undefined) {
+        const remaining = remainingBoundarySuppressions.get(fingerprint) ?? 0
         if (remaining > 0) {
-          remainingBoundarySuppressions.set(deployment.entityId, remaining - 1)
+          remainingBoundarySuppressions.set(fingerprint, remaining - 1)
           alreadyDeliveredBeforeThisPoll = true
         }
       }
@@ -175,11 +209,21 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
           source: 'pointer-changes'
         })
         yield deployment
-        if (localTimestamp === greatestLocalTimestampProcessed) {
-          rowsDeliveredAtGreatestTimestamp.set(
-            deployment.entityId,
-            (rowsDeliveredAtGreatestTimestamp.get(deployment.entityId) ?? 0) + 1
-          )
+        if (localTimestamp === greatestLocalTimestampProcessed && fingerprint !== undefined) {
+          const alreadyTracked = rowsDeliveredAtGreatestTimestamp.has(fingerprint)
+          if (alreadyTracked || rowsDeliveredAtGreatestTimestamp.size < MAX_BOUNDARY_ROWS_TRACKED) {
+            rowsDeliveredAtGreatestTimestamp.set(
+              fingerprint,
+              (rowsDeliveredAtGreatestTimestamp.get(fingerprint) ?? 0) + 1
+            )
+          } else if (!boundaryTrackingCapReported) {
+            boundaryTrackingCapReported = true
+            logs.warn('Too many distinct deployments at one timestamp to track; some may be re-delivered.', {
+              contentServer,
+              localTimestamp,
+              limit: String(MAX_BOUNDARY_ROWS_TRACKED)
+            })
+          }
         }
       }
     }

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -89,7 +89,9 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
   },
   options: PointerChangesDeployedEntityStreamOptions,
   contentServer: string,
-  shouldStop: () => boolean = () => false
+  shouldStop: () => boolean = () => false,
+  /** Awaited at the end of every poll, before the next one starts. See the call site below. */
+  onPollEnd?: () => Promise<void>
 ) {
   const logs = components.logs.getLogger(`pointerChangesStream(${contentServer})`)
   // Origin only, so the label stays low-cardinality. Unlike a snapshot, a pointer-changes deployment
@@ -143,6 +145,14 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
           entityIdsYieldedAtGreatestTimestamp.add(deployment.entityId)
         }
       }
+    }
+
+    // The end of a poll: everything this poll had to offer has been yielded, and nothing more will be
+    // until the next one. That makes it the only point in a stream designed never to end where a
+    // consumer can ask "did all of it actually land?" — awaited here rather than announced, so the
+    // consumer can settle its deployer before more entities arrive.
+    if (onPollEnd) {
+      await onPollEnd()
     }
 
     // Interruptible: lifecycle stop now awaits the running stream, so a plain sleep here would make

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -6,7 +6,7 @@ import {
   SnapshotDeployedEntityStreamOptions,
   SnapshotsFetcherComponents
 } from './types'
-import { sleep } from './utils'
+import { sleepUnlessStopped } from './utils'
 
 export { metricsDefinitions } from './metrics'
 export { IDeployerComponent, SynchronizerComponent } from './types'
@@ -132,6 +132,8 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
       }
     }
 
-    await sleep(options.pointerChangesWaitTime)
+    // Interruptible: lifecycle stop now awaits the running stream, so a plain sleep here would make
+    // shutdown latency the full configured poll interval.
+    await sleepUnlessStopped(options.pointerChangesWaitTime, shouldStop)
   } while (options.pointerChangesWaitTime > 0 && !shouldStop())
 }

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -103,15 +103,21 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
   const genesisTimestamp = options.fromTimestamp || 0
   let greatestLocalTimestampProcessed = genesisTimestamp
   // `from` is inclusive, so every poll re-returns the deployments sitting exactly at the high-water
-  // timestamp. This holds the ids that *earlier* polls already yielded at that timestamp — the only
-  // re-yields there are to suppress.
+  // timestamp. This records how many rows *per entity id* earlier polls already delivered at that
+  // timestamp — the only re-yields there are to suppress.
   //
-  // Read frozen for the duration of a poll rather than consulted as it grows: two distinct deltas for the
-  // same entity at the same localTimestamp inside one response are both legitimate rows, and a set that
-  // accumulated during the poll would treat the second as a re-yield and drop it. Suppression now rests
-  // only on "this was already delivered before this poll began", so it does not depend on entityId being
-  // unique per timestamp — an invariant this package cannot enforce on a remote server.
-  let entityIdsYieldedAtPreviousBoundary = new Set<string>()
+  // Counts rather than a Set, and read frozen for the duration of a poll rather than consulted as it
+  // grows. Both details exist to avoid resting on the same unverifiable assumption, that one entity id
+  // appears at most once per timestamp:
+  //
+  //   - growing during a poll collapses two rows for the same entity in one response, because the first
+  //     yield makes the second look like a re-yield;
+  //   - a Set collapses the case where a later poll shows one row already delivered *plus* a new one, since
+  //     membership cannot tell "seen once" from "seen twice".
+  //
+  // Consuming one allowance per matching row suppresses exactly what was delivered and lets any extra
+  // through. Nothing here needs the remote server to be well-behaved about identifiers.
+  let rowsDeliveredAtPreviousBoundary = new Map<string, number>()
   logs.debug('Starting to stream entities from Pointer-Changes.', {
     contentServer,
     timestamp: new Date(genesisTimestamp).toISOString()
@@ -122,13 +128,13 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
       return
     }
 
-    // Captured before the poll so the suppression test below compares against a fixed boundary and a
-    // fixed id set, neither of which this poll's own rows can alter.
+    // Captured before the poll so the suppression budget is fixed at what earlier polls delivered; this
+    // poll's own rows cannot add to it.
     const boundaryTimestamp = greatestLocalTimestampProcessed
-    const idsDeliveredAtBoundary = entityIdsYieldedAtPreviousBoundary
+    const remainingBoundarySuppressions = new Map(rowsDeliveredAtPreviousBoundary)
     // Seeded from the previous boundary because the stream is still standing at that timestamp: if this
-    // poll never advances past it, the next one must still skip everything already delivered there.
-    let entityIdsYieldedAtGreatestTimestamp = new Set<string>(idsDeliveredAtBoundary)
+    // poll never advances past it, the next one must still skip what was already sent there.
+    let rowsDeliveredAtGreatestTimestamp = new Map(rowsDeliveredAtPreviousBoundary)
 
     // 1. download pointer changes and yield
     const pointerChanges = fetchPointerChanges(
@@ -146,14 +152,21 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
 
       const localTimestamp = deployment.localTimestamp
 
-      // when we move past the previous high-water timestamp, reset the per-timestamp dedup set
+      // when we move past the previous high-water timestamp, nothing has been delivered at the new one yet
       if (localTimestamp > greatestLocalTimestampProcessed) {
         greatestLocalTimestampProcessed = localTimestamp
-        entityIdsYieldedAtGreatestTimestamp = new Set<string>()
+        rowsDeliveredAtGreatestTimestamp = new Map<string, number>()
       }
 
-      const alreadyDeliveredBeforeThisPoll =
-        localTimestamp === boundaryTimestamp && idsDeliveredAtBoundary.has(deployment.entityId)
+      // Spends one allowance per matching row, so a row beyond what was delivered is not suppressed.
+      let alreadyDeliveredBeforeThisPoll = false
+      if (localTimestamp === boundaryTimestamp) {
+        const remaining = remainingBoundarySuppressions.get(deployment.entityId) ?? 0
+        if (remaining > 0) {
+          remainingBoundarySuppressions.set(deployment.entityId, remaining - 1)
+          alreadyDeliveredBeforeThisPoll = true
+        }
+      }
 
       // selectively ignore deployments by localTimestamp, and skip only what an earlier poll delivered
       if (localTimestamp >= genesisTimestamp && !alreadyDeliveredBeforeThisPoll) {
@@ -163,14 +176,17 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
         })
         yield deployment
         if (localTimestamp === greatestLocalTimestampProcessed) {
-          entityIdsYieldedAtGreatestTimestamp.add(deployment.entityId)
+          rowsDeliveredAtGreatestTimestamp.set(
+            deployment.entityId,
+            (rowsDeliveredAtGreatestTimestamp.get(deployment.entityId) ?? 0) + 1
+          )
         }
       }
     }
 
     // Whatever ended up at the high-water timestamp is what the next poll's inclusive `from` will hand
-    // back, so it becomes that poll's suppression set.
-    entityIdsYieldedAtPreviousBoundary = entityIdsYieldedAtGreatestTimestamp
+    // back, so it becomes that poll's suppression budget.
+    rowsDeliveredAtPreviousBoundary = rowsDeliveredAtGreatestTimestamp
 
     // The end of a poll: everything this poll had to offer has been yielded, and nothing more will be
     // until the next one. That makes it the only point in a stream designed never to end where a

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -1,6 +1,6 @@
 import { fetchPointerChanges } from './client'
 import { downloadFileWithRetries } from './downloader'
-import { processDeploymentsInFile } from './file-processor'
+import { processDeploymentsInFile, SnapshotStreamReport } from './file-processor'
 import {
   PointerChangesDeployedEntityStreamOptions,
   SnapshotDeployedEntityStreamOptions,
@@ -24,7 +24,8 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
   options: SnapshotDeployedEntityStreamOptions,
   snapshotHash: string,
   servers: Set<string>,
-  shouldStop: () => boolean = () => false
+  shouldStop: () => boolean = () => false,
+  report?: SnapshotStreamReport
 ) {
   const genesisTimestamp = options.fromTimestamp || 0
   const logs = components.logs.getLogger('getDeployedEntitiesStreamFromSnapshot')
@@ -46,7 +47,7 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
     )
 
     // 2. open the snapshot file and process line by line
-    const deploymentsInFile = processDeploymentsInFile(snapshotHash, components, logs)
+    const deploymentsInFile = processDeploymentsInFile(snapshotHash, components, logs, report)
     for await (const deployment of deploymentsInFile) {
       if (deployment.entityTimestamp >= genesisTimestamp) {
         // Empty remote_server: a snapshot is content-addressed and usually advertised by several

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -102,9 +102,16 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
   // fetch the /pointer-changes of the remote server using the last timestamp from the previous step with a grace period of 20 min
   const genesisTimestamp = options.fromTimestamp || 0
   let greatestLocalTimestampProcessed = genesisTimestamp
-  // `from` is inclusive, so each poll re-returns the deployments at the high-water timestamp. Track
-  // the entityIds already yielded at that timestamp to skip those re-yields (never a distinct one).
-  let entityIdsYieldedAtGreatestTimestamp = new Set<string>()
+  // `from` is inclusive, so every poll re-returns the deployments sitting exactly at the high-water
+  // timestamp. This holds the ids that *earlier* polls already yielded at that timestamp — the only
+  // re-yields there are to suppress.
+  //
+  // Read frozen for the duration of a poll rather than consulted as it grows: two distinct deltas for the
+  // same entity at the same localTimestamp inside one response are both legitimate rows, and a set that
+  // accumulated during the poll would treat the second as a re-yield and drop it. Suppression now rests
+  // only on "this was already delivered before this poll began", so it does not depend on entityId being
+  // unique per timestamp — an invariant this package cannot enforce on a remote server.
+  let entityIdsYieldedAtPreviousBoundary = new Set<string>()
   logs.debug('Starting to stream entities from Pointer-Changes.', {
     contentServer,
     timestamp: new Date(genesisTimestamp).toISOString()
@@ -114,6 +121,14 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
       logs.debug('Stopping the Pointer-Changes stream.', { contentServer })
       return
     }
+
+    // Captured before the poll so the suppression test below compares against a fixed boundary and a
+    // fixed id set, neither of which this poll's own rows can alter.
+    const boundaryTimestamp = greatestLocalTimestampProcessed
+    const idsDeliveredAtBoundary = entityIdsYieldedAtPreviousBoundary
+    // Seeded from the previous boundary because the stream is still standing at that timestamp: if this
+    // poll never advances past it, the next one must still skip everything already delivered there.
+    let entityIdsYieldedAtGreatestTimestamp = new Set<string>(idsDeliveredAtBoundary)
 
     // 1. download pointer changes and yield
     const pointerChanges = fetchPointerChanges(
@@ -137,12 +152,11 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
         entityIdsYieldedAtGreatestTimestamp = new Set<string>()
       }
 
-      const alreadyYielded =
-        localTimestamp === greatestLocalTimestampProcessed &&
-        entityIdsYieldedAtGreatestTimestamp.has(deployment.entityId)
+      const alreadyDeliveredBeforeThisPoll =
+        localTimestamp === boundaryTimestamp && idsDeliveredAtBoundary.has(deployment.entityId)
 
-      // selectively ignore deployments by localTimestamp, and skip ones already yielded this run
-      if (localTimestamp >= genesisTimestamp && !alreadyYielded) {
+      // selectively ignore deployments by localTimestamp, and skip only what an earlier poll delivered
+      if (localTimestamp >= genesisTimestamp && !alreadyDeliveredBeforeThisPoll) {
         components.metrics?.increment('dcl_entities_deployments_streamed_total', {
           ...pointerChangesMetricLabels,
           source: 'pointer-changes'
@@ -153,6 +167,10 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
         }
       }
     }
+
+    // Whatever ended up at the high-water timestamp is what the next poll's inclusive `from` will hand
+    // back, so it becomes that poll's suppression set.
+    entityIdsYieldedAtPreviousBoundary = entityIdsYieldedAtGreatestTimestamp
 
     // The end of a poll: everything this poll had to offer has been yielded, and nothing more will be
     // until the next one. That makes it the only point in a stream designed never to end where a

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -6,7 +6,7 @@ import {
   SnapshotDeployedEntityStreamOptions,
   SnapshotsFetcherComponents
 } from './types'
-import { sleepUnlessStopped } from './utils'
+import { contentServerMetricLabels, sleepUnlessStopped } from './utils'
 
 export { metricsDefinitions } from './metrics'
 export { IDeployerComponent, SynchronizerComponent } from './types'
@@ -49,7 +49,12 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
     const deploymentsInFile = processDeploymentsInFile(snapshotHash, components, logs)
     for await (const deployment of deploymentsInFile) {
       if (deployment.entityTimestamp >= genesisTimestamp) {
-        components.metrics?.increment('dcl_entities_deployments_streamed_total', { source: 'snapshots' })
+        // Empty remote_server: a snapshot is content-addressed and usually advertised by several
+        // servers at once, so its entities cannot be attributed to one origin.
+        components.metrics?.increment('dcl_entities_deployments_streamed_total', {
+          remote_server: '',
+          source: 'snapshots'
+        })
         yield {
           ...deployment,
           snapshotHash,
@@ -86,6 +91,10 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
   shouldStop: () => boolean = () => false
 ) {
   const logs = components.logs.getLogger(`pointerChangesStream(${contentServer})`)
+  // Origin only, so the label stays low-cardinality. Unlike a snapshot, a pointer-changes deployment
+  // has exactly one server behind it, which is what makes "who stopped delivering entities?"
+  // answerable from this counter.
+  const pointerChangesMetricLabels = contentServerMetricLabels(contentServer)
   // fetch the /pointer-changes of the remote server using the last timestamp from the previous step with a grace period of 20 min
   const genesisTimestamp = options.fromTimestamp || 0
   let greatestLocalTimestampProcessed = genesisTimestamp
@@ -124,7 +133,10 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
 
       // selectively ignore deployments by localTimestamp, and skip ones already yielded this run
       if (localTimestamp >= genesisTimestamp && !alreadyYielded) {
-        components.metrics?.increment('dcl_entities_deployments_streamed_total', { source: 'pointer-changes' })
+        components.metrics?.increment('dcl_entities_deployments_streamed_total', {
+          ...pointerChangesMetricLabels,
+          source: 'pointer-changes'
+        })
         yield deployment
         if (localTimestamp === greatestLocalTimestampProcessed) {
           entityIdsYieldedAtGreatestTimestamp.add(deployment.entityId)

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -43,7 +43,8 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
       new Map(),
       options.requestMaxRetries,
       options.requestRetryWaitTime,
-      shouldStop
+      shouldStop,
+      options.transferLimits
     )
 
     // 2. open the snapshot file and process line by line
@@ -115,7 +116,13 @@ export async function* getDeployedEntitiesStreamFromPointerChanges(
     }
 
     // 1. download pointer changes and yield
-    const pointerChanges = fetchPointerChanges(components, contentServer, greatestLocalTimestampProcessed, logs)
+    const pointerChanges = fetchPointerChanges(
+      components,
+      contentServer,
+      greatestLocalTimestampProcessed,
+      logs,
+      options.transferLimits
+    )
     for await (const deployment of pointerChanges) {
       if (shouldStop()) {
         logs.debug('Stopping the Pointer-Changes stream.', { contentServer })

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -175,12 +175,29 @@ export async function createSynchronizer(
     type Snapshot = SnapshotMetadata & { server: string }
     const snapshotsByHash: Map<string, Snapshot[]> = new Map()
     const snapshotLastTimestampByServer: Map<string, number> = new Map()
+    // Servers whose bootstrap is incomplete, for any reason: a snapshot list we could not fully read, or
+    // a snapshot that failed to deploy. They must neither advance their last-entity timestamp nor be
+    // reported as synced — either one would resume pointer-changes past entities that were never
+    // deployed, and (because the snapshot stays unmarked) those entities would only reappear on the next
+    // full snapshot sync.
+    const serversWithFailedSnapshots = new Set<string>()
     // Fetch all servers concurrently; getSnapshots already runs through the concurrency-limited
     // downloadQueue. The synchronous map mutations below can't interleave (no await between them).
     await Promise.all(
       Array.from(serversToSync).map(async (server) => {
         try {
-          const snapshots = await getSnapshots(components, server, options.requestMaxRetries)
+          const { snapshots, discardedEntries } = await getSnapshots(components, server, options.requestMaxRetries)
+          if (discardedEntries > 0) {
+            // The surviving subset is not this server's history. Each discarded entry stood for a time
+            // range, so deploying only what parsed and then advancing past the newest of them would skip
+            // whatever lived in the ranges we threw away. Still deploy what we can read — that work is
+            // real — but keep the server in snapshot bootstrap so the list is fetched again.
+            logger.warn('Snapshot list was not fully readable; keeping the server in snapshot bootstrap.', {
+              server,
+              discardedEntries: String(discardedEntries)
+            })
+            serversWithFailedSnapshots.add(server)
+          }
           // A server may legitimately have no snapshots yet (e.g. brand new). Math.max() of an empty
           // list is -Infinity, so fall back to the genesis timestamp to keep a sane starting point.
           const lastTimestamp =
@@ -219,12 +236,6 @@ export async function createSynchronizer(
         : new Set<string>()
 
     const timeRangesOfEntitiesToDeploy: TimeRange[] = []
-    // Servers with at least one snapshot that could not be fully deployed. Their bootstrap is
-    // incomplete, so they must neither advance their last-entity timestamp nor be reported as
-    // synced: either one would resume pointer-changes past entities that were never deployed, and
-    // (because the snapshot stays unmarked) those entities would only reappear on the next full
-    // snapshot sync — up to 14 days later.
-    const serversWithFailedSnapshots = new Set<string>()
     // Each decision may still hit snapshotStorage; run them with bounded concurrency instead of a
     // serial chain.
     const shouldProcessChecksQueue = new PQueue({ concurrency: snapshotChecksConcurrency })

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -95,6 +95,10 @@ export async function createSynchronizer(
   })
   let firstSyncJobStarted = false
   let snapshotsSyncTimeout: NodeJS.Timeout | undefined
+  // The periodic post-bootstrap sync's run, so stop() can wait for it rather than only signalling it.
+  let regularSyncRun: Promise<void> | undefined
+  // Memoised shutdown, so concurrent stop() callers share one and none of them returns early.
+  let shutdown: Promise<void> | undefined
 
   function pointerChangesStartingTimestamp(server: string): number {
     const lastTimestamp = lastEntityTimestampFromSnapshotsByServer.get(server)
@@ -244,6 +248,15 @@ export async function createSynchronizer(
         })
       )
     )
+
+    // stop() now waits for this action to return, so bail before the expensive phase rather than
+    // deploying every queued snapshot while the caller's shutdown blocks on us. The queue is never
+    // started, so nothing in it runs.
+    if (isStopped) {
+      logger.info('Stopped while syncing from snapshots; abandoning the queued snapshot deployments.')
+      deploymentsProcessorsQueue.clear()
+      return new Set()
+    }
 
     logger.info('Warming up deployer.')
     await components.deployer.prepareForDeploymentsIn(timeRangesOfEntitiesToDeploy)
@@ -453,6 +466,17 @@ export async function createSynchronizer(
     })
     return {
       ...syncRetry,
+      async start() {
+        try {
+          await syncRetry.start()
+        } finally {
+          // Catch-all: whatever reason the retry loop exits for, the future must be settled. Only the
+          // success path resolves it, and the loop has other exits — a zero `reconnectTime` makes it
+          // return after the first failure — each of which would otherwise leave a consumer awaiting
+          // onSyncFinished() forever. A no-op once resolved.
+          abortSyncFinished()
+        }
+      },
       async stop() {
         await syncRetry.stop()
         // Also covers jobs the serial runner drops from its queue without ever starting them.
@@ -507,33 +531,46 @@ export async function createSynchronizer(
       if (!firstSyncJobStarted) {
         firstSyncJobStarted = true
         await newSyncJob.onInitialBootstrapFinished(async () => {
-          snapshotsSyncTimeout = setTimeout(
-            async () => await regularSyncFromSnapshotsAfterBootstrapJob.start(),
-            3_600_000
-          )
+          snapshotsSyncTimeout = setTimeout(() => {
+            // Kept so stop() can wait for it. Dropping the promise here meant nothing could await the
+            // periodic sync, so stop() returned while it was still deploying entities.
+            regularSyncRun = regularSyncFromSnapshotsAfterBootstrapJob.start()
+          }, 3_600_000)
         })
       }
       syncJobsRunner.enqueue(newSyncJob)
+      // The await above is the only suspension point in this method, so stop() can land in the middle
+      // of the very first call. The runner silently drops jobs enqueued after it stopped, which would
+      // leave this job's onSyncFinished() pending forever, so settle it here instead.
+      if (isStopped) {
+        await newSyncJob.stop()
+      }
       return newSyncJob
     },
     async stop() {
-      // Component will not stop until the sync from snapshots is over.
-      if (!isStopped) {
-        isStopped = true
+      // Component will not stop until the sync from snapshots is over. Memoised so overlapping callers
+      // all wait for the same shutdown instead of a second one reporting success immediately.
+      if (!shutdown) {
+        shutdown = (async () => {
+          isStopped = true
 
-        await syncJobsRunner.stop()
-        syncingServers.clear()
-        if (deployPointerChangesAfterBootstrapJobManager.stop) {
-          await deployPointerChangesAfterBootstrapJobManager.stop()
-        }
-        // Cancel the pending start before stopping the job, so a timer that is about to fire cannot
-        // restart it after it was stopped.
-        if (snapshotsSyncTimeout) {
-          clearTimeout(snapshotsSyncTimeout)
-          snapshotsSyncTimeout = undefined
-        }
-        await regularSyncFromSnapshotsAfterBootstrapJob.stop()
+          await syncJobsRunner.stop()
+          syncingServers.clear()
+          if (deployPointerChangesAfterBootstrapJobManager.stop) {
+            await deployPointerChangesAfterBootstrapJobManager.stop()
+          }
+          // Cancel the pending start before stopping the job, so a timer that is about to fire cannot
+          // restart it after it was stopped.
+          if (snapshotsSyncTimeout) {
+            clearTimeout(snapshotsSyncTimeout)
+            snapshotsSyncTimeout = undefined
+          }
+          await regularSyncFromSnapshotsAfterBootstrapJob.stop()
+          // Signalling it is not enough: wait for the run itself, as we do for every other job.
+          await regularSyncRun?.catch(() => undefined)
+        })()
       }
+      return shutdown
     }
   }
 }

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -582,9 +582,23 @@ export async function createSynchronizer(
               async () => {
                 await components.deployer.onIdle()
                 // Cumulative, not per poll: this asks whether everything scheduled since the stream
-                // started has been confirmed, which is exactly the contiguity condition. Once something
-                // is outstanding the mark stops advancing until the stream restarts and re-fetches it.
-                if (report.acknowledged < report.scheduled || tentativeTimestamps.length === 0) {
+                // started has been confirmed, which is exactly the contiguity condition.
+                if (report.acknowledged < report.scheduled) {
+                  // End the run rather than carry on. Holding the durable mark back already stops the
+                  // missing entity being skipped, but the live stream polls from its OWN internal
+                  // high-water mark, so continuing means nothing re-fetches that entity until the stream
+                  // happens to restart — and the periodic snapshot sync that would otherwise catch it runs
+                  // every 14 days. Ending the run reconnects from the durable mark, which re-delivers it.
+                  //
+                  // Well-behaved against a deployer that drops it permanently: each attempt now fails
+                  // fast, so the exponential falloff throttles the retries, while healthyRunTime means a
+                  // single bad poll after a long healthy run reconnects promptly instead of inheriting an
+                  // interval grown by unrelated failures.
+                  throw new Error(
+                    `Not all pointer-change deployments were acknowledged for ${contentServer} (${report.acknowledged} of ${report.scheduled}); reconnecting from the last confirmed timestamp`
+                  )
+                }
+                if (tentativeTimestamps.length === 0) {
                   return
                 }
                 increaseLastTimestamp(contentServer, ...tentativeTimestamps)

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -272,8 +272,12 @@ export async function createSynchronizer(
       candidates = stillDeployable
     }
 
+    // Which servers advertised each snapshot we are about to deploy, so the marker re-check after the
+    // deployer drains can attribute an unfinished snapshot back to them.
+    const serversBySnapshotDeployed = new Map<string, Set<string>>()
     for (const [snapshotHash, snapshots] of snapshotsToDeploy) {
       const servers = new Set(snapshots.map((s) => s.server))
+      serversBySnapshotDeployed.set(snapshotHash, servers)
       timeRangesOfEntitiesToDeploy.push(...snapshots.map((s) => s.timeRange))
       deploymentsProcessorsQueue
         .add(async () => {
@@ -313,6 +317,28 @@ export async function createSynchronizer(
     // timestamp now would resume its pointer-changes past entities that had only been scheduled.
     await components.deployer.onIdle()
     logger.info('End deploying entities from snapshots.')
+
+    // Draining proves the deployer's queue is empty, NOT that every scheduled entity reported back
+    // through markAsDeployed. deployEntitiesFromSnapshot only marks a snapshot once they all have, and
+    // it returns normally either way, so the marker is the only evidence that a snapshot completed.
+    // Without re-reading it, a deployer that quietly dropped an entity would still let the servers
+    // advertising that snapshot advance past it.
+    if (serversBySnapshotDeployed.size > 0) {
+      const processedAfterDeploying = await components.processedSnapshotStorage.filterProcessedSnapshotsFrom(
+        Array.from(serversBySnapshotDeployed.keys())
+      )
+      for (const [snapshotHash, servers] of serversBySnapshotDeployed) {
+        if (processedAfterDeploying.has(snapshotHash)) {
+          continue
+        }
+        logger.warn('Snapshot was not marked as processed once the deployer drained; treating it as failed.', {
+          snapshotHash
+        })
+        for (const server of servers) {
+          serversWithFailedSnapshots.add(server)
+        }
+      }
+    }
 
     // Once the snapshots were correctly streamed, update the last entity timestamps
     for (const [server, lastTimestamp] of snapshotLastTimestampByServer) {
@@ -379,8 +405,10 @@ export async function createSynchronizer(
             () => isStopped,
             increaseLastTimestamp
           )
-          bootstrappingServersFromPointerChanges.delete(bootstrappingServersFromPointerChange)
-          // Promotion is deferred until the deployer has drained, below.
+          // Both leaving pointer-changes bootstrap and entering the syncing state are deferred until
+          // the deployer has drained, below. Removing it here would strand the server in neither state
+          // if the drain then fails: the retry would find nothing left to bootstrap, report the sync as
+          // successful, and stop syncing a server the caller still wants.
           bootstrappedFromPointerChanges.add(bootstrappingServersFromPointerChange)
         } catch (error) {
           // If there's an error, the server doesn't pass to syncing state
@@ -404,8 +432,11 @@ export async function createSynchronizer(
       // the server resume from its high-water timestamp, so wait for the deployer's own drain signal
       // first — otherwise an asynchronous deployer is still working through entities the server is
       // already considered to be past.
+      // If this rejects, nothing below runs and every server stays in pointer-changes bootstrap, so the
+      // retry picks them up again rather than losing them.
       await components.deployer.onIdle()
       for (const server of bootstrappedFromPointerChanges) {
+        bootstrappingServersFromPointerChanges.delete(server)
         if (!canAdvanceServer(server)) {
           logger.info('Not moving a server to the syncing state: it is no longer desired.', { server })
           continue

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -226,42 +226,70 @@ export async function createSynchronizer(
     // snapshot sync — up to 14 days later.
     const serversWithFailedSnapshots = new Set<string>()
     // Each decision may still hit snapshotStorage; run them with bounded concurrency instead of a
-    // serial chain. The synchronous push/enqueue after each await can't interleave.
+    // serial chain.
     const shouldProcessChecksQueue = new PQueue({ concurrency: snapshotChecksConcurrency })
-    await Promise.all(
-      Array.from(snapshotsByHash).map(([snapshotHash, snapshots]) =>
-        shouldProcessChecksQueue.add(async () => {
-          const replacedSnapshotHashes = snapshots.map((s) => s.replacedSnapshotHashes ?? [])
-          const greatestEndTimestamp = Math.max(...snapshots.map((s) => s.timeRange.endTimestamp))
-          const shouldProcessSnapshot = await decideSnapshotDeploymentFromProcessedSet(
-            components,
-            processedSnapshots,
-            genesisTimestamp,
-            snapshotHash,
-            greatestEndTimestamp,
-            replacedSnapshotHashes
-          )
-          if (shouldProcessSnapshot) {
-            const servers = new Set(snapshots.map((s) => s.server))
-            timeRangesOfEntitiesToDeploy.push(...snapshots.map((s) => s.timeRange))
-            deploymentsProcessorsQueue
-              .add(async () => {
-                try {
-                  await deployEntitiesFromSnapshot(components, options, snapshotHash, servers, () => isStopped)
-                } catch (err: any) {
-                  // Recorded inside the job (not in a .catch on the add() promise) so the set is
-                  // guaranteed to be populated before onIdle() resolves and it gets read below.
-                  logger.error(err)
-                  for (const server of servers) {
-                    serversWithFailedSnapshots.add(server)
-                  }
-                }
-              })
-              .catch((err) => logger.error(err))
+
+    // A decision can mark a snapshot as processed, because a group it replaces already is — and that
+    // mark is exactly what makes the snapshot replacing IT skippable in turn. Every decision in one
+    // pass reads the same set, so a replacement chain (h2 replaces h1 replaces an processed h0) only
+    // collapses one link per pass and its tail gets deployed for nothing.
+    //
+    // So re-run over the candidates that still look deployable until a pass marks nothing new. Only
+    // that outcome can change: "already processed", "older than the genesis timestamp" and "present in
+    // snapshotStorage" do not depend on what else got marked, so those snapshots are decided for good
+    // the first time and drop out. Each pass therefore either marks at least one snapshot — shrinking
+    // the candidate pool, since a marked snapshot is no longer deployable — or ends the loop.
+    let candidates = Array.from(snapshotsByHash)
+    let snapshotsToDeploy: typeof candidates = []
+    for (;;) {
+      const markedBeforePass = processedSnapshots.size
+      const stillDeployable: typeof candidates = []
+      await Promise.all(
+        candidates.map(([snapshotHash, snapshots]) =>
+          shouldProcessChecksQueue.add(async () => {
+            const replacedSnapshotHashes = snapshots.map((s) => s.replacedSnapshotHashes ?? [])
+            const greatestEndTimestamp = Math.max(...snapshots.map((s) => s.timeRange.endTimestamp))
+            const shouldProcessSnapshot = await decideSnapshotDeploymentFromProcessedSet(
+              components,
+              processedSnapshots,
+              genesisTimestamp,
+              snapshotHash,
+              greatestEndTimestamp,
+              replacedSnapshotHashes
+            )
+            if (shouldProcessSnapshot) {
+              // Only collected here; the deployment is enqueued once the set has settled, so a snapshot
+              // a later pass turns out to have marked is never queued at all.
+              stillDeployable.push([snapshotHash, snapshots])
+            }
+          })
+        )
+      )
+      if (processedSnapshots.size === markedBeforePass) {
+        snapshotsToDeploy = stillDeployable
+        break
+      }
+      candidates = stillDeployable
+    }
+
+    for (const [snapshotHash, snapshots] of snapshotsToDeploy) {
+      const servers = new Set(snapshots.map((s) => s.server))
+      timeRangesOfEntitiesToDeploy.push(...snapshots.map((s) => s.timeRange))
+      deploymentsProcessorsQueue
+        .add(async () => {
+          try {
+            await deployEntitiesFromSnapshot(components, options, snapshotHash, servers, () => isStopped)
+          } catch (err: any) {
+            // Recorded inside the job (not in a .catch on the add() promise) so the set is
+            // guaranteed to be populated before onIdle() resolves and it gets read below.
+            logger.error(err)
+            for (const server of servers) {
+              serversWithFailedSnapshots.add(server)
+            }
           }
         })
-      )
-    )
+        .catch((err) => logger.error(err))
+    }
 
     // stop() now waits for this action to return, so bail before the expensive phase rather than
     // deploying every queued snapshot while the caller's shutdown blocks on us. The queue is never

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -440,7 +440,12 @@ export async function createSynchronizer(
             components,
             { ...options, fromTimestamp, pointerChangesWaitTime: 0 },
             bootstrappingServersFromPointerChange,
-            () => isStopped,
+            // Also stops when the caller drops this server, not only on a full shutdown. A bootstrap
+            // pass over a long backlog can run for a while, and canAdvanceServer only stops the server
+            // being promoted at the end of it — it does not stop the streaming and deploying in the
+            // meantime, so a server removed mid-pass kept having its entities deployed until the pass
+            // happened to finish.
+            () => isStopped || !desiredServers.has(bootstrappingServersFromPointerChange),
             collectTentativeTimestamp,
             report
           )

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -4,7 +4,8 @@ import { getSnapshots } from './client'
 import {
   decideSnapshotDeploymentFromProcessedSet,
   deployEntitiesFromPointerChanges,
-  deployEntitiesFromSnapshot
+  deployEntitiesFromSnapshot,
+  PointerChangesDeploymentReport
 } from './deploy-entities'
 import { createExponentialFallofRetry } from './exponential-fallof-retry'
 import { createJobLifecycleManagerComponent } from './job-lifecycle-manager'
@@ -420,6 +421,12 @@ export async function createSynchronizer(
         current === undefined ? Math.max(...newTimestamps) : Math.max(current, ...newTimestamps)
       )
     }
+    // What each server's run handed to the deployer against what the deployer confirmed. Draining says
+    // the queue emptied, not that every entity in it reported back, and because the resume point is a
+    // maximum over acknowledged timestamps a deployer that drops t=100 and confirms t=200 still leaves a
+    // mark past the dropped one. This is the pointer-changes equivalent of re-reading the processed
+    // marker after a snapshot deployment.
+    const deploymentReports = new Map<string, PointerChangesDeploymentReport>()
     let minStartingPoint: undefined | number
     for (const bootstrappingServersFromPointerChange of bootstrappingServersFromPointerChanges) {
       const fromTimestamp = pointerChangesStartingTimestamp(bootstrappingServersFromPointerChange)
@@ -427,12 +434,15 @@ export async function createSynchronizer(
       pointerChangesBootstrappingJobs.push(async () => {
         try {
           const fromTimestamp = pointerChangesStartingTimestamp(bootstrappingServersFromPointerChange)
+          const report: PointerChangesDeploymentReport = { scheduled: 0, acknowledged: 0 }
+          deploymentReports.set(bootstrappingServersFromPointerChange, report)
           await deployEntitiesFromPointerChanges(
             components,
             { ...options, fromTimestamp, pointerChangesWaitTime: 0 },
             bootstrappingServersFromPointerChange,
             () => isStopped,
-            collectTentativeTimestamp
+            collectTentativeTimestamp,
+            report
           )
           // Both leaving pointer-changes bootstrap and entering the syncing state are deferred until
           // the deployer has drained, below. Removing it here would strand the server in neither state
@@ -465,6 +475,22 @@ export async function createSynchronizer(
       // retry picks them up again rather than losing them.
       await components.deployer.onIdle()
       for (const server of bootstrappedFromPointerChanges) {
+        // The drain succeeding is necessary but not sufficient: it says the queue emptied, and this says
+        // everything that went into it came back. Short of that the run is incomplete, so the server
+        // keeps its old resume point and stays in pointer-changes bootstrap to be retried — committing
+        // the tentative mark here would move it past whatever the deployer dropped.
+        const report = deploymentReports.get(server)
+        if (report && report.acknowledged < report.scheduled) {
+          logger.warn(
+            'Not all pointer-change deployments were acknowledged once the deployer drained; keeping the server in bootstrap.',
+            {
+              server,
+              scheduled: String(report.scheduled),
+              acknowledged: String(report.acknowledged)
+            }
+          )
+          continue
+        }
         // Committed only here: the drain succeeded, so everything this pass scheduled for this server
         // really did deploy. A rejection above skips this entirely and the pass is retried from the
         // timestamp it started at.

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -243,7 +243,7 @@ export async function createSynchronizer(
     }
     const processedSnapshots =
       allSnapshotHashesToCheck.size > 0
-        ? await filterProcessedSnapshotsInChunks(components, Array.from(allSnapshotHashesToCheck))
+        ? await filterProcessedSnapshotsInChunks(components, allSnapshotHashesToCheck)
         : new Set<string>()
 
     const timeRangesOfEntitiesToDeploy: TimeRange[] = []
@@ -348,7 +348,7 @@ export async function createSynchronizer(
     if (serversBySnapshotDeployed.size > 0) {
       const processedAfterDeploying = await filterProcessedSnapshotsInChunks(
         components,
-        Array.from(serversBySnapshotDeployed.keys())
+        serversBySnapshotDeployed.keys()
       )
       for (const [snapshotHash, servers] of serversBySnapshotDeployed) {
         if (processedAfterDeploying.has(snapshotHash)) {

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -547,28 +547,49 @@ export async function createSynchronizer(
             )
           }
 
+          // The resume point is a maximum over acknowledged timestamps, so committing each mark as its
+          // entity reports deployed lets an entity confirmed at t=200 carry the mark past one the deployer
+          // dropped at t=100. This stream resumes from the raw mark with no 20-minute shift, so the dropped
+          // entity would never be re-fetched from pointer-changes — only the periodic snapshot re-sync
+          // would eventually recover it. A single scalar cannot express "everything through T except
+          // t=100", which is why no amount of validation fixes this; the mark has to stop advancing past
+          // an unconfirmed entity.
+          //
+          // So hold the marks and commit them at a poll boundary, once the deployer has drained and every
+          // entity scheduled so far has reported back. It is the same shape as bootstrap's guard, applied
+          // per poll instead of once — the end of a poll is the only checkpoint a stream designed never to
+          // end has.
+          //
+          // Measured cost, against this code with a batching deployer: 0.5% with a 5s poll interval, 2.4%
+          // with 1s, 3.7-5.3% back-to-back when either side dominates, and 18.5% back-to-back when network
+          // and deployer latency are evenly matched. Far less than it sounds like, because the drain sits at
+          // the end of a poll rather than per page or per entity: the pagination loop already overlaps
+          // fetching with deploying, so this only ever waits for the residual queue.
+          //
+          // Liveness is preserved: an entity the deployer permanently drops pins the durable resume point
+          // but does not stall the stream, which keeps polling from its own internal high-water mark.
+          const tentativeTimestamps: number[] = []
+          const report: PointerChangesDeploymentReport = { scheduled: 0, acknowledged: 0 }
           try {
             components.metrics.increment('dcl_deployments_stream_reconnection_count', metricsLabels)
-            // The canonical callback, committing each mark as the entity reports deployed — NOT the
-            // hold-until-drained treatment bootstrapFromPointerChanges gives it. The same hazard exists
-            // here: because the mark is a max, an entity deployed at t=200 advances it past one that
-            // failed at t=100, and this stream resumes from the raw mark with no 20-minute shift, so that
-            // entity is not re-fetched from pointer-changes until the periodic snapshot re-sync.
-            //
-            // Left as-is deliberately, because there is no correct cheap fix here. Bootstrap has a natural
-            // checkpoint — it ends, and onIdle() gates the promotion — while this stream is designed to
-            // run forever, so there is nothing to hold the marks until. The two real options both change
-            // behaviour beyond a bug fix: drain the deployer once per poll, which serialises it against
-            // polling and caps throughput at the deployer's latency; or stop resuming from a max and track
-            // a contiguous watermark, which is the actual modelling error — a single scalar cannot express
-            // "everything through T except t=100". That is a design decision about the resume model, so it
-            // wants a deliberate choice rather than being smuggled in here.
             await deployEntitiesFromPointerChanges(
               components,
               { ...options, fromTimestamp },
               contentServer,
               shouldStopStream,
-              increaseLastTimestamp
+              (_server, ...newTimestamps) => tentativeTimestamps.push(...newTimestamps),
+              report,
+              async () => {
+                await components.deployer.onIdle()
+                // Cumulative, not per poll: this asks whether everything scheduled since the stream
+                // started has been confirmed, which is exactly the contiguity condition. Once something
+                // is outstanding the mark stops advancing until the stream restarts and re-fetches it.
+                if (report.acknowledged < report.scheduled || tentativeTimestamps.length === 0) {
+                  return
+                }
+                increaseLastTimestamp(contentServer, ...tentativeTimestamps)
+                tentativeTimestamps.length = 0
+              }
             )
           } catch (e: any) {
             // we don't log the exception here because createExponentialFallofRetry(logger, options) receives the logger

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -5,6 +5,7 @@ import {
   decideSnapshotDeploymentFromProcessedSet,
   deployEntitiesFromPointerChanges,
   deployEntitiesFromSnapshot,
+  filterProcessedSnapshotsInChunks,
   PointerChangesDeploymentReport
 } from './deploy-entities'
 import { createExponentialFallofRetry } from './exponential-fallof-retry'
@@ -242,7 +243,7 @@ export async function createSynchronizer(
     }
     const processedSnapshots =
       allSnapshotHashesToCheck.size > 0
-        ? await components.processedSnapshotStorage.filterProcessedSnapshotsFrom(Array.from(allSnapshotHashesToCheck))
+        ? await filterProcessedSnapshotsInChunks(components, Array.from(allSnapshotHashesToCheck))
         : new Set<string>()
 
     const timeRangesOfEntitiesToDeploy: TimeRange[] = []
@@ -345,7 +346,8 @@ export async function createSynchronizer(
     // Without re-reading it, a deployer that quietly dropped an entity would still let the servers
     // advertising that snapshot advance past it.
     if (serversBySnapshotDeployed.size > 0) {
-      const processedAfterDeploying = await components.processedSnapshotStorage.filterProcessedSnapshotsFrom(
+      const processedAfterDeploying = await filterProcessedSnapshotsInChunks(
+        components,
         Array.from(serversBySnapshotDeployed.keys())
       )
       for (const [snapshotHash, servers] of serversBySnapshotDeployed) {

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -507,6 +507,20 @@ export async function createSynchronizer(
 
           try {
             components.metrics.increment('dcl_deployments_stream_reconnection_count', metricsLabels)
+            // The canonical callback, committing each mark as the entity reports deployed — NOT the
+            // hold-until-drained treatment bootstrapFromPointerChanges gives it. The same hazard exists
+            // here: because the mark is a max, an entity deployed at t=200 advances it past one that
+            // failed at t=100, and this stream resumes from the raw mark with no 20-minute shift, so that
+            // entity is not re-fetched from pointer-changes until the periodic snapshot re-sync.
+            //
+            // Left as-is deliberately, because there is no correct cheap fix here. Bootstrap has a natural
+            // checkpoint — it ends, and onIdle() gates the promotion — while this stream is designed to
+            // run forever, so there is nothing to hold the marks until. The two real options both change
+            // behaviour beyond a bug fix: drain the deployer once per poll, which serialises it against
+            // polling and caps throughput at the deployer's latency; or stop resuming from a max and track
+            // a contiguous watermark, which is the actual modelling error — a single scalar cannot express
+            // "everything through T except t=100". That is a design decision about the resume model, so it
+            // wants a deliberate choice rather than being smuggled in here.
             await deployEntitiesFromPointerChanges(
               components,
               { ...options, fromTimestamp },

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -19,6 +19,21 @@ import {
 } from './types'
 import { contentServerMetricLabels } from './utils'
 
+// Preserved as the defaults these two queues have always used, so omitting `options.concurrency`
+// keeps the previous behaviour exactly.
+const DEFAULT_SNAPSHOT_DEPLOYMENTS_CONCURRENCY = 10
+const DEFAULT_SNAPSHOT_CHECKS_CONCURRENCY = 10
+
+function resolveConcurrency(name: string, value: number | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback
+  }
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`options.concurrency.${name} must be an integer >= 1, got ${value}`)
+  }
+  return value
+}
+
 /**
  * @public
  */
@@ -28,6 +43,26 @@ export async function createSynchronizer(
   },
   options: SynchronizerOptions
 ): Promise<SynchronizerComponent> {
+  // Fail fast on a value that would otherwise break sync silently: scheduleJobWithRetries throws
+  // synchronously when given 0, and that throw is swallowed by the per-server catch in
+  // syncFromSnapshots, so every server would just log "Error getting snapshots" forever.
+  if (!Number.isInteger(options.requestMaxRetries) || options.requestMaxRetries < 1) {
+    throw new Error(`options.requestMaxRetries must be an integer >= 1, got ${options.requestMaxRetries}`)
+  }
+
+  // Resolved up front so a bad value fails here with a clear message instead of inside p-queue's
+  // constructor, several stack frames deep in a background sync job.
+  const snapshotDeploymentsConcurrency = resolveConcurrency(
+    'snapshotDeployments',
+    options.concurrency?.snapshotDeployments,
+    DEFAULT_SNAPSHOT_DEPLOYMENTS_CONCURRENCY
+  )
+  const snapshotChecksConcurrency = resolveConcurrency(
+    'snapshotChecks',
+    options.concurrency?.snapshotChecks,
+    DEFAULT_SNAPSHOT_CHECKS_CONCURRENCY
+  )
+
   const logger = components.logs.getLogger('synchronizer')
   const genesisTimestamp = options.fromTimestamp || 0
   const bootstrappingServersFromSnapshots: Set<string> = new Set()
@@ -92,7 +127,33 @@ export async function createSynchronizer(
     components.metrics.observe('dcl_syncing_servers', {}, syncingServers.size)
   }
 
-  async function syncFromSnapshots(serversToSync: Set<string>): Promise<Set<string>> {
+  // Serializes every snapshot sync, whoever starts it. The periodic post-bootstrap job is not
+  // enqueued in syncJobsRunner (it loops forever, so it would block the queue), which used to let it
+  // run concurrently with a bootstrap sync job. Two concurrent runs can both decide to process a
+  // snapshot hash advertised by servers in different states, and the first stream to finish deletes
+  // the snapshot file from storage while the other is still reading it.
+  let snapshotsSyncChain: Promise<unknown> = Promise.resolve()
+
+  function syncFromSnapshots(serversToSync: Set<string>): Promise<Set<string>> {
+    const run = snapshotsSyncChain.then(
+      () => syncFromSnapshotsExclusively(serversToSync),
+      () => syncFromSnapshotsExclusively(serversToSync)
+    )
+    snapshotsSyncChain = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
+  }
+
+  async function syncFromSnapshotsExclusively(serversToSync: Set<string>): Promise<Set<string>> {
+    // Callers check isStopped before asking for a sync, but queueing behind the lock means the check
+    // can go stale before this run starts. Re-check here so a shutdown that lands while a sync is
+    // queued doesn't kick off a fresh round of /snapshots requests and snapshot downloads.
+    if (isStopped) {
+      return new Set()
+    }
+
     type Snapshot = SnapshotMetadata & { server: string }
     const snapshotsByHash: Map<string, Snapshot[]> = new Map()
     const snapshotLastTimestampByServer: Map<string, number> = new Map()
@@ -119,7 +180,7 @@ export async function createSynchronizer(
     )
 
     const deploymentsProcessorsQueue = new PQueue({
-      concurrency: 10,
+      concurrency: snapshotDeploymentsConcurrency,
       autoStart: false
     })
 
@@ -140,9 +201,15 @@ export async function createSynchronizer(
         : new Set<string>()
 
     const timeRangesOfEntitiesToDeploy: TimeRange[] = []
+    // Servers with at least one snapshot that could not be fully deployed. Their bootstrap is
+    // incomplete, so they must neither advance their last-entity timestamp nor be reported as
+    // synced: either one would resume pointer-changes past entities that were never deployed, and
+    // (because the snapshot stays unmarked) those entities would only reappear on the next full
+    // snapshot sync — up to 14 days later.
+    const serversWithFailedSnapshots = new Set<string>()
     // Each decision may still hit snapshotStorage; run them with bounded concurrency instead of a
     // serial chain. The synchronous push/enqueue after each await can't interleave.
-    const shouldProcessChecksQueue = new PQueue({ concurrency: 10 })
+    const shouldProcessChecksQueue = new PQueue({ concurrency: snapshotChecksConcurrency })
     await Promise.all(
       Array.from(snapshotsByHash).map(([snapshotHash, snapshots]) =>
         shouldProcessChecksQueue.add(async () => {
@@ -161,7 +228,16 @@ export async function createSynchronizer(
             timeRangesOfEntitiesToDeploy.push(...snapshots.map((s) => s.timeRange))
             deploymentsProcessorsQueue
               .add(async () => {
-                await deployEntitiesFromSnapshot(components, options, snapshotHash, servers, () => isStopped)
+                try {
+                  await deployEntitiesFromSnapshot(components, options, snapshotHash, servers, () => isStopped)
+                } catch (err: any) {
+                  // Recorded inside the job (not in a .catch on the add() promise) so the set is
+                  // guaranteed to be populated before onIdle() resolves and it gets read below.
+                  logger.error(err)
+                  for (const server of servers) {
+                    serversWithFailedSnapshots.add(server)
+                  }
+                }
               })
               .catch((err) => logger.error(err))
           }
@@ -180,10 +256,17 @@ export async function createSynchronizer(
 
     // Once the snapshots were correctly streamed, update the last entity timestamps
     for (const [server, lastTimestamp] of snapshotLastTimestampByServer) {
+      if (serversWithFailedSnapshots.has(server)) {
+        logger.warn('Keeping the last entity timestamp: some of its snapshots failed to deploy.', { server })
+        continue
+      }
       increaseLastTimestamp(server, lastTimestamp)
     }
-    // We only return servers that didn't fail to get its snapshots
-    return new Set(snapshotLastTimestampByServer.keys())
+    // We only return servers that got their snapshots AND deployed every one of them, so a server
+    // with a failed snapshot stays in the bootstrapping state and the whole bootstrap is retried.
+    return new Set(
+      Array.from(snapshotLastTimestampByServer.keys()).filter((server) => !serversWithFailedSnapshots.has(server))
+    )
   }
 
   async function bootstrapFromSnapshots() {
@@ -242,17 +325,33 @@ export async function createSynchronizer(
   const deployPointerChangesAfterBootstrapJobManager = createJobLifecycleManagerComponent(components, {
     jobManagerName: 'SynchronizationJobManager',
     createJob(contentServer) {
-      const fromTimestamp = lastEntityTimestampFromSnapshotsByServer.get(contentServer)
-      if (fromTimestamp === undefined) {
+      if (lastEntityTimestampFromSnapshotsByServer.get(contentServer) === undefined) {
         throw new Error(
           `Can't start pointer changes stream without last entity timestamp for ${contentServer}. This should never happen.`
         )
       }
       const metricsLabels = contentServerMetricLabels(contentServer)
+      // Per-job stop signal. The retry component's stop() only prevents the NEXT iteration, and the
+      // in-flight pointer-changes stream polls forever on its own (pointerChangesWaitTime > 0), so
+      // without a job-scoped flag a server dropped from the desired set would keep being polled and
+      // deployed until the whole synchronizer stopped.
+      let jobStopped = false
+      const shouldStopStream = () => isStopped || jobStopped
+
       const exponentialFallofRetryComponent = createExponentialFallofRetry(logger, {
         async action() {
-          if (isStopped) {
+          if (shouldStopStream()) {
             return
+          }
+
+          // Read the timestamp on every attempt. increaseLastTimestamp advances it as entities are
+          // deployed, so a reconnect resumes from the latest processed entity; capturing it once at
+          // job creation made every reconnect re-stream everything since bootstrap.
+          const fromTimestamp = lastEntityTimestampFromSnapshotsByServer.get(contentServer)
+          if (fromTimestamp === undefined) {
+            throw new Error(
+              `Can't start pointer changes stream without last entity timestamp for ${contentServer}. This should never happen.`
+            )
           }
 
           try {
@@ -261,7 +360,7 @@ export async function createSynchronizer(
               components,
               { ...options, fromTimestamp },
               contentServer,
-              () => isStopped,
+              shouldStopStream,
               increaseLastTimestamp
             )
           } catch (e: any) {
@@ -272,9 +371,20 @@ export async function createSynchronizer(
         },
         retryTime: options.syncingReconnection.reconnectTime,
         retryTimeExponent: options.syncingReconnection.reconnectRetryTimeExponent ?? 1.1,
-        maxInterval: options.syncingReconnection.maxReconnectionTime
+        maxInterval: options.syncingReconnection.maxReconnectionTime,
+        // Surviving a full poll cycle is evidence the stream was healthy, so an isolated failure after
+        // hours of syncing reconnects at the base interval instead of the grown one.
+        healthyRunTime: Math.max(options.pointerChangesWaitTime, options.syncingReconnection.reconnectTime)
       })
-      return exponentialFallofRetryComponent
+
+      return {
+        ...exponentialFallofRetryComponent,
+        async stop() {
+          // Set before awaiting, so the in-flight stream sees it at its next check.
+          jobStopped = true
+          await exponentialFallofRetryComponent.stop()
+        }
+      }
     }
   })
 
@@ -282,9 +392,23 @@ export async function createSynchronizer(
     const onFirstBootstrapFinishedCallbacks: Array<() => Promise<void>> = []
     let firstBootstrapTryFinished = false
     const syncFinished = future<void>()
+    // onSyncFinished() hands this future to consumers, so every path that ends the job must settle
+    // it. Stopping the synchronizer makes the action short-circuit and exitOnSuccess ends the retry
+    // loop, which would otherwise leave the future pending and hang the consumer's shutdown forever.
+    // The no-op catch keeps that rejection from surfacing as an unhandled rejection for consumers
+    // that never call onSyncFinished().
+    syncFinished.catch(() => undefined)
+
+    function abortSyncFinished() {
+      if (syncFinished.isPending) {
+        syncFinished.reject(new Error('The synchronization job was stopped before it finished.'))
+      }
+    }
+
     const syncRetry = createExponentialFallofRetry(logger, {
       async action() {
         if (isStopped) {
+          abortSyncFinished()
           return
         }
 
@@ -297,6 +421,7 @@ export async function createSynchronizer(
         logger.info('Bootstrap finished')
 
         if (isStopped) {
+          abortSyncFinished()
           return
         }
 
@@ -328,6 +453,11 @@ export async function createSynchronizer(
     })
     return {
       ...syncRetry,
+      async stop() {
+        await syncRetry.stop()
+        // Also covers jobs the serial runner drops from its queue without ever starting them.
+        abortSyncFinished()
+      },
       async onInitialBootstrapFinished(cb: () => Promise<void>) {
         if (!firstBootstrapTryFinished) {
           onFirstBootstrapFinishedCallbacks.push(cb)
@@ -396,13 +526,13 @@ export async function createSynchronizer(
         if (deployPointerChangesAfterBootstrapJobManager.stop) {
           await deployPointerChangesAfterBootstrapJobManager.stop()
         }
-        if (regularSyncFromSnapshotsAfterBootstrapJob.stop) {
-          await regularSyncFromSnapshotsAfterBootstrapJob.stop()
-        }
+        // Cancel the pending start before stopping the job, so a timer that is about to fire cannot
+        // restart it after it was stopped.
         if (snapshotsSyncTimeout) {
           clearTimeout(snapshotsSyncTimeout)
-          await regularSyncFromSnapshotsAfterBootstrapJob.stop()
+          snapshotsSyncTimeout = undefined
         }
+        await regularSyncFromSnapshotsAfterBootstrapJob.stop()
       }
     }
   }

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -391,6 +391,24 @@ export async function createSynchronizer(
     // Servers whose pointer-changes bootstrap streamed through without error. They are promoted to the
     // syncing state only after the deployer has drained, not as each stream ends.
     const bootstrappedFromPointerChanges = new Set<string>()
+    // Where each server WOULD resume from, held back until the drain confirms it.
+    //
+    // Advancing the canonical high-water mark as each entity reports deployed commits progress the drain
+    // has not confirmed. If onIdle() then rejects because some other queued deployment failed, the
+    // server correctly stays in bootstrap — but a later successful deployment has already pushed its
+    // mark past the failed one, so the retry resumes beyond an entity that never deployed. Only the
+    // 20-minute bootstrap shift stood between that and a silent gap.
+    const tentativeTimestamps = new Map<string, number>()
+    function collectTentativeTimestamp(contentServer: string, ...newTimestamps: number[]) {
+      if (newTimestamps.length === 0) {
+        return
+      }
+      const current = tentativeTimestamps.get(contentServer)
+      tentativeTimestamps.set(
+        contentServer,
+        current === undefined ? Math.max(...newTimestamps) : Math.max(current, ...newTimestamps)
+      )
+    }
     let minStartingPoint: undefined | number
     for (const bootstrappingServersFromPointerChange of bootstrappingServersFromPointerChanges) {
       const fromTimestamp = pointerChangesStartingTimestamp(bootstrappingServersFromPointerChange)
@@ -403,7 +421,7 @@ export async function createSynchronizer(
             { ...options, fromTimestamp, pointerChangesWaitTime: 0 },
             bootstrappingServersFromPointerChange,
             () => isStopped,
-            increaseLastTimestamp
+            collectTentativeTimestamp
           )
           // Both leaving pointer-changes bootstrap and entering the syncing state are deferred until
           // the deployer has drained, below. Removing it here would strand the server in neither state
@@ -436,6 +454,13 @@ export async function createSynchronizer(
       // retry picks them up again rather than losing them.
       await components.deployer.onIdle()
       for (const server of bootstrappedFromPointerChanges) {
+        // Committed only here: the drain succeeded, so everything this pass scheduled for this server
+        // really did deploy. A rejection above skips this entirely and the pass is retried from the
+        // timestamp it started at.
+        const tentative = tentativeTimestamps.get(server)
+        if (tentative !== undefined) {
+          increaseLastTimestamp(server, tentative)
+        }
         bootstrappingServersFromPointerChanges.delete(server)
         if (!canAdvanceServer(server)) {
           logger.info('Not moving a server to the syncing state: it is no longer desired.', { server })
@@ -644,6 +669,13 @@ export async function createSynchronizer(
 
       // 2. c) Remove from syncing servers that should stop syncing
       removeServersNotToSyncFromStateSet(serversToSync, syncingServers)
+
+      // Signal the dropped servers' pointer-changes jobs now rather than waiting for the next bootstrap
+      // pass to reconcile. That pass is serialized behind whatever is already running, so a server the
+      // caller just removed would otherwise keep polling and deploying for as long as that takes. Only
+      // already-syncing servers are in this set — newly desired ones start in snapshot bootstrap — so
+      // this stops the removed jobs without starting anything.
+      deployPointerChangesAfterBootstrapJobManager.setDesiredJobs(syncingServers)
 
       reportServerStateMetric()
 

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -304,7 +304,22 @@ export async function createSynchronizer(
       deploymentsProcessorsQueue
         .add(async () => {
           try {
-            await deployEntitiesFromSnapshot(components, options, snapshotHash, servers, () => isStopped)
+            // Stops when the shutdown flag is set, or when no server that advertised this snapshot is
+            // wanted any more — matching how a pointer-changes job stops as soon as its server is dropped.
+            // Checked across all of them rather than one: a snapshot advertised by several servers is still
+            // worth deploying while any of them is desired, since its entities serve all of them.
+            //
+            // An early stop leaves the snapshot unmarked, so the marker re-check after the deployer drains
+            // attributes it back to those servers as unfinished and they do not advance. That is the
+            // correct outcome — the work really did not complete — and it costs nothing for a server that
+            // is no longer desired.
+            await deployEntitiesFromSnapshot(
+              components,
+              options,
+              snapshotHash,
+              servers,
+              () => isStopped || !Array.from(servers).some((server) => desiredServers.has(server))
+            )
           } catch (err: any) {
             // Recorded inside the job (not in a .catch on the add() promise) so the set is
             // guaranteed to be populated before onIdle() resolves and it gets read below.

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -307,6 +307,11 @@ export async function createSynchronizer(
     deploymentsProcessorsQueue.start()
 
     await deploymentsProcessorsQueue.onIdle()
+    // The queue draining only means every snapshot finished STREAMING. Per IDeployerComponent,
+    // scheduleEntityDeployment may resolve before the entity is deployed and onIdle() is the drain
+    // signal, so with a batching deployer the entities are still in flight here. Advancing a server's
+    // timestamp now would resume its pointer-changes past entities that had only been scheduled.
+    await components.deployer.onIdle()
     logger.info('End deploying entities from snapshots.')
 
     // Once the snapshots were correctly streamed, update the last entity timestamps
@@ -357,6 +362,9 @@ export async function createSynchronizer(
   async function bootstrapFromPointerChanges() {
     logger.debug(`Bootstrapping servers (Pointer Changes): ${Array.from(bootstrappingServersFromPointerChanges)}`)
     const pointerChangesBootstrappingJobs: (() => Promise<void>)[] = []
+    // Servers whose pointer-changes bootstrap streamed through without error. They are promoted to the
+    // syncing state only after the deployer has drained, not as each stream ends.
+    const bootstrappedFromPointerChanges = new Set<string>()
     let minStartingPoint: undefined | number
     for (const bootstrappingServersFromPointerChange of bootstrappingServersFromPointerChanges) {
       const fromTimestamp = pointerChangesStartingTimestamp(bootstrappingServersFromPointerChange)
@@ -372,13 +380,8 @@ export async function createSynchronizer(
             increaseLastTimestamp
           )
           bootstrappingServersFromPointerChanges.delete(bootstrappingServersFromPointerChange)
-          if (!canAdvanceServer(bootstrappingServersFromPointerChange)) {
-            logger.info('Not moving a server to the syncing state: it is no longer desired.', {
-              server: bootstrappingServersFromPointerChange
-            })
-            return
-          }
-          syncingServers.add(bootstrappingServersFromPointerChange)
+          // Promotion is deferred until the deployer has drained, below.
+          bootstrappedFromPointerChanges.add(bootstrappingServersFromPointerChange)
         } catch (error) {
           // If there's an error, the server doesn't pass to syncing state
           logger.info(`Error bootstrapping from pointer changes for server: ${bootstrappingServersFromPointerChange}`)
@@ -397,6 +400,18 @@ export async function createSynchronizer(
 
     if (pointerChangesBootstrappingJobs.length > 0) {
       await Promise.all(pointerChangesBootstrappingJobs.map((job) => job()))
+      // A stream ending means every deployment was SCHEDULED. Entering the syncing state is what makes
+      // the server resume from its high-water timestamp, so wait for the deployer's own drain signal
+      // first — otherwise an asynchronous deployer is still working through entities the server is
+      // already considered to be past.
+      await components.deployer.onIdle()
+      for (const server of bootstrappedFromPointerChanges) {
+        if (!canAdvanceServer(server)) {
+          logger.info('Not moving a server to the syncing state: it is no longer desired.', { server })
+          continue
+        }
+        syncingServers.add(server)
+      }
     }
 
     reportServerStateMetric()
@@ -666,6 +681,10 @@ export async function createSynchronizer(
           await regularSyncFromSnapshotsAfterBootstrapJob.stop()
           // Signalling it is not enough: wait for the run itself, as we do for every other job.
           await regularSyncRun?.catch(() => undefined)
+          // Our own queues being drained does not mean the deployer is. Entities scheduled before the
+          // stop are still being deployed — and mutating the caller's state — until it reports idle, so
+          // this is what makes stop() resolving mean "nothing is still deploying".
+          await components.deployer.onIdle()
         })()
       }
       return shutdown

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -18,7 +18,7 @@ import {
   SynchronizerOptions,
   TimeRange
 } from './types'
-import { contentServerMetricLabels } from './utils'
+import { contentServerMetricLabels, resolveTransferLimits } from './utils'
 
 // Preserved as the defaults these two queues have always used, so omitting `options.concurrency`
 // keeps the previous behaviour exactly.
@@ -50,6 +50,10 @@ export async function createSynchronizer(
   if (!Number.isInteger(options.requestMaxRetries) || options.requestMaxRetries < 1) {
     throw new Error(`options.requestMaxRetries must be an integer >= 1, got ${options.requestMaxRetries}`)
   }
+
+  // Same reasoning as the concurrency options: resolved here so a bad transfer limit is rejected at
+  // construction rather than surfacing as a puzzling failure on some individual download later.
+  resolveTransferLimits(options.transferLimits)
 
   // Resolved up front so a bad value fails here with a clear message instead of inside p-queue's
   // constructor, several stack frames deep in a background sync job.
@@ -187,7 +191,12 @@ export async function createSynchronizer(
     await Promise.all(
       Array.from(serversToSync).map(async (server) => {
         try {
-          const { snapshots, discardedEntries } = await getSnapshots(components, server, options.requestMaxRetries)
+          const { snapshots, discardedEntries } = await getSnapshots(
+            components,
+            server,
+            options.requestMaxRetries,
+            options.transferLimits
+          )
           if (discardedEntries > 0) {
             // The surviving subset is not this server's history. Each discarded entry stood for a time
             // range, so deploying only what parsed and then advancing past the newest of them would skip

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -103,6 +103,16 @@ export async function createSynchronizer(
   let regularSyncRun: Promise<void> | undefined
   // Memoised shutdown, so concurrent stop() callers share one and none of them returns early.
   let shutdown: Promise<void> | undefined
+  // The sync job that is enqueued but has not started yet, if any. At most one is ever waiting: see
+  // the coalescing note in syncWithServers.
+  let queuedSyncJob: ReturnType<typeof createSyncJob> | undefined
+
+  /** Clears the pending slot, but only if `job` is still the one holding it. */
+  function releaseQueuedSyncJob(job: ReturnType<typeof createSyncJob>) {
+    if (queuedSyncJob === job) {
+      queuedSyncJob = undefined
+    }
+  }
 
   function pointerChangesStartingTimestamp(server: string): number {
     const lastTimestamp = lastEntityTimestampFromSnapshotsByServer.get(server)
@@ -563,7 +573,19 @@ export async function createSynchronizer(
 
       reportServerStateMetric()
 
+      // A job that is queued but not yet running is pure redundancy against a second one: when it
+      // starts it re-reads the live bootstrapping/syncing sets, which steps 0-2 above have already
+      // updated for this caller. Handing back the waiting job keeps a periodic DAO refresh from
+      // stacking one full bootstrap pass per call behind a job that is slow or repeatedly failing —
+      // the runner is serial, so that queue only ever drained as N redundant passes.
+      if (queuedSyncJob) {
+        return queuedSyncJob
+      }
+
       const newSyncJob = createSyncJob()
+      // Claimed before the only await below, so a concurrent caller coalesces onto this job rather
+      // than racing to create a second one in that window.
+      queuedSyncJob = newSyncJob
       if (!firstSyncJobStarted) {
         firstSyncJobStarted = true
         await newSyncJob.onInitialBootstrapFinished(async () => {
@@ -574,11 +596,20 @@ export async function createSynchronizer(
           }, 3_600_000)
         })
       }
-      syncJobsRunner.enqueue(newSyncJob)
+      syncJobsRunner.enqueue({
+        async start() {
+          // No longer waiting, so the next caller queues a fresh job instead of being handed this
+          // one, whose view of the desired servers is already fixed.
+          releaseQueuedSyncJob(newSyncJob)
+          await newSyncJob.start()
+        },
+        stop: () => newSyncJob.stop()
+      })
       // The await above is the only suspension point in this method, so stop() can land in the middle
       // of the very first call. The runner silently drops jobs enqueued after it stopped, which would
       // leave this job's onSyncFinished() pending forever, so settle it here instead.
       if (isStopped) {
+        releaseQueuedSyncJob(newSyncJob)
         await newSyncJob.stop()
       }
       return newSyncJob
@@ -590,6 +621,9 @@ export async function createSynchronizer(
         shutdown = (async () => {
           isStopped = true
 
+          // The runner drops whatever is still queued, so the pending slot must not keep handing that
+          // now-dead job to anyone.
+          queuedSyncJob = undefined
           await syncJobsRunner.stop()
           syncingServers.clear()
           if (deployPointerChangesAfterBootstrapJobManager.stop) {

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -36,6 +36,28 @@ function resolveConcurrency(name: string, value: number | undefined, fallback: n
   return value
 }
 
+function validateReconnectionOptions(name: string, options: SynchronizerOptions['bootstrapReconnection']): void {
+  if (!Number.isFinite(options.reconnectTime) || options.reconnectTime < 0) {
+    throw new Error(`options.${name}.reconnectTime must be a finite number >= 0, got ${options.reconnectTime}`)
+  }
+  if (
+    options.reconnectRetryTimeExponent !== undefined &&
+    (!Number.isFinite(options.reconnectRetryTimeExponent) || options.reconnectRetryTimeExponent < 1)
+  ) {
+    throw new Error(
+      `options.${name}.reconnectRetryTimeExponent must be a finite number >= 1, got ${options.reconnectRetryTimeExponent}`
+    )
+  }
+  if (
+    options.maxReconnectionTime !== undefined &&
+    (!Number.isFinite(options.maxReconnectionTime) || options.maxReconnectionTime < 0)
+  ) {
+    throw new Error(
+      `options.${name}.maxReconnectionTime must be a finite number >= 0, got ${options.maxReconnectionTime}`
+    )
+  }
+}
+
 /**
  * @public
  */
@@ -51,6 +73,9 @@ export async function createSynchronizer(
   if (!Number.isInteger(options.requestMaxRetries) || options.requestMaxRetries < 1) {
     throw new Error(`options.requestMaxRetries must be an integer >= 1, got ${options.requestMaxRetries}`)
   }
+
+  validateReconnectionOptions('bootstrapReconnection', options.bootstrapReconnection)
+  validateReconnectionOptions('syncingReconnection', options.syncingReconnection)
 
   // Same reasoning as the concurrency options: resolved here so a bad transfer limit is rejected at
   // construction rather than surfacing as a puzzling failure on some individual download later.

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -68,6 +68,10 @@ export async function createSynchronizer(
   const bootstrappingServersFromSnapshots: Set<string> = new Set()
   const bootstrappingServersFromPointerChanges: Set<string> = new Set()
   const syncingServers: Set<string> = new Set()
+  // The servers the caller last asked for, i.e. the authority every state transition is checked
+  // against. The three sets above are *where* a server currently is; this is whether it should be
+  // anywhere at all.
+  const desiredServers: Set<string> = new Set()
   const lastEntityTimestampFromSnapshotsByServer: Map<string, number> = new Map()
   // Sync jobs are serialized: only one runs at a time, the rest queue (FIFO).
   const syncJobsRunner = createSerialJobRunner(logger)
@@ -282,13 +286,32 @@ export async function createSynchronizer(
     )
   }
 
+  /**
+   * Whether a server may still be advanced to the next sync state.
+   *
+   * Bootstrap phases are long-running, so `syncWithServers` can drop a server while a phase that
+   * already captured it is still in flight. Promoting unconditionally when that phase finishes
+   * resurrects the server: it lands in `syncingServers` and the next `setDesiredJobs` starts a
+   * long-lived pointer-changes job for a server the caller explicitly removed. `desiredServers` is the
+   * authority on what the caller last asked for, so every state transition is validated against it.
+   */
+  function canAdvanceServer(server: string): boolean {
+    return !isStopped && desiredServers.has(server)
+  }
+
   async function bootstrapFromSnapshots() {
     logger.debug(`Bootstrapping servers (snapshots): ${Array.from(bootstrappingServersFromSnapshots)}`)
     const syncedServersFromSnapshot = await syncFromSnapshots(bootstrappingServersFromSnapshots)
 
     for (const bootstrappedServer of syncedServersFromSnapshot) {
-      bootstrappingServersFromPointerChanges.add(bootstrappedServer)
       bootstrappingServersFromSnapshots.delete(bootstrappedServer)
+      if (!canAdvanceServer(bootstrappedServer)) {
+        logger.info('Not advancing a server to the pointer-changes bootstrap: it is no longer desired.', {
+          server: bootstrappedServer
+        })
+        continue
+      }
+      bootstrappingServersFromPointerChanges.add(bootstrappedServer)
     }
     reportServerStateMetric()
   }
@@ -310,8 +333,14 @@ export async function createSynchronizer(
             () => isStopped,
             increaseLastTimestamp
           )
-          syncingServers.add(bootstrappingServersFromPointerChange)
           bootstrappingServersFromPointerChanges.delete(bootstrappingServersFromPointerChange)
+          if (!canAdvanceServer(bootstrappingServersFromPointerChange)) {
+            logger.info('Not moving a server to the syncing state: it is no longer desired.', {
+              server: bootstrappingServersFromPointerChange
+            })
+            return
+          }
+          syncingServers.add(bootstrappingServersFromPointerChange)
         } catch (error) {
           // If there's an error, the server doesn't pass to syncing state
           logger.info(`Error bootstrapping from pointer changes for server: ${bootstrappingServersFromPointerChange}`)
@@ -509,6 +538,13 @@ export async function createSynchronizer(
       if (isStopped) {
         throw new Error('synchronizer is stopped.')
       }
+      // 0. Record what the caller wants, so an in-flight bootstrap phase that already captured a
+      //    now-removed server cannot promote it back into the sync states when it finishes.
+      desiredServers.clear()
+      for (const serverToSync of serversToSync) {
+        desiredServers.add(serverToSync)
+      }
+
       // 1. Add the new servers (not currently syncing) to the bootstrapping state from snapshots
       for (const serverToSync of serversToSync) {
         if (!syncingServers.has(serverToSync) && !bootstrappingServersFromPointerChanges.has(serverToSync)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,23 @@ export type TransferLimits = {
    */
   minTransferRateInBytesPerSecond?: number
   /**
+   * Ceiling on how many pages a single paginated call (`/pointer-changes`) will follow before giving up.
+   *
+   * A hostile or broken server can keep advertising a `next` link, and each page is another request to the
+   * same path, so this bounds the amplification one poll can produce. The default is far above any
+   * legitimate page count — at ~1000 entries per page it allows 10M deployments in one poll — so lower it
+   * if you would rather cap the amplification tightly than tolerate an unusually deep backlog in a single
+   * poll.
+   *
+   * There is deliberately no wall-clock budget for a paginated call. Pagination progress is not committed
+   * until the poll completes, so aborting a long one throws the poll's work away and resumes from the last
+   * confirmed timestamp — a node with a genuinely deep backlog would restart the same walk forever rather
+   * than catch up. A page count degrades the same way, which is why the default is set where no real
+   * backlog reaches it. Must be an integer >= 1.
+   * @defaultValue 10000
+   */
+  maxPagesPerPaginatedCall?: number
+  /**
    * How long a transfer runs before its rate is judged at all. Small responses finish well inside this,
    * and earlier samples are dominated by connection setup rather than throughput. Raise it alongside
    * lowering the floor if your peers are slow to get going. Must be an integer >= 0.

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,11 +62,19 @@ export type SnapshotsFetcherComponents = {
  */
 export type TransferLimits = {
   /**
-   * Deadline for a JSON request's body read, refreshed on every chunk received — an inactivity
-   * deadline, not a total one. Must be an integer >= 1.
+   * Deadline for a **JSON request's** body read — `/snapshots` and `/pointer-changes`. Refreshed on every
+   * chunk received, so it is an inactivity deadline rather than a total one. Content-file downloads have
+   * their own, `downloadInactivityTimeoutInMs`, because a file legitimately takes longer than a JSON
+   * document and one value cannot serve both. Must be an integer >= 1.
    * @defaultValue 15000
    */
   requestTimeoutInMs?: number
+  /**
+   * Deadline for a content-file download, measured from the last byte received on the socket rather than
+   * from the start, so a large file making steady progress is never cut off. Must be an integer >= 1.
+   * @defaultValue 30000
+   */
+  downloadInactivityTimeoutInMs?: number
   /**
    * Hard ceiling on the bytes written to disk for a single content file, after decompression. Guards
    * against gzip bombs and otherwise unbounded responses. Must be an integer >= 1.

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,13 +27,21 @@ export type Path = string
 export type ContentMapping = { file: string; hash: string }
 
 /**
+ * The only part of IJobQueue this package actually calls. Requiring just this lets callers supply
+ * their own bounded scheduler without implementing the queue methods nothing here uses; the queue
+ * returned by createJobQueue satisfies it as-is.
+ * @public
+ */
+export type IDownloadQueue = Pick<IJobQueue, 'scheduleJobWithRetries'>
+
+/**
  * Components needed by the DeploymentsFetcher to work
  * @public
  */
 export type SnapshotsFetcherComponents = {
   metrics: IMetricsComponent<keyof typeof metricsDefinitions>
   fetcher: IFetchComponent
-  downloadQueue: IJobQueue
+  downloadQueue: IDownloadQueue
   logs: ILoggerComponent
   storage: IContentStorageComponent
   processedSnapshotStorage: IProcessedSnapshotStorageComponent
@@ -143,7 +151,33 @@ export type SynchronizerOptions = SnapshotDeployedEntityStreamOptions &
   PointerChangesDeployedEntityStreamOptions & {
     bootstrapReconnection: ReconnectionOptions
     syncingReconnection: ReconnectionOptions
+    /**
+     * Tunes how much work the synchronizer runs at once. Omit it, or any of its fields, to keep the
+     * defaults.
+     */
+    concurrency?: SynchronizerConcurrencyOptions
   }
+
+/**
+ * Bounds on the work the synchronizer performs in parallel. The right values depend on the deployment:
+ * available bandwidth, how fast the deployer drains, and any rate limits the remote content servers
+ * apply. Every field must be an integer >= 1.
+ * @public
+ */
+export type SynchronizerConcurrencyOptions = {
+  /**
+   * Snapshots being streamed and deployed at the same time. Each one holds an open snapshot file and
+   * feeds entities to the deployer, so raising this multiplies both bandwidth and deployer pressure.
+   * @defaultValue 10
+   */
+  snapshotDeployments?: number
+  /**
+   * Decisions about whether a snapshot needs deploying, evaluated at the same time. Each one may hit
+   * `snapshotStorage`, so this mostly bounds load on that component.
+   * @defaultValue 10
+   */
+  snapshotChecks?: number
+}
 
 /**
  * @public
@@ -231,9 +265,14 @@ export type SynchronizerComponent = IBaseComponent & {
 export type SnapshotMetadata = {
   hash: string
   timeRange: TimeRange
-  numberOfEntities: number
   replacedSnapshotHashes?: string[]
-  generationTimestamp: number
+  /**
+   * Informational only: nothing in this package reads these, and content servers do not always
+   * include them. They are optional so the type matches what isValidSnapshotMetadata actually
+   * guarantees — declaring them as required made every validated snapshot a type lie.
+   */
+  numberOfEntities?: number
+  generationTimestamp?: number
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,8 +76,16 @@ export type TransferLimits = {
    */
   downloadInactivityTimeoutInMs?: number
   /**
-   * Hard ceiling on the bytes written to disk for a single content file, after decompression. Guards
-   * against gzip bombs and otherwise unbounded responses. Must be an integer >= 1.
+   * Hard ceiling on the bytes of a single content file. Applied on **both sides** of a gzip boundary: to
+   * the decompressed bytes written to disk, which is the gzip-bomb bound, and to the compressed response
+   * as well.
+   *
+   * The compressed bound is needed because a peer can stream valid gzip indefinitely while producing no
+   * decompressed output at all — concatenated empty gzip members are legal — so a bound only on the
+   * decompressed side never receives a byte to measure. For real content it never binds: gzip exceeds its
+   * input only for incompressible data, and then by about 0.03%. A failure names which side tripped.
+   *
+   * Must be an integer >= 1.
    * @defaultValue 1073741824
    */
   maxDownloadedFileSizeInBytes?: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,58 @@ export type SnapshotsFetcherComponents = {
   snapshotStorage: ISnapshotStorageComponent
 }
 
+/**
+ * Bounds applied to an individual HTTP transfer.
+ *
+ * Supplied per call, on the options bag, rather than once on the components bag: a components container
+ * is a fixed set of members — this package's own test harness proxies it and throws on any name it does
+ * not know — so an optional configuration field read from it is not safe to assume present. Config is
+ * not a component.
+ *
+ * The defaults are the values this package used before they were configurable, so omitting the field, or
+ * any field within it, changes nothing.
+ * @public
+ */
+export type TransferLimits = {
+  /**
+   * Deadline for a JSON request's body read, refreshed on every chunk received — an inactivity
+   * deadline, not a total one. Must be an integer >= 1.
+   * @defaultValue 15000
+   */
+  requestTimeoutInMs?: number
+  /**
+   * Hard ceiling on the bytes written to disk for a single content file, after decompression. Guards
+   * against gzip bombs and otherwise unbounded responses. Must be an integer >= 1.
+   * @defaultValue 1073741824
+   */
+  maxDownloadedFileSizeInBytes?: number
+  /**
+   * Minimum rate a transfer must average, once it has been running longer than
+   * `transferRateGracePeriodInMs`, to be allowed to continue. This is what stops a peer trickling bytes
+   * to hold a slot indefinitely: the inactivity deadline above only asks whether bytes are still
+   * arriving, this asks whether they add up to progress.
+   *
+   * Lower it on a constrained link. Must be an integer >= 0; **0 disables the check**, which restores
+   * the pre-3.0.0 behaviour of allowing an arbitrarily slow transfer to continue as long as it keeps
+   * sending something.
+   * @defaultValue 4096
+   */
+  minTransferRateInBytesPerSecond?: number
+  /**
+   * How long a transfer runs before its rate is judged at all. Small responses finish well inside this,
+   * and earlier samples are dominated by connection setup rather than throughput. Raise it alongside
+   * lowering the floor if your peers are slow to get going. Must be an integer >= 0.
+   * @defaultValue 60000
+   */
+  transferRateGracePeriodInMs?: number
+}
+
+/**
+ * {@link TransferLimits} with every default filled in.
+ * @public
+ */
+export type ResolvedTransferLimits = Required<TransferLimits>
+
 export type DeployableEntity = SyncDeployment & {
   markAsDeployed?: () => Promise<void>
   snapshotHash?: string
@@ -222,6 +274,11 @@ export type PointerChangesDeployedEntityStreamOptions = DeployedEntityStreamComm
  */
 export type DeployedEntityStreamCommonOptions = {
   fromTimestamp?: number
+  /**
+   * Bounds on the individual HTTP transfers this stream performs. Omit it, or any of its fields, to keep
+   * the defaults. See {@link TransferLimits}.
+   */
+  transferLimits?: TransferLimits
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,12 +267,19 @@ export type SnapshotMetadata = {
   timeRange: TimeRange
   replacedSnapshotHashes?: string[]
   /**
-   * Informational only: nothing in this package reads these, and content servers do not always
-   * include them. They are optional so the type matches what isValidSnapshotMetadata actually
-   * guarantees — declaring them as required made every validated snapshot a type lie.
+   * Informational only — nothing in this package reads either field.
+   *
+   * Kept required. They were briefly made optional so the type would match exactly what
+   * isValidSnapshotMetadata verifies, but that validation was then removed (rejecting a snapshot over a
+   * field we never read would silently stop us syncing from that server), so the optionality bought
+   * nothing while breaking every downstream consumer that reads these as numbers.
+   *
+   * The residual inaccuracy is that a server omitting them yields `undefined` at runtime. Addressing
+   * that properly means a separate validated-remote-response type rather than weakening this public
+   * one; it is not worth a source-compatibility break for two fields this package ignores.
    */
-  numberOfEntities?: number
-  generationTimestamp?: number
+  numberOfEntities: number
+  generationTimestamp: number
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -216,21 +216,21 @@ export async function fetchJson(
   if (response.status >= 300 && response.status < 400) {
     await response.body?.cancel().catch(() => undefined)
     throw new Error(
-      `Refusing to follow a redirect while fetching ${url}: got status ${response.status} to ${JSON.stringify(
-        response.headers.get('location')
-      )}`
+      `Refusing to follow a redirect while fetching ${sanitizeUrlForLog(url)}: got status ${
+        response.status
+      } to ${truncateForLog(JSON.stringify(response.headers.get('location')))}`
     )
   }
 
   if (!response.ok) {
     // Drain the body so undici releases the socket back to the pool before throwing.
     await response.body?.cancel().catch(() => undefined)
-    throw new Error('Error fetching ' + url + '. Status code was: ' + response.status)
+    throw new Error('Error fetching ' + sanitizeUrlForLog(url) + '. Status code was: ' + response.status)
   }
 
   const body = await readBodyWithSizeLimit(response, MAX_JSON_RESPONSE_SIZE_IN_BYTES, bodyReadTimeout, limits)
   if (body === '') {
-    throw new Error('Error fetching ' + url + '. The response body was empty.')
+    throw new Error('Error fetching ' + sanitizeUrlForLog(url) + '. The response body was empty.')
   }
 
   return JSON.parse(body)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,12 @@ const MAX_JSON_RESPONSE_SIZE_IN_BYTES = 50 * 1024 * 1024 // 50 MiB
 // Reads a response body while enforcing a maximum size. The native fetcher (unlike node-fetch) has
 // no `size` option, so we cap manually: read the stream with a running byte count and abort —
 // cancelling the stream to free its socket — if it exceeds the limit.
-async function readBodyWithSizeLimit(response: Response, maxBytes: number): Promise<string> {
+// Applied to the body read when the caller did not ask for a specific timeout.
+const DEFAULT_BODY_READ_TIMEOUT_IN_MS = 30_000
+// How many same-origin redirects fetchJson will follow itself.
+const MAX_JSON_REDIRECTS = 5
+
+async function readBodyWithSizeLimit(response: Response, maxBytes: number, timeoutMs: number): Promise<string> {
   const reader = response.body?.getReader()
   if (!reader) {
     return ''
@@ -30,6 +35,15 @@ async function readBodyWithSizeLimit(response: Response, maxBytes: number): Prom
 
   const chunks: Uint8Array[] = []
   let total = 0
+  // The fetch component's timeout only covers time-to-headers: it clears its abort timer as soon as
+  // the response object exists. Without a deadline here a server can send headers, write half a
+  // document and then go silent forever — exactly the stall the request timeout was meant to prevent,
+  // and a pending promise never reaches the reconnection logic.
+  let timedOut = false
+  const timeout = setTimeout(() => {
+    timedOut = true
+    void reader.cancel().catch(() => undefined)
+  }, timeoutMs)
 
   try {
     for (;;) {
@@ -43,29 +57,71 @@ async function readBodyWithSizeLimit(response: Response, maxBytes: number): Prom
         chunks.push(value)
       }
     }
+  } catch (e) {
+    throw timedOut ? new Error(`Timed out after ${timeoutMs}ms while reading the response body`) : e
   } finally {
+    clearTimeout(timeout)
     // Frees the socket on the size-exceeded path; a no-op once the stream has been fully read.
     await reader.cancel().catch(() => undefined)
+  }
+
+  if (timedOut) {
+    throw new Error(`Timed out after ${timeoutMs}ms while reading the response body`)
   }
 
   return Buffer.concat(chunks).toString('utf8')
 }
 
 export async function fetchJson(url: string, fetcher: IFetchComponent, init?: RequestOptions): Promise<any> {
-  const response = await fetcher.fetch(url, init)
+  const bodyReadTimeout = init?.timeout ?? DEFAULT_BODY_READ_TIMEOUT_IN_MS
 
-  if (!response.ok) {
-    // Drain the body so undici releases the socket back to the pool before throwing.
-    await response.body?.cancel().catch(() => undefined)
-    throw new Error('Error fetching ' + url + '. Status code was: ' + response.status)
+  // redirect: 'manual' so redirects are followed here, under a same-origin rule, instead of by the
+  // fetch implementation — whose default ('follow') chases any host the server names. That turned
+  // every JSON endpoint into an SSRF primitive and let a redirect sidestep the same-origin check
+  // fetchJsonPaginated applies to `pagination.next`.
+  let currentUrl = url
+  for (let redirects = 0; ; redirects++) {
+    const response = await fetcher.fetch(currentUrl, { ...init, redirect: 'manual' })
+
+    if (response.status >= 300 && response.status < 400) {
+      await response.body?.cancel().catch(() => undefined)
+      const location = response.headers.get('location')
+      if (!location) {
+        throw new Error(`Error fetching ${currentUrl}. Redirect status ${response.status} without a location.`)
+      }
+      if (redirects >= MAX_JSON_REDIRECTS) {
+        throw new Error(`Error fetching ${url}. Too many redirects.`)
+      }
+      let redirectTarget: URL
+      try {
+        redirectTarget = new URL(location, currentUrl)
+      } catch {
+        throw new Error(`Error fetching ${currentUrl}. Invalid redirect location ${JSON.stringify(location)}.`)
+      }
+      if (redirectTarget.origin !== new URL(currentUrl).origin) {
+        throw new Error(
+          `Refusing to follow a cross-origin redirect while fetching ${url}: ${redirectTarget.origin} does not match ${
+            new URL(currentUrl).origin
+          }`
+        )
+      }
+      currentUrl = redirectTarget.toString()
+      continue
+    }
+
+    if (!response.ok) {
+      // Drain the body so undici releases the socket back to the pool before throwing.
+      await response.body?.cancel().catch(() => undefined)
+      throw new Error('Error fetching ' + currentUrl + '. Status code was: ' + response.status)
+    }
+
+    const body = await readBodyWithSizeLimit(response, MAX_JSON_RESPONSE_SIZE_IN_BYTES, bodyReadTimeout)
+    if (body === '') {
+      throw new Error('Error fetching ' + currentUrl + '. The response body was empty.')
+    }
+
+    return JSON.parse(body)
   }
-
-  const body = await readBodyWithSizeLimit(response, MAX_JSON_RESPONSE_SIZE_IN_BYTES)
-  if (body === '') {
-    throw new Error('Error fetching ' + url + '. The response body was empty.')
-  }
-
-  return JSON.parse(body)
 }
 
 export async function checkFileExists(file: string): Promise<boolean> {
@@ -193,34 +249,98 @@ const DOWNLOAD_INACTIVITY_TIMEOUT_MS = 30_000
 // bombs and otherwise unbounded responses that could exhaust the disk.
 const MAX_DOWNLOADED_FILE_SIZE_IN_BYTES = 1024 * 1024 * 1024 // 1 GiB
 
+function isNonPublicIPv4(address: string): boolean {
+  const [first, second] = address.split('.').map(Number)
+  if (first === 0) return true // 0.0.0.0/8 "this network"
+  if (first === 10) return true // 10.0.0.0/8 private
+  if (first === 127) return true // loopback
+  if (first === 169 && second === 254) return true // link-local, incl. cloud metadata
+  if (first === 172 && second >= 16 && second <= 31) return true // 172.16.0.0/12 private
+  if (first === 192 && second === 168) return true // 192.168.0.0/16 private
+  if (first === 100 && second >= 64 && second <= 127) return true // 100.64.0.0/10 CGNAT
+  if (first >= 224) return true // multicast and reserved
+  return false
+}
+
+/**
+ * Expands an IPv6 literal to its 16 bytes, resolving `::` and any trailing dotted-quad.
+ *
+ * Textual matching is not good enough here: WHATWG URL rewrites every IPv4-mapped literal into
+ * compressed hex (`::ffff:127.0.0.1` becomes `::ffff:7f00:1`), so a guard that only recognises the
+ * dotted form never sees the shape that actually arrives. Comparing bytes removes that whole class of
+ * near-miss.
+ */
+function parseIPv6ToBytes(address: string): Uint8Array | undefined {
+  // A zone id is meaningless to us and cannot reach here through URL parsing; drop it defensively.
+  let text = address.toLowerCase().split('%')[0]
+
+  const trailingIPv4 = text.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)
+  if (trailingIPv4) {
+    const octets = trailingIPv4[1].split('.').map(Number)
+    if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return undefined
+    const high = ((octets[0] << 8) | octets[1]).toString(16)
+    const low = ((octets[2] << 8) | octets[3]).toString(16)
+    text = text.slice(0, trailingIPv4.index) + high + ':' + low
+  }
+
+  const halves = text.split('::')
+  if (halves.length > 2) return undefined
+  const toHextets = (part: string) => (part ? part.split(':') : [])
+  const head = toHextets(halves[0])
+  const tail = halves.length === 2 ? toHextets(halves[1]) : []
+
+  let hextets: string[]
+  if (halves.length === 1) {
+    if (head.length !== 8) return undefined
+    hextets = head
+  } else {
+    const missing = 8 - head.length - tail.length
+    if (missing < 0) return undefined
+    hextets = [...head, ...new Array(missing).fill('0'), ...tail]
+  }
+
+  const bytes = new Uint8Array(16)
+  for (let index = 0; index < 8; index++) {
+    if (!/^[0-9a-f]{1,4}$/.test(hextets[index])) return undefined
+    const value = parseInt(hextets[index], 16)
+    bytes[index * 2] = value >> 8
+    bytes[index * 2 + 1] = value & 0xff
+  }
+  return bytes
+}
+
 /**
  * True for addresses that are only reachable from inside our own network: RFC1918 private ranges,
  * loopback, link-local (which covers the cloud metadata endpoints at 169.254.169.254), carrier-grade
  * NAT, "this network", multicast/reserved space, and their IPv6 equivalents.
+ *
+ * Anything that is not a recognisable IP literal is reported as non-public: callers only ever pass
+ * resolved addresses, so an unparseable value means something unexpected happened and refusing is the
+ * safe direction.
  */
 export function isNonPublicAddress(address: string): boolean {
-  // ::ffff:10.0.0.1 and friends are IPv4 wearing an IPv6 hat.
-  const withoutV6Prefix = address.toLowerCase().startsWith('::ffff:') ? address.slice('::ffff:'.length) : address
+  if (net.isIPv4(address)) {
+    return isNonPublicIPv4(address)
+  }
 
-  if (net.isIPv4(withoutV6Prefix)) {
-    const [first, second] = withoutV6Prefix.split('.').map(Number)
-    if (first === 0) return true // 0.0.0.0/8 "this network"
-    if (first === 10) return true // 10.0.0.0/8 private
-    if (first === 127) return true // loopback
-    if (first === 169 && second === 254) return true // link-local, incl. cloud metadata
-    if (first === 172 && second >= 16 && second <= 31) return true // 172.16.0.0/12 private
-    if (first === 192 && second === 168) return true // 192.168.0.0/16 private
-    if (first === 100 && second >= 64 && second <= 127) return true // 100.64.0.0/10 CGNAT
-    if (first >= 224) return true // multicast and reserved
+  if (net.isIPv6(address)) {
+    const bytes = parseIPv6ToBytes(address)
+    if (!bytes) return true
+
+    const first10AreZero = bytes.subarray(0, 10).every((byte) => byte === 0)
+    // ::ffff:0:0/96 — IPv4-mapped. Judge the IPv4 address it carries.
+    if (first10AreZero && bytes[10] === 0xff && bytes[11] === 0xff) {
+      return isNonPublicIPv4(`${bytes[12]}.${bytes[13]}.${bytes[14]}.${bytes[15]}`)
+    }
+    // ::/96 — covers :: (unspecified), ::1 (loopback) and the deprecated IPv4-compatible form.
+    if (bytes.subarray(0, 12).every((byte) => byte === 0)) return true
+    if (bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0x80) return true // fe80::/10 link-local
+    if ((bytes[0] & 0xfe) === 0xfc) return true // fc00::/7 unique local
+    if (bytes[0] === 0xff) return true // ff00::/8 multicast
     return false
   }
 
-  const lowercased = withoutV6Prefix.toLowerCase()
-  if (lowercased === '::1' || lowercased === '::') return true // loopback / unspecified
-  if (lowercased.startsWith('fe8') || lowercased.startsWith('fe9')) return true // fe80::/10 link-local
-  if (lowercased.startsWith('fea') || lowercased.startsWith('feb')) return true // fe80::/10 link-local
-  if (lowercased.startsWith('fc') || lowercased.startsWith('fd')) return true // fc00::/7 unique local
-  return false
+  return true
 }
 
 /**
@@ -310,7 +430,18 @@ function downloadFile(
 
     function requestWithRedirects(redirectedUrl: string, baseUrl: string, redirects: number) {
       // Relative redirects must be resolved against the URL that issued them, not the original URL.
-      const url = new URL(redirectedUrl, baseUrl)
+      //
+      // Guarded because this function is re-entered from inside the response listener: a `Location`
+      // the URL parser rejects (`http://[`, `http://:80`, …) would throw there, escape this Promise's
+      // executor and surface as an uncaughtException — a remote crash of the whole process, triggerable
+      // by any server in the list on any content file.
+      let url: URL
+      try {
+        url = new URL(redirectedUrl, baseUrl)
+      } catch {
+        settleWithError(new Error(`Invalid redirect location ${JSON.stringify(redirectedUrl)} from ${baseUrl}`))
+        return
+      }
       // Only http(s) is supported; reject other schemes (e.g. file:) a redirect could point to.
       if (url.protocol !== 'http:' && url.protocol !== 'https:') {
         settleWithError(new Error('Unsupported protocol in URL ' + url.toString()))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,6 +161,24 @@ export async function sleepUnlessStopped(time: number, shouldStop?: () => boolea
   }
 }
 
+// How much of an untrusted string is worth keeping in a log entry.
+const LOG_PREVIEW_LENGTH = 512
+
+/**
+ * A log-safe rendering of remote text.
+ *
+ * Every string a content server sends is a candidate log payload, and several are logged once per
+ * offending item: a snapshot line can be 10 MiB, a snapshot metadata entry or a pointer-change delta can
+ * be most of a 50 MiB response body. Logging them whole lets one bad response push gigabytes of
+ * attacker-chosen text into the log pipeline. The prefix is what identifies the problem; the length is
+ * what tells you it was truncated.
+ */
+export function truncateForLog(text: string): string {
+  return text.length <= LOG_PREVIEW_LENGTH
+    ? text
+    : `${text.slice(0, LOG_PREVIEW_LENGTH)}… (truncated, original length ${text.length})`
+}
+
 // Content hashes are IPFS CIDs (base58/base32), hence alphanumeric. Validating against this charset
 // before using a hash in a path or storage key prevents path traversal from untrusted hashes.
 const VALID_CONTENT_HASH = /^[a-zA-Z0-9]+$/

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -799,11 +799,37 @@ function downloadFile(
           settleWithError(new Error('Invalid response from ' + url + ' status: ' + response.statusCode))
           return
         } else {
+          // Content-coding tokens are case-insensitive (RFC 9110 §8.4.1) and `x-gzip` is a legacy alias
+          // for `gzip` that some servers still send, so matching the exact string `gzip` meant a correct
+          // `Content-Encoding: GZip` response was written to disk still compressed, failed hash
+          // verification, and burned the whole retry ladder against a well-behaved server. `identity`
+          // means no coding was applied and is dropped here rather than treated as one.
+          const declaredEncodings = String(response.headers['content-encoding'] ?? '')
+            .split(',')
+            .map((coding) => coding.trim().toLowerCase())
+            .filter((coding) => coding !== '' && coding !== 'identity')
+          const isGzip =
+            declaredEncodings.length === 1 && (declaredEncodings[0] === 'gzip' || declaredEncodings[0] === 'x-gzip')
+
+          // Any other coding — `br`, `deflate`, or several layered together — is one this client cannot
+          // undo, so the bytes could never match the hash. Failing here names the reason instead of
+          // surfacing as a hash mismatch after the retry ladder has been spent. Truncated because the
+          // header value is the server's choice.
+          if (declaredEncodings.length > 0 && !isGzip) {
+            response.resume()
+            settleWithError(
+              new Error(
+                `Cannot decode ${url}: unsupported content-encoding ${truncateForLog(
+                  JSON.stringify(declaredEncodings.join(', '))
+                )}`
+              )
+            )
+            return
+          }
+
           const file = fs.createWriteStream(tmpFileName, {
             emitClose: true
           })
-
-          const isGzip = response.headers['content-encoding'] === 'gzip'
 
           const pipe = streamPipeline([response, ...createDownloadTransforms(isGzip, limits), file])
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,6 +72,17 @@ export function resolveTransferLimits(limits?: TransferLimits): ResolvedTransfer
   // undefined rather than a missing key.
   const resolved = { ...DEFAULT_TRANSFER_LIMITS }
   for (const [name, value] of Object.entries(limits ?? {})) {
+    // Rejected rather than ignored. These are safety bounds, so a typo silently falling back to the
+    // default is the one outcome a caller cannot detect: they asked for a stricter limit, got the
+    // permissive one, and nothing said so. TypeScript catches this for a literal, but not for config
+    // assembled from env vars or spread from a wider object, which is how these tend to be built.
+    if (!(name in DEFAULT_TRANSFER_LIMITS)) {
+      throw new Error(
+        `transferLimits.${name} is not a known limit. Valid names: ${Object.keys(DEFAULT_TRANSFER_LIMITS)
+          .sort()
+          .join(', ')}`
+      )
+    }
     if (value !== undefined) {
       resolved[name as keyof ResolvedTransferLimits] = value as number
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -603,11 +603,35 @@ export function contentServerMetricLabels(contentServer: string): ContentServerM
   }
 }
 
-export function streamToBuffer(stream: Readable): Promise<Buffer> {
+/**
+ * Reads a stream fully into memory.
+ *
+ * @param maxBytes - Optional ceiling. Reject and destroy the stream once more than this many bytes
+ *   have arrived, instead of buffering whatever the producer sends. Callers reading content-addressed
+ *   files should pass one: the download cap alone allows a single file of
+ *   {@link MAX_DOWNLOADED_FILE_SIZE_IN_BYTES}, and nothing stops several from being read at once.
+ */
+export function streamToBuffer(stream: Readable, maxBytes?: number): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    const buffers: any[] = []
+    const buffers: Buffer[] = []
+    let total = 0
+
+    function fail(error: Error) {
+      // Without this the producer keeps reading into a buffer nobody will use, and the underlying
+      // handle is only reclaimed whenever GC gets to it.
+      stream.destroy()
+      reject(error)
+    }
+
     stream.on('error', reject)
-    stream.on('data', (data) => buffers.push(data))
+    stream.on('data', (data: Buffer) => {
+      total += data.length
+      if (maxBytes !== undefined && total > maxBytes) {
+        fail(new Error(`Stream exceeds the maximum allowed size of ${maxBytes} bytes`))
+        return
+      }
+      buffers.push(data)
+    })
     stream.on('end', () => resolve(Buffer.concat(buffers)))
   })
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -168,6 +168,38 @@ export function isValidContentHash(hash: string): boolean {
   return typeof hash === 'string' && hash.length > 0 && hash.length <= 128 && VALID_CONTENT_HASH.test(hash)
 }
 
+// How far ahead of our own clock a remote timestamp may sit. Snapshots describe history that already
+// happened, so anything beyond this is either the server's clock being wrong or a value we should not
+// adopt as sync state.
+const MAX_TIMESTAMP_CLOCK_SKEW_IN_MS = 24 * 60 * 60 * 1000
+
+/**
+ * A remote timestamp we are willing to adopt as sync state.
+ *
+ * These values become a server's high-water mark, and `increaseLastTimestamp` only ever moves it forward,
+ * so a single bad one is permanent for the life of the process: the server then polls `/pointer-changes`
+ * from a point nothing can ever reach and silently stops syncing.
+ *
+ * `typeof x === 'number'` does not begin to cover it, and neither does finiteness:
+ *
+ * - A JSON body cannot carry NaN (`{"a":NaN}` is a syntax error) but it CAN carry Infinity, because the
+ *   number grammar has no range limit and `1e999` parses to it.
+ * - `1e308` is finite, non-negative, and every bit as poisonous — it is not a date any deployment can
+ *   exceed. Finiteness was the wrong test; being a plausible instant is the right one.
+ * - Past 2^53 integer arithmetic silently stops being exact, so `Number.isSafeInteger` is the floor for a
+ *   value we do `Math.max` on. It also rejects fractions, which epoch milliseconds never legitimately are
+ *   — an earlier version of this deliberately allowed them, but the upper bound below makes that leniency
+ *   pointless and a fractional timestamp only ever indicates a malformed server.
+ */
+export function isUsableTimestamp(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= Date.now() + MAX_TIMESTAMP_CLOCK_SKEW_IN_MS
+  )
+}
+
 export async function assertHash(filename: string, hash: string) {
   if (hash.startsWith('Qm')) {
     const file = fs.createReadStream(filename)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -200,6 +200,22 @@ export function isUsableTimestamp(value: unknown): value is number {
   )
 }
 
+/**
+ * Whether {@link assertHash} can verify bytes against this hash at all.
+ *
+ * `isValidContentHash` is deliberately looser, because it answers a different question: is this string
+ * safe to use as a filesystem path and a storage key. Verification is narrower — assertHash dispatches on
+ * the `Qm`/`ba` CID prefixes and can do nothing with anything else — so a hash that passes the first check
+ * but not this one can only fail *after* its bytes have been fetched.
+ *
+ * Deliberately mirrors assertHash's own dispatch rather than a stricter CID grammar: a tighter predicate
+ * here could refuse a hash assertHash would have happily verified, which would stop syncing content that
+ * works today. This can only ever reject hashes that were going to fail anyway.
+ */
+export function isVerifiableContentHash(hash: string): boolean {
+  return hash.startsWith('Qm') || hash.startsWith('ba')
+}
+
 export async function assertHash(filename: string, hash: string) {
   if (hash.startsWith('Qm')) {
     const file = fs.createReadStream(filename)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -538,8 +538,13 @@ function downloadFile(
 
       const request = httpModule.get(url.toString(), requestOptions, (response) => {
         if (response.statusCode && REDIRECT_STATUS_CODES.has(response.statusCode) && response.headers.location) {
-          // drain the redirect response so its socket is freed (and its inactivity timer cleared)
-          response.resume()
+          // Destroy rather than drain. Only the Location header matters here, and resume() would keep
+          // reading a body we already decided to throw away — a server can attach an arbitrarily large or
+          // slow one to every hop, so up to MAX_REDIRECTS of them would stream in parallel with the hops
+          // that follow. Destroying frees the socket immediately and bounds a redirect to its headers.
+          // Verified not to make the abandoned request emit 'error': that would otherwise reach
+          // settleWithError and fail the download even though the next hop is proceeding.
+          response.destroy()
           // handle redirection
           requestWithRedirects(response.headers.location!, url.toString(), redirects + 1)
           return

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,14 +19,12 @@ const streamPipeline = promisify(pipeline)
 // Bounds buffered JSON responses so a malicious server can't OOM the process via response.json().
 const MAX_JSON_RESPONSE_SIZE_IN_BYTES = 50 * 1024 * 1024 // 50 MiB
 
+// Applied to the body read when the caller did not ask for a specific timeout.
+const DEFAULT_BODY_READ_TIMEOUT_IN_MS = 30_000
+
 // Reads a response body while enforcing a maximum size. The native fetcher (unlike node-fetch) has
 // no `size` option, so we cap manually: read the stream with a running byte count and abort —
 // cancelling the stream to free its socket — if it exceeds the limit.
-// Applied to the body read when the caller did not ask for a specific timeout.
-const DEFAULT_BODY_READ_TIMEOUT_IN_MS = 30_000
-// How many same-origin redirects fetchJson will follow itself.
-const MAX_JSON_REDIRECTS = 5
-
 async function readBodyWithSizeLimit(response: Response, maxBytes: number, timeoutMs: number): Promise<string> {
   const reader = response.body?.getReader()
   if (!reader) {
@@ -88,53 +86,45 @@ async function readBodyWithSizeLimit(response: Response, maxBytes: number, timeo
 export async function fetchJson(url: string, fetcher: IFetchComponent, init?: RequestOptions): Promise<any> {
   const bodyReadTimeout = init?.timeout ?? DEFAULT_BODY_READ_TIMEOUT_IN_MS
 
-  // redirect: 'manual' so redirects are followed here, under a same-origin rule, instead of by the
-  // fetch implementation — whose default ('follow') chases any host the server names. That turned
-  // every JSON endpoint into an SSRF primitive and let a redirect sidestep the same-origin check
-  // fetchJsonPaginated applies to `pagination.next`.
-  let currentUrl = url
-  for (let redirects = 0; ; redirects++) {
-    const response = await fetcher.fetch(currentUrl, { ...init, redirect: 'manual' })
+  // JSON endpoints do not follow redirects at all.
+  //
+  // The fetch implementation's default ('follow') chases any host the server names, which made every
+  // JSON endpoint an SSRF primitive. Following same-origin redirects here instead was not enough: a URL
+  // origin is a hostname, not an address, so a hostile host can serve the first response from a public
+  // IP, return `Location: /next`, and rebind that same hostname to loopback or 169.254.169.254 before
+  // the next request — the origin still matches and the check passes.
+  //
+  // The download path defends against that with a DNS `lookup` that classifies and pins resolved
+  // addresses, but `IFetchComponent` exposes no way to inject one: the consumer supplies the fetcher,
+  // and native fetch resolves DNS itself. Any check performed here would be a separate resolution from
+  // the one the request actually uses, i.e. defeated by the same race it claims to close. Refusing
+  // redirects is the only complete answer available on this path.
+  //
+  // No known catalyst JSON endpoint redirects. If one legitimately must, the fix is a redirect-aware
+  // fetch component, not a check here that cannot bind to the request's own resolution.
+  const response = await fetcher.fetch(url, { ...init, redirect: 'manual' })
 
-    if (response.status >= 300 && response.status < 400) {
-      await response.body?.cancel().catch(() => undefined)
-      const location = response.headers.get('location')
-      if (!location) {
-        throw new Error(`Error fetching ${currentUrl}. Redirect status ${response.status} without a location.`)
-      }
-      if (redirects >= MAX_JSON_REDIRECTS) {
-        throw new Error(`Error fetching ${url}. Too many redirects.`)
-      }
-      let redirectTarget: URL
-      try {
-        redirectTarget = new URL(location, currentUrl)
-      } catch {
-        throw new Error(`Error fetching ${currentUrl}. Invalid redirect location ${JSON.stringify(location)}.`)
-      }
-      if (redirectTarget.origin !== new URL(currentUrl).origin) {
-        throw new Error(
-          `Refusing to follow a cross-origin redirect while fetching ${url}: ${redirectTarget.origin} does not match ${
-            new URL(currentUrl).origin
-          }`
-        )
-      }
-      currentUrl = redirectTarget.toString()
-      continue
-    }
-
-    if (!response.ok) {
-      // Drain the body so undici releases the socket back to the pool before throwing.
-      await response.body?.cancel().catch(() => undefined)
-      throw new Error('Error fetching ' + currentUrl + '. Status code was: ' + response.status)
-    }
-
-    const body = await readBodyWithSizeLimit(response, MAX_JSON_RESPONSE_SIZE_IN_BYTES, bodyReadTimeout)
-    if (body === '') {
-      throw new Error('Error fetching ' + currentUrl + '. The response body was empty.')
-    }
-
-    return JSON.parse(body)
+  if (response.status >= 300 && response.status < 400) {
+    await response.body?.cancel().catch(() => undefined)
+    throw new Error(
+      `Refusing to follow a redirect while fetching ${url}: got status ${response.status} to ${JSON.stringify(
+        response.headers.get('location')
+      )}`
+    )
   }
+
+  if (!response.ok) {
+    // Drain the body so undici releases the socket back to the pool before throwing.
+    await response.body?.cancel().catch(() => undefined)
+    throw new Error('Error fetching ' + url + '. Status code was: ' + response.status)
+  }
+
+  const body = await readBodyWithSizeLimit(response, MAX_JSON_RESPONSE_SIZE_IN_BYTES, bodyReadTimeout)
+  if (body === '') {
+    throw new Error('Error fetching ' + url + '. The response body was empty.')
+  }
+
+  return JSON.parse(body)
 }
 
 export async function checkFileExists(file: string): Promise<boolean> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,6 +22,42 @@ const MAX_JSON_RESPONSE_SIZE_IN_BYTES = 50 * 1024 * 1024 // 50 MiB
 // Applied to the body read when the caller did not ask for a specific timeout.
 const DEFAULT_BODY_READ_TIMEOUT_IN_MS = 30_000
 
+// Minimum sustained rate a transfer must average once it has been running longer than the grace period
+// below. The inactivity deadlines on both transfer paths only ask "did a byte arrive recently?", so a
+// peer that trickles one byte per window answers yes forever while holding its queue slot; the size
+// caps are the only other bound, and at that rate 1 GiB is geological. A rate floor is what makes
+// staying connected cost the peer real bandwidth instead of nothing.
+//
+// Set far below any usable link (4 KiB/s is worse than a 56k modem) rather than near real throughput:
+// this is here to catch transfers that are not really transferring, and a legitimate peer that cannot
+// beat it would exhaust its retry ladder on duration anyway. Downloads are retried, so a false
+// positive costs an attempt rather than the entity.
+const MIN_TRANSFER_RATE_IN_BYTES_PER_SECOND = 4 * 1024
+// Rate is not judged before this. Small responses finish well inside it, and earlier samples are
+// dominated by connection setup and server think-time rather than by throughput.
+const TRANSFER_RATE_GRACE_PERIOD_IN_MS = 60_000
+
+/**
+ * Companion to the per-chunk inactivity deadlines: they check that bytes are still arriving, this
+ * checks that the bytes add up to progress. Returns the error to fail with, or undefined to continue.
+ */
+export function tooSlowToContinue(bytesSoFar: number, startedAt: number): Error | undefined {
+  const elapsed = Date.now() - startedAt
+  if (elapsed <= TRANSFER_RATE_GRACE_PERIOD_IN_MS) {
+    return undefined
+  }
+  const bytesPerSecond = (bytesSoFar * 1000) / elapsed
+  if (bytesPerSecond >= MIN_TRANSFER_RATE_IN_BYTES_PER_SECOND) {
+    return undefined
+  }
+  // The byte total is part of the message because the rate alone rounds a trickle and a dead silence
+  // to the same "0.0 bytes/s", and those are different problems to go looking for.
+  return new Error(
+    `Transfer of ${bytesSoFar} bytes averaged ${bytesPerSecond.toFixed(2)} bytes/s over ` +
+      `${Math.round(elapsed / 1000)}s, below the minimum of ${MIN_TRANSFER_RATE_IN_BYTES_PER_SECOND} bytes/s`
+  )
+}
+
 // Reads a response body while enforcing a maximum size. The native fetcher (unlike node-fetch) has
 // no `size` option, so we cap manually: read the stream with a running byte count and abort —
 // cancelling the stream to free its socket — if it exceeds the limit.
@@ -33,6 +69,7 @@ async function readBodyWithSizeLimit(response: Response, maxBytes: number, timeo
 
   const chunks: Uint8Array[] = []
   let total = 0
+  const startedAt = Date.now()
   // The fetch component's timeout only covers time-to-headers: it clears its abort timer as soon as the
   // response object exists. Without a deadline here a server can send headers, write half a document
   // and then go silent forever — exactly the stall the request timeout was meant to prevent, and a
@@ -64,6 +101,10 @@ async function readBodyWithSizeLimit(response: Response, maxBytes: number, timeo
         total += value.byteLength
         if (total > maxBytes) {
           throw new Error(`Response body exceeds the maximum allowed size of ${maxBytes} bytes`)
+        }
+        const tooSlow = tooSlowToContinue(total, startedAt)
+        if (tooSlow) {
+          throw tooSlow
         }
         chunks.push(value)
       }
@@ -522,16 +563,28 @@ export function createRedirectSafeLookup(allowedHostname: string): LookupFunctio
 
 // Fails the pipeline once more than maxBytes have flowed through it. Placed *after* gunzip so it
 // bounds the decompressed size.
-function createSizeLimiter(maxBytes: number): Transform {
+/**
+ * Enforces both bounds a body stream needs: a ceiling on total bytes, and a floor on the rate those
+ * bytes arrive at. Named for the pair because size alone was never a time bound — see
+ * {@link tooSlowToContinue}. The clock starts when the response headers arrive, which is the right
+ * origin for measuring body throughput.
+ */
+export function createTransferLimiter(maxBytes: number): Transform {
   let total = 0
+  const startedAt = Date.now()
   return new Transform({
     transform(chunk, _encoding, callback) {
       total += chunk.length
       if (total > maxBytes) {
         callback(new Error(`Downloaded file exceeds the maximum allowed size of ${maxBytes} bytes`))
-      } else {
-        callback(null, chunk)
+        return
       }
+      const tooSlow = tooSlowToContinue(total, startedAt)
+      if (tooSlow) {
+        callback(tooSlow)
+        return
+      }
+      callback(null, chunk)
     }
   })
 }
@@ -647,11 +700,11 @@ function downloadFile(
           })
 
           const isGzip = response.headers['content-encoding'] === 'gzip'
-          const sizeLimiter = createSizeLimiter(MAX_DOWNLOADED_FILE_SIZE_IN_BYTES)
+          const transferLimiter = createTransferLimiter(MAX_DOWNLOADED_FILE_SIZE_IN_BYTES)
 
           const pipe = isGzip
-            ? streamPipeline(response, zlib.createGunzip(), sizeLimiter, file)
-            : streamPipeline(response, sizeLimiter, file)
+            ? streamPipeline(response, zlib.createGunzip(), transferLimiter, file)
+            : streamPipeline(response, transferLimiter, file)
 
           pipe
             .then(() => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -451,7 +451,11 @@ export function isNonPublicAddress(address: string): boolean {
  * host the caller originally asked for, which comes from the trusted server list — is always allowed,
  * which is what keeps loopback-based local development and tests working.
  */
-function createRedirectSafeLookup(allowedHostname: string): LookupFunction {
+/**
+ * Exported for testing: this guard's decisions depend on DNS answer sets that are impractical to
+ * produce through a real download, and it is the piece of this file with the worst track record.
+ */
+export function createRedirectSafeLookup(allowedHostname: string): LookupFunction {
   const allowed = allowedHostname.toLowerCase()
   // Whether the caller's own host resolved to a non-public address the first time we looked it up.
   // Recorded once and then held for the whole download, which is what closes DNS rebinding: a host that
@@ -475,9 +479,25 @@ function createRedirectSafeLookup(allowedHostname: string): LookupFunction {
         // The caller's host comes from the trusted server list, so it is allowed to be private — that
         // is what keeps loopback-based local development and the tests working. It just may not
         // *change* classification mid-download.
+        //
+        // A mixed answer set has no single classification to pin, and taking "contains a non-public
+        // address" as the answer is exploitable: the connection may well use the public address, while
+        // the guard records "non-public" — after which a same-host redirect resolving to ONLY loopback
+        // matches the recorded value and is waved through, which is the exact pivot this exists to stop.
+        // It cuts the other way too, rejecting a redirect that narrows to public-only. Neither set is a
+        // configuration a real content server has, so refuse the ambiguity instead of guessing at it.
+        const everyAddressNonPublic = resolved.every((entry) => isNonPublicAddress(entry.address))
+        if (nonPublic && !everyAddressNonPublic) {
+          callback(
+            new Error(
+              `Refusing to use ${hostname}: it resolves to a mix of public and non-public addresses, which has no single classification to hold for the rest of the download`
+            )
+          )
+          return
+        }
         if (allowedHostWasNonPublic === undefined) {
-          allowedHostWasNonPublic = !!nonPublic
-        } else if (!!nonPublic !== allowedHostWasNonPublic) {
+          allowedHostWasNonPublic = everyAddressNonPublic
+        } else if (everyAddressNonPublic !== allowedHostWasNonPublic) {
           callback(
             new Error(
               `Refusing to follow a redirect to ${hostname}: it now resolves to ${

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,11 +4,12 @@ import * as crypto from 'crypto'
 import * as fs from 'fs'
 import * as http from 'http'
 import * as https from 'https'
+import * as path from 'path'
 import { pipeline, Readable, Transform } from 'stream'
 import { promisify } from 'util'
 import * as zlib from 'zlib'
 import { ContentServerMetricLabels } from './metrics'
-import { Server, SnapshotsFetcherComponents } from './types'
+import { Path, Server, SnapshotsFetcherComponents } from './types'
 
 const streamPipeline = promisify(pipeline)
 
@@ -120,12 +121,13 @@ export async function saveContentFileToDisk(
   hash: string,
   checkHash: boolean = true
 ): Promise<void> {
-  let tmpFileName: string
+  const tmpFolder = path.dirname(destinationFilename)
+  await ensureFolderExists(tmpFolder)
 
-  do {
-    tmpFileName = destinationFilename + crypto.randomBytes(16).toString('hex')
-    // this is impossible
-  } while (await checkFileExists(tmpFileName))
+  // A 128-bit random suffix on a content-addressed path: a collision needs the same hash *and* the
+  // same suffix, and concurrent downloads of one hash already share a single job. Not worth an
+  // existence check (a syscall) on every downloaded file.
+  const tmpFileName = destinationFilename + crypto.randomBytes(16).toString('hex')
 
   const metricsLabels: ContentServerMetricLabels = {
     remote_server: ''
@@ -144,23 +146,39 @@ export async function saveContentFileToDisk(
       } catch (e) {
         components.metrics?.increment('dcl_content_download_hash_errors_total', metricsLabels)
         // delete the downloaded file if failed
-        try {
-          if (await checkFileExists(tmpFileName)) {
-            await fs.promises.unlink(tmpFileName)
-          }
-        } catch {}
+        await deleteFileIfPresent(tmpFileName)
         throw e
       }
     }
 
     // move downloaded file to target folder
     await components.storage.storeStream(hash, fs.createReadStream(tmpFileName))
+  } catch (e) {
+    // The folder may have been removed from under us; forget it so a retry recreates it.
+    ensuredFolders.delete(tmpFolder)
+    throw e
   } finally {
-    // Delete the file async.
-    if (await checkFileExists(tmpFileName)) {
-      await fs.promises.unlink(tmpFileName)
-    }
+    await deleteFileIfPresent(tmpFileName)
   }
+}
+
+// Folders this process has already created. mkdir(recursive) still costs a syscall when the folder is
+// already there, and saveContentFileToDisk runs once per downloaded file — which is once per entry of
+// every entity's content[]. Invalidated on failure so an externally removed folder self-heals.
+const ensuredFolders = new Set<Path>()
+
+async function ensureFolderExists(folder: Path): Promise<void> {
+  if (ensuredFolders.has(folder)) {
+    return
+  }
+  await fs.promises.mkdir(folder, { recursive: true })
+  ensuredFolders.add(folder)
+}
+
+// unlink + ignore ENOENT rather than exists-then-unlink: one syscall instead of two, and no window
+// between the check and the delete.
+async function deleteFileIfPresent(filename: string): Promise<void> {
+  await fs.promises.unlink(filename).catch(() => undefined)
 }
 
 // Stop following redirects after this many hops.
@@ -195,26 +213,50 @@ function downloadFile(
   tmpFileName: string
 ) {
   return new Promise<void>((resolve, reject) => {
+    // One timer for the whole download instead of one per redirect hop: a hop that redirects never
+    // reaches a terminal state, so its timer was started and then silently dropped. The labels are
+    // supplied at end() (they are merged there) because the origin that ultimately served the file
+    // is only known after the last redirect.
+    const { end: endTimeMeasurement } = components.metrics?.startTimer('dcl_content_download_duration_seconds') || {
+      end: (_endLabels?: ContentServerMetricLabels) => {}
+    }
+
+    // A destroyed socket can reject the pipeline *and* emit 'error' on the request. Without this
+    // guard that records the duration twice and double-counts the error, so the first terminal
+    // outcome wins and the rest are ignored.
+    let settled = false
+
+    function settleWithSuccess(bytesWritten: number) {
+      if (settled) return
+      settled = true
+      components.metrics?.increment('dcl_content_download_bytes_total', metricsLabels, bytesWritten)
+      endTimeMeasurement({ ...metricsLabels })
+      resolve()
+    }
+
+    function settleWithError(err: Error) {
+      if (settled) return
+      settled = true
+      components.metrics?.increment('dcl_content_download_errors_total', metricsLabels)
+      endTimeMeasurement({ ...metricsLabels })
+      reject(err)
+    }
+
     function requestWithRedirects(redirectedUrl: string, baseUrl: string, redirects: number) {
       // Relative redirects must be resolved against the URL that issued them, not the original URL.
       const url = new URL(redirectedUrl, baseUrl)
       // Only http(s) is supported; reject other schemes (e.g. file:) a redirect could point to.
       if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-        reject(new Error('Unsupported protocol in URL ' + url.toString()))
+        settleWithError(new Error('Unsupported protocol in URL ' + url.toString()))
         return
       }
       const httpModule = url.protocol === 'https:' ? https : http
       if (redirects > MAX_REDIRECTS) {
-        reject(new Error('Too much redirects'))
+        settleWithError(new Error('Too much redirects'))
         return
       }
 
       Object.assign(metricsLabels, contentServerMetricLabels(url.toString()))
-
-      const { end: endTimeMeasurement } = components.metrics?.startTimer(
-        'dcl_content_download_duration_seconds',
-        metricsLabels
-      ) || { end: () => {} }
 
       const request = httpModule.get(url.toString(), { headers: { 'accept-encoding': 'gzip' } }, (response) => {
         if ((response.statusCode === 302 || response.statusCode === 301) && response.headers.location) {
@@ -225,7 +267,7 @@ function downloadFile(
           return
         } else if (!response.statusCode || response.statusCode > 300) {
           response.resume()
-          reject(new Error('Invalid response from ' + url + ' status: ' + response.statusCode))
+          settleWithError(new Error('Invalid response from ' + url + ' status: ' + response.statusCode))
           return
         } else {
           const file = fs.createWriteStream(tmpFileName, {
@@ -242,15 +284,11 @@ function downloadFile(
           pipe
             .then(() => {
               file.close() // close() is async, call cb after close completes.
-              components.metrics?.increment('dcl_content_download_bytes_total', metricsLabels, file.bytesWritten)
-              endTimeMeasurement()
-              resolve()
+              settleWithSuccess(file.bytesWritten)
             })
             .catch((err) => {
               file.close()
-              reject(err)
-              components.metrics?.increment('dcl_content_download_errors_total', metricsLabels)
-              endTimeMeasurement()
+              settleWithError(err)
             })
         }
       })
@@ -261,9 +299,7 @@ function downloadFile(
       })
 
       request.on('error', function (err) {
-        reject(err)
-        components.metrics?.increment('dcl_content_download_errors_total', metricsLabels)
-        endTimeMeasurement()
+        settleWithError(err)
       })
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,8 @@ export const DEFAULT_TRANSFER_LIMITS: ResolvedTransferLimits = {
   downloadInactivityTimeoutInMs: 30_000,
   maxDownloadedFileSizeInBytes: 1024 * 1024 * 1024, // 1 GiB
   minTransferRateInBytesPerSecond: 4 * 1024,
-  transferRateGracePeriodInMs: 60_000
+  transferRateGracePeriodInMs: 60_000,
+  maxPagesPerPaginatedCall: 10_000
 }
 
 // Zero is meaningful for these two and not for the others: a rate floor of 0 disables the check, and a
@@ -53,7 +54,8 @@ const TRANSFER_LIMIT_MINIMUMS: ResolvedTransferLimits = {
   downloadInactivityTimeoutInMs: 1,
   maxDownloadedFileSizeInBytes: 1,
   minTransferRateInBytesPerSecond: 0,
-  transferRateGracePeriodInMs: 0
+  transferRateGracePeriodInMs: 0,
+  maxPagesPerPaginatedCall: 1
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -273,6 +273,11 @@ async function deleteFileIfPresent(filename: string): Promise<void> {
 
 // Stop following redirects after this many hops.
 const MAX_REDIRECTS = 10
+// Redirects worth following for a content download. 303/307/308 are as common as 301/302 in front of
+// object storage (HTTP->HTTPS upgrades, bucket relocations); treating them as hard errors made every
+// download from such a peer burn its whole retry ladder. All of these are followed with GET, which is
+// what 303 mandates and what 307/308 preserve, since this client only ever issues GET.
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308])
 // Abort a download after this many milliseconds of socket inactivity. Healthy downloads keep the
 // socket busy, so this only trips on stalled connections (e.g. a server that stops sending bytes).
 const DOWNLOAD_INACTIVITY_TIMEOUT_MS = 30_000
@@ -532,13 +537,16 @@ function downloadFile(
       }
 
       const request = httpModule.get(url.toString(), requestOptions, (response) => {
-        if ((response.statusCode === 302 || response.statusCode === 301) && response.headers.location) {
+        if (response.statusCode && REDIRECT_STATUS_CODES.has(response.statusCode) && response.headers.location) {
           // drain the redirect response so its socket is freed (and its inactivity timer cleared)
           response.resume()
           // handle redirection
           requestWithRedirects(response.headers.location!, url.toString(), redirects + 1)
           return
-        } else if (!response.statusCode || response.statusCode > 300) {
+          // Only a 2xx carries the content. The previous `> 300` test also accepted 300 Multiple
+          // Choices, writing its body to disk as though it were the file, and accepted a redirect
+          // status that arrived without a Location header.
+        } else if (!response.statusCode || response.statusCode < 200 || response.statusCode >= 300) {
           response.resume()
           settleWithError(new Error('Invalid response from ' + url + ' status: ' + response.statusCode))
           return

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,13 +8,11 @@ import * as https from 'https'
 import * as net from 'net'
 import { LookupFunction } from 'net'
 import * as path from 'path'
-import { pipeline, Readable, Transform } from 'stream'
-import { promisify } from 'util'
+import { Readable, Transform } from 'stream'
+import { pipeline as streamPipeline } from 'stream/promises'
 import * as zlib from 'zlib'
 import { ContentServerMetricLabels } from './metrics'
 import { Path, ResolvedTransferLimits, Server, SnapshotsFetcherComponents, TransferLimits } from './types'
-
-const streamPipeline = promisify(pipeline)
 
 // Bounds buffered JSON responses so a malicious server can't OOM the process via response.json().
 const MAX_JSON_RESPONSE_SIZE_IN_BYTES = 50 * 1024 * 1024 // 50 MiB
@@ -42,6 +40,7 @@ const DEFAULT_BODY_READ_TIMEOUT_IN_MS = 30_000
 // by connection setup and server think-time rather than by throughput.
 export const DEFAULT_TRANSFER_LIMITS: ResolvedTransferLimits = {
   requestTimeoutInMs: 15_000,
+  downloadInactivityTimeoutInMs: 30_000,
   maxDownloadedFileSizeInBytes: 1024 * 1024 * 1024, // 1 GiB
   minTransferRateInBytesPerSecond: 4 * 1024,
   transferRateGracePeriodInMs: 60_000
@@ -51,6 +50,7 @@ export const DEFAULT_TRANSFER_LIMITS: ResolvedTransferLimits = {
 // grace period of 0 judges from the first chunk. A timeout or size cap of 0 would reject every transfer.
 const TRANSFER_LIMIT_MINIMUMS: ResolvedTransferLimits = {
   requestTimeoutInMs: 1,
+  downloadInactivityTimeoutInMs: 1,
   maxDownloadedFileSizeInBytes: 1,
   minTransferRateInBytesPerSecond: 0,
   transferRateGracePeriodInMs: 0
@@ -64,7 +64,16 @@ const TRANSFER_LIMIT_MINIMUMS: ResolvedTransferLimits = {
  * instead of as a puzzling per-download failure.
  */
 export function resolveTransferLimits(limits?: TransferLimits): ResolvedTransferLimits {
-  const resolved = { ...DEFAULT_TRANSFER_LIMITS, ...limits }
+  // Only *defined* fields override a default. A plain spread would let `{ requestTimeoutInMs: undefined }`
+  // overwrite the default with undefined and then fail validation, which punishes the common case of
+  // config assembled from env vars or optional options where an absent value arrives as an explicit
+  // undefined rather than a missing key.
+  const resolved = { ...DEFAULT_TRANSFER_LIMITS }
+  for (const [name, value] of Object.entries(limits ?? {})) {
+    if (value !== undefined) {
+      resolved[name as keyof ResolvedTransferLimits] = value as number
+    }
+  }
   for (const name of Object.keys(DEFAULT_TRANSFER_LIMITS) as Array<keyof ResolvedTransferLimits>) {
     const value = resolved[name]
     const minimum = TRANSFER_LIMIT_MINIMUMS[name]
@@ -446,9 +455,6 @@ const MAX_REDIRECTS = 10
 // download from such a peer burn its whole retry ladder. All of these are followed with GET, which is
 // what 303 mandates and what 307/308 preserve, since this client only ever issues GET.
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308])
-// Abort a download after this many milliseconds of socket inactivity. Healthy downloads keep the
-// socket busy, so this only trips on stalled connections (e.g. a server that stops sending bytes).
-const DOWNLOAD_INACTIVITY_TIMEOUT_MS = 30_000
 function isNonPublicIPv4(address: string): boolean {
   const [first, second] = address.split('.').map(Number)
   if (first === 0) return true // 0.0.0.0/8 "this network"
@@ -621,22 +627,21 @@ export function createRedirectSafeLookup(allowedHostname: string): LookupFunctio
 // Fails the pipeline once more than maxBytes have flowed through it. Placed *after* gunzip so it
 // bounds the decompressed size.
 /**
- * Enforces both bounds a body stream needs: a ceiling on total bytes, and a floor on the rate those
- * bytes arrive at. Named for the pair because size alone was never a time bound — see
- * {@link tooSlowToContinue}. The clock starts when the response headers arrive, which is the right
- * origin for measuring body throughput.
+ * Rate floor for a body stream. **Must sit on the raw response, before any decompression.**
+ *
+ * A Transform's check only runs when a chunk reaches it, and gunzip can consume unbounded raw input while
+ * emitting nothing at all — concatenated empty gzip members are valid and decompress to zero bytes
+ * (measured: 1 MB of raw input, 0 bytes out, this check never invoked once). Placed after gunzip the
+ * guard was not merely lenient, it never ran, while the raw socket traffic kept the inactivity deadline
+ * refreshed. The clock starts when the response headers arrive, which is the right origin for measuring
+ * body throughput.
  */
-export function createTransferLimiter(limits: ResolvedTransferLimits): Transform {
+export function createTransferRateGuard(limits: ResolvedTransferLimits): Transform {
   let total = 0
   const startedAt = Date.now()
-  const maxBytes = limits.maxDownloadedFileSizeInBytes
   return new Transform({
     transform(chunk, _encoding, callback) {
       total += chunk.length
-      if (total > maxBytes) {
-        callback(new Error(`Downloaded file exceeds the maximum allowed size of ${maxBytes} bytes`))
-        return
-      }
       const tooSlow = tooSlowToContinue(total, startedAt, limits)
       if (tooSlow) {
         callback(tooSlow)
@@ -645,6 +650,46 @@ export function createTransferLimiter(limits: ResolvedTransferLimits): Transform
       callback(null, chunk)
     }
   })
+}
+
+/**
+ * Ceiling on the bytes passing through, named by `subject` so a failure says which side of a gzip
+ * boundary tripped.
+ */
+export function createSizeCap(maxBytes: number, subject: string): Transform {
+  let total = 0
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      total += chunk.length
+      if (total > maxBytes) {
+        callback(new Error(`${subject} exceeds the maximum allowed size of ${maxBytes} bytes`))
+        return
+      }
+      callback(null, chunk)
+    }
+  })
+}
+
+/**
+ * The transforms a download applies, in order, between the response and the file.
+ *
+ * Exported as one unit because the *ordering* is the security property — see
+ * {@link createTransferRateGuard} for what putting the rate check on the wrong side of gunzip costs — and
+ * a test that rebuilt the chain itself would not be testing this ordering at all.
+ */
+export function createDownloadTransforms(isGzip: boolean, limits: ResolvedTransferLimits): Transform[] {
+  const maxBytes = limits.maxDownloadedFileSizeInBytes
+  const transforms: Transform[] = [createTransferRateGuard(limits)]
+  if (isGzip) {
+    // Bounds the compressed stream too, or a peer could stream valid gzip indefinitely while staying
+    // above the rate floor and never produce a decompressed byte for the cap below to measure. For real
+    // content this never binds: gzip exceeds its input only for incompressible data, and then by ~0.03%.
+    transforms.push(createSizeCap(maxBytes, 'Compressed response'))
+    transforms.push(zlib.createGunzip())
+  }
+  // After decompression, so this bounds what actually reaches the disk: the gzip-bomb guard.
+  transforms.push(createSizeCap(maxBytes, 'Downloaded file'))
+  return transforms
 }
 
 function downloadFile(
@@ -759,11 +804,8 @@ function downloadFile(
           })
 
           const isGzip = response.headers['content-encoding'] === 'gzip'
-          const transferLimiter = createTransferLimiter(limits)
 
-          const pipe = isGzip
-            ? streamPipeline(response, zlib.createGunzip(), transferLimiter, file)
-            : streamPipeline(response, transferLimiter, file)
+          const pipe = streamPipeline([response, ...createDownloadTransforms(isGzip, limits), file])
 
           pipe
             .then(() => {
@@ -778,7 +820,7 @@ function downloadFile(
       })
 
       // Reject (instead of hanging forever) when the connection stalls before/while downloading.
-      request.setTimeout(DOWNLOAD_INACTIVITY_TIMEOUT_MS, () => {
+      request.setTimeout(limits.downloadInactivityTimeoutInMs, () => {
         request.destroy(new Error('Timeout while downloading ' + url.toString()))
       })
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,12 @@
 import { hashV0, hashV1 } from '@dcl/hashing'
 import { IFetchComponent, RequestOptions } from '@dcl/core-commons'
 import * as crypto from 'crypto'
+import { lookup as dnsLookup } from 'dns'
 import * as fs from 'fs'
 import * as http from 'http'
 import * as https from 'https'
+import * as net from 'net'
+import { LookupFunction } from 'net'
 import * as path from 'path'
 import { pipeline, Readable, Transform } from 'stream'
 import { promisify } from 'util'
@@ -190,6 +193,67 @@ const DOWNLOAD_INACTIVITY_TIMEOUT_MS = 30_000
 // bombs and otherwise unbounded responses that could exhaust the disk.
 const MAX_DOWNLOADED_FILE_SIZE_IN_BYTES = 1024 * 1024 * 1024 // 1 GiB
 
+/**
+ * True for addresses that are only reachable from inside our own network: RFC1918 private ranges,
+ * loopback, link-local (which covers the cloud metadata endpoints at 169.254.169.254), carrier-grade
+ * NAT, "this network", multicast/reserved space, and their IPv6 equivalents.
+ */
+export function isNonPublicAddress(address: string): boolean {
+  // ::ffff:10.0.0.1 and friends are IPv4 wearing an IPv6 hat.
+  const withoutV6Prefix = address.toLowerCase().startsWith('::ffff:') ? address.slice('::ffff:'.length) : address
+
+  if (net.isIPv4(withoutV6Prefix)) {
+    const [first, second] = withoutV6Prefix.split('.').map(Number)
+    if (first === 0) return true // 0.0.0.0/8 "this network"
+    if (first === 10) return true // 10.0.0.0/8 private
+    if (first === 127) return true // loopback
+    if (first === 169 && second === 254) return true // link-local, incl. cloud metadata
+    if (first === 172 && second >= 16 && second <= 31) return true // 172.16.0.0/12 private
+    if (first === 192 && second === 168) return true // 192.168.0.0/16 private
+    if (first === 100 && second >= 64 && second <= 127) return true // 100.64.0.0/10 CGNAT
+    if (first >= 224) return true // multicast and reserved
+    return false
+  }
+
+  const lowercased = withoutV6Prefix.toLowerCase()
+  if (lowercased === '::1' || lowercased === '::') return true // loopback / unspecified
+  if (lowercased.startsWith('fe8') || lowercased.startsWith('fe9')) return true // fe80::/10 link-local
+  if (lowercased.startsWith('fea') || lowercased.startsWith('feb')) return true // fe80::/10 link-local
+  if (lowercased.startsWith('fc') || lowercased.startsWith('fd')) return true // fc00::/7 unique local
+  return false
+}
+
+/**
+ * A DNS lookup that refuses to resolve to a non-public address, so a redirect cannot steer a download
+ * at an internal service by pointing at a hostname whose A record is private. `allowedHostname` — the
+ * host the caller originally asked for, which comes from the trusted server list — is always allowed,
+ * which is what keeps loopback-based local development and tests working.
+ */
+function createRedirectSafeLookup(allowedHostname: string): LookupFunction {
+  const allowed = allowedHostname.toLowerCase()
+
+  return ((hostname: string, options: any, callback: any) => {
+    if (hostname.toLowerCase() === allowed) {
+      dnsLookup(hostname, options, callback)
+      return
+    }
+
+    dnsLookup(hostname, options, (err: any, address: any, family: any) => {
+      if (err) {
+        callback(err, address, family)
+        return
+      }
+      const resolved: { address: string }[] = Array.isArray(address) ? address : [{ address }]
+      const blocked = resolved.find((entry) => isNonPublicAddress(entry.address))
+      if (blocked) {
+        callback(new Error(`Refusing to follow a redirect to ${hostname} (${blocked.address}): not a public address`))
+        return
+      }
+      callback(null, address, family)
+    })
+  }) as LookupFunction
+}
+
 // Fails the pipeline once more than maxBytes have flowed through it. Placed *after* gunzip so it
 // bounds the decompressed size.
 function createSizeLimiter(maxBytes: number): Transform {
@@ -242,6 +306,8 @@ function downloadFile(
       reject(err)
     }
 
+    const originalHostname = new URL(originalUrlString).hostname
+
     function requestWithRedirects(redirectedUrl: string, baseUrl: string, redirects: number) {
       // Relative redirects must be resolved against the URL that issued them, not the original URL.
       const url = new URL(redirectedUrl, baseUrl)
@@ -256,9 +322,27 @@ function downloadFile(
         return
       }
 
+      // A literal IP never reaches the lookup below (there is nothing to resolve), so it is checked
+      // here. Redirect targets are chosen by the remote server; without this it could point the
+      // download at an internal address and use this process to reach it.
+      const hostnameWithoutBrackets = url.hostname.replace(/^\[|\]$/g, '')
+      if (
+        url.hostname.toLowerCase() !== originalHostname.toLowerCase() &&
+        net.isIP(hostnameWithoutBrackets) &&
+        isNonPublicAddress(hostnameWithoutBrackets)
+      ) {
+        settleWithError(new Error(`Refusing to follow a redirect to ${url.hostname}: not a public address`))
+        return
+      }
+
       Object.assign(metricsLabels, contentServerMetricLabels(url.toString()))
 
-      const request = httpModule.get(url.toString(), { headers: { 'accept-encoding': 'gzip' } }, (response) => {
+      const requestOptions = {
+        headers: { 'accept-encoding': 'gzip' },
+        lookup: createRedirectSafeLookup(originalHostname)
+      }
+
+      const request = httpModule.get(url.toString(), requestOptions, (response) => {
         if ((response.statusCode === 302 || response.statusCode === 301) && response.headers.location) {
           // drain the redirect response so its socket is freed (and its inactivity timer cleared)
           response.resume()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -246,7 +246,13 @@ export async function saveContentFileToDisk(
     }
 
     // move downloaded file to target folder
-    await components.storage.storeStream(hash, fs.createReadStream(tmpFileName))
+    const storedStream = fs.createReadStream(tmpFileName)
+    // storage is supplied by the consumer. A component that resolves storeStream without consuming the
+    // stream leaves it to open the temp file after the finally below has removed it, and an unhandled
+    // 'error' event takes the whole process down. Absorb it here: a real read failure still reaches the
+    // storage component through its own consumption of the stream.
+    storedStream.on('error', () => undefined)
+    await components.storage.storeStream(hash, storedStream)
   } catch (e) {
     // The folder may have been removed from under us; forget it so a retry recreates it.
     ensuredFolders.delete(tmpFolder)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,21 +35,34 @@ async function readBodyWithSizeLimit(response: Response, maxBytes: number, timeo
 
   const chunks: Uint8Array[] = []
   let total = 0
-  // The fetch component's timeout only covers time-to-headers: it clears its abort timer as soon as
-  // the response object exists. Without a deadline here a server can send headers, write half a
-  // document and then go silent forever — exactly the stall the request timeout was meant to prevent,
-  // and a pending promise never reaches the reconnection logic.
+  // The fetch component's timeout only covers time-to-headers: it clears its abort timer as soon as the
+  // response object exists. Without a deadline here a server can send headers, write half a document
+  // and then go silent forever — exactly the stall the request timeout was meant to prevent, and a
+  // pending promise never reaches the reconnection logic.
+  //
+  // An *inactivity* deadline, refreshed on every chunk, not a total one: a large response (the cap is
+  // 50 MiB) can legitimately take longer than one request timeout to stream, and a total deadline would
+  // abort a slow-but-healthy content server that is making steady progress. This mirrors
+  // DOWNLOAD_INACTIVITY_TIMEOUT_MS on the file-download path.
   let timedOut = false
-  const timeout = setTimeout(() => {
-    timedOut = true
-    void reader.cancel().catch(() => undefined)
-  }, timeoutMs)
+  let timeout: NodeJS.Timeout | undefined
+  const refreshInactivityTimeout = () => {
+    if (timeout) clearTimeout(timeout)
+    timeout = setTimeout(() => {
+      timedOut = true
+      void reader.cancel().catch(() => undefined)
+    }, timeoutMs)
+  }
+  const timedOutError = () => new Error(`Timed out after ${timeoutMs}ms without receiving response body data`)
+
+  refreshInactivityTimeout()
 
   try {
     for (;;) {
       const { done, value } = await reader.read()
       if (done) break
       if (value) {
+        refreshInactivityTimeout()
         total += value.byteLength
         if (total > maxBytes) {
           throw new Error(`Response body exceeds the maximum allowed size of ${maxBytes} bytes`)
@@ -58,15 +71,15 @@ async function readBodyWithSizeLimit(response: Response, maxBytes: number, timeo
       }
     }
   } catch (e) {
-    throw timedOut ? new Error(`Timed out after ${timeoutMs}ms while reading the response body`) : e
+    throw timedOut ? timedOutError() : e
   } finally {
-    clearTimeout(timeout)
+    if (timeout) clearTimeout(timeout)
     // Frees the socket on the size-exceeded path; a no-op once the stream has been fully read.
     await reader.cancel().catch(() => undefined)
   }
 
   if (timedOut) {
-    throw new Error(`Timed out after ${timeoutMs}ms while reading the response body`)
+    throw timedOutError()
   }
 
   return Buffer.concat(chunks).toString('utf8')
@@ -134,6 +147,28 @@ export async function checkFileExists(file: string): Promise<boolean> {
 export async function sleep(time: number): Promise<void> {
   if (time <= 0) return
   return new Promise<void>((resolve) => setTimeout(resolve, time))
+}
+
+// How often an interruptible sleep samples its stop predicate.
+const STOP_SIGNAL_SAMPLE_INTERVAL_IN_MS = 50
+
+/**
+ * sleep(), but returns early once `shouldStop()` becomes true.
+ *
+ * Every waiting period between attempts or polls is otherwise added to shutdown latency: callers now
+ * await the running work rather than merely signalling it, so a plain sleep of the poll interval or the
+ * retry backoff is time a caller's stop() spends blocked. The signal is a predicate rather than an
+ * event, so it is sampled; at these intervals that is far cheaper than the wait it replaces.
+ */
+export async function sleepUnlessStopped(time: number, shouldStop?: () => boolean): Promise<void> {
+  if (!shouldStop) return sleep(time)
+  if (time <= 0) return
+
+  const deadline = Date.now() + time
+  while (Date.now() < deadline) {
+    if (shouldStop()) return
+    await sleep(Math.min(STOP_SIGNAL_SAMPLE_INTERVAL_IN_MS, deadline - Date.now()))
+  }
 }
 
 // Content hashes are IPFS CIDs (base58/base32), hence alphanumeric. Validating against this charset
@@ -351,22 +386,46 @@ export function isNonPublicAddress(address: string): boolean {
  */
 function createRedirectSafeLookup(allowedHostname: string): LookupFunction {
   const allowed = allowedHostname.toLowerCase()
+  // Whether the caller's own host resolved to a non-public address the first time we looked it up.
+  // Recorded once and then held for the whole download, which is what closes DNS rebinding: a host that
+  // answers the initial request from a public address cannot later resolve to loopback on a same-host
+  // redirect, even though such a redirect passes every origin and hostname check.
+  //
+  // Deliberately the public/non-public *classification* rather than the exact address, so a legitimate
+  // round-robin CDN handing out a different public IP per query still works.
+  let allowedHostWasNonPublic: boolean | undefined
 
   return ((hostname: string, options: any, callback: any) => {
-    if (hostname.toLowerCase() === allowed) {
-      dnsLookup(hostname, options, callback)
-      return
-    }
-
     dnsLookup(hostname, options, (err: any, address: any, family: any) => {
       if (err) {
         callback(err, address, family)
         return
       }
       const resolved: { address: string }[] = Array.isArray(address) ? address : [{ address }]
-      const blocked = resolved.find((entry) => isNonPublicAddress(entry.address))
-      if (blocked) {
-        callback(new Error(`Refusing to follow a redirect to ${hostname} (${blocked.address}): not a public address`))
+      const nonPublic = resolved.find((entry) => isNonPublicAddress(entry.address))
+
+      if (hostname.toLowerCase() === allowed) {
+        // The caller's host comes from the trusted server list, so it is allowed to be private — that
+        // is what keeps loopback-based local development and the tests working. It just may not
+        // *change* classification mid-download.
+        if (allowedHostWasNonPublic === undefined) {
+          allowedHostWasNonPublic = !!nonPublic
+        } else if (!!nonPublic !== allowedHostWasNonPublic) {
+          callback(
+            new Error(
+              `Refusing to follow a redirect to ${hostname}: it now resolves to ${
+                nonPublic ? 'a non-public' : 'a public'
+              } address, unlike the original request`
+            )
+          )
+          return
+        }
+        callback(null, address, family)
+        return
+      }
+
+      if (nonPublic) {
+        callback(new Error(`Refusing to follow a redirect to ${hostname} (${nonPublic.address}): not a public address`))
         return
       }
       callback(null, address, family)
@@ -427,6 +486,9 @@ function downloadFile(
     }
 
     const originalHostname = new URL(originalUrlString).hostname
+    // Created once for the whole download, not per hop: it carries the resolved-address classification
+    // of the original host between hops, which is what lets it detect a rebind.
+    const redirectSafeLookup = createRedirectSafeLookup(originalHostname)
 
     function requestWithRedirects(redirectedUrl: string, baseUrl: string, redirects: number) {
       // Relative redirects must be resolved against the URL that issued them, not the original URL.
@@ -470,7 +532,7 @@ function downloadFile(
 
       const requestOptions = {
         headers: { 'accept-encoding': 'gzip' },
-        lookup: createRedirectSafeLookup(originalHostname)
+        lookup: redirectSafeLookup
       }
 
       const request = httpModule.get(url.toString(), requestOptions, (response) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,56 +12,106 @@ import { pipeline, Readable, Transform } from 'stream'
 import { promisify } from 'util'
 import * as zlib from 'zlib'
 import { ContentServerMetricLabels } from './metrics'
-import { Path, Server, SnapshotsFetcherComponents } from './types'
+import { Path, ResolvedTransferLimits, Server, SnapshotsFetcherComponents, TransferLimits } from './types'
 
 const streamPipeline = promisify(pipeline)
 
 // Bounds buffered JSON responses so a malicious server can't OOM the process via response.json().
 const MAX_JSON_RESPONSE_SIZE_IN_BYTES = 50 * 1024 * 1024 // 50 MiB
 
-// Applied to the body read when the caller did not ask for a specific timeout.
+// Fallback for a fetchJson caller that names no timeout of its own. Distinct from
+// `requestTimeoutInMs` below, which is what this package's own JSON calls pass: collapsing the two would
+// quietly halve this one.
 const DEFAULT_BODY_READ_TIMEOUT_IN_MS = 30_000
 
-// Minimum sustained rate a transfer must average once it has been running longer than the grace period
-// below. The inactivity deadlines on both transfer paths only ask "did a byte arrive recently?", so a
-// peer that trickles one byte per window answers yes forever while holding its queue slot; the size
-// caps are the only other bound, and at that rate 1 GiB is geological. A rate floor is what makes
-// staying connected cost the peer real bandwidth instead of nothing.
+// The values this package used before these became configurable, so an omitted `transferLimits` — or an
+// omitted field within it — behaves exactly as before.
 //
-// Set far below any usable link (4 KiB/s is worse than a 56k modem) rather than near real throughput:
-// this is here to catch transfers that are not really transferring, and a legitimate peer that cannot
-// beat it would exhaust its retry ladder on duration anyway. Downloads are retried, so a false
-// positive costs an attempt rather than the entity.
-const MIN_TRANSFER_RATE_IN_BYTES_PER_SECOND = 4 * 1024
-// Rate is not judged before this. Small responses finish well inside it, and earlier samples are
-// dominated by connection setup and server think-time rather than by throughput.
-const TRANSFER_RATE_GRACE_PERIOD_IN_MS = 60_000
+// requestTimeoutInMs: an *inactivity* deadline refreshed per chunk, not a total one, so a large
+// response can legitimately outlast it while making steady progress.
+//
+// minTransferRateInBytesPerSecond: the companion to that deadline. Refreshing per chunk means the
+// deadline only ever asks "did a byte arrive recently?", which a peer trickling one byte per window
+// answers yes to forever while holding its slot; the size caps are then the only other bound, and at
+// that rate 1 GiB is geological. The floor is what makes staying connected cost real bandwidth. Set far
+// below any usable link (4 KiB/s is worse than a 56k modem) rather than near real throughput: it exists
+// to catch transfers that are not really transferring, and downloads retry, so a false positive costs
+// an attempt rather than the entity.
+//
+// transferRateGracePeriodInMs: small responses finish well inside it, and earlier samples are dominated
+// by connection setup and server think-time rather than by throughput.
+export const DEFAULT_TRANSFER_LIMITS: ResolvedTransferLimits = {
+  requestTimeoutInMs: 15_000,
+  maxDownloadedFileSizeInBytes: 1024 * 1024 * 1024, // 1 GiB
+  minTransferRateInBytesPerSecond: 4 * 1024,
+  transferRateGracePeriodInMs: 60_000
+}
+
+// Zero is meaningful for these two and not for the others: a rate floor of 0 disables the check, and a
+// grace period of 0 judges from the first chunk. A timeout or size cap of 0 would reject every transfer.
+const TRANSFER_LIMIT_MINIMUMS: ResolvedTransferLimits = {
+  requestTimeoutInMs: 1,
+  maxDownloadedFileSizeInBytes: 1,
+  minTransferRateInBytesPerSecond: 0,
+  transferRateGracePeriodInMs: 0
+}
+
+/**
+ * Fills in {@link DEFAULT_TRANSFER_LIMITS} for anything the caller omitted, and rejects values that
+ * would silently disable a bound rather than tune it.
+ *
+ * Validated here rather than at each point of use so a misconfiguration surfaces once, at construction,
+ * instead of as a puzzling per-download failure.
+ */
+export function resolveTransferLimits(limits?: TransferLimits): ResolvedTransferLimits {
+  const resolved = { ...DEFAULT_TRANSFER_LIMITS, ...limits }
+  for (const name of Object.keys(DEFAULT_TRANSFER_LIMITS) as Array<keyof ResolvedTransferLimits>) {
+    const value = resolved[name]
+    const minimum = TRANSFER_LIMIT_MINIMUMS[name]
+    if (!Number.isSafeInteger(value) || value < minimum) {
+      throw new Error(`transferLimits.${name} must be an integer >= ${minimum}, got ${value}`)
+    }
+  }
+  return resolved
+}
 
 /**
  * Companion to the per-chunk inactivity deadlines: they check that bytes are still arriving, this
  * checks that the bytes add up to progress. Returns the error to fail with, or undefined to continue.
  */
-export function tooSlowToContinue(bytesSoFar: number, startedAt: number): Error | undefined {
+export function tooSlowToContinue(
+  bytesSoFar: number,
+  startedAt: number,
+  limits: ResolvedTransferLimits
+): Error | undefined {
+  if (limits.minTransferRateInBytesPerSecond === 0) {
+    return undefined
+  }
   const elapsed = Date.now() - startedAt
-  if (elapsed <= TRANSFER_RATE_GRACE_PERIOD_IN_MS) {
+  if (elapsed <= limits.transferRateGracePeriodInMs) {
     return undefined
   }
   const bytesPerSecond = (bytesSoFar * 1000) / elapsed
-  if (bytesPerSecond >= MIN_TRANSFER_RATE_IN_BYTES_PER_SECOND) {
+  if (bytesPerSecond >= limits.minTransferRateInBytesPerSecond) {
     return undefined
   }
   // The byte total is part of the message because the rate alone rounds a trickle and a dead silence
   // to the same "0.0 bytes/s", and those are different problems to go looking for.
   return new Error(
     `Transfer of ${bytesSoFar} bytes averaged ${bytesPerSecond.toFixed(2)} bytes/s over ` +
-      `${Math.round(elapsed / 1000)}s, below the minimum of ${MIN_TRANSFER_RATE_IN_BYTES_PER_SECOND} bytes/s`
+      `${Math.round(elapsed / 1000)}s, below the minimum of ${limits.minTransferRateInBytesPerSecond} bytes/s`
   )
 }
 
 // Reads a response body while enforcing a maximum size. The native fetcher (unlike node-fetch) has
 // no `size` option, so we cap manually: read the stream with a running byte count and abort —
 // cancelling the stream to free its socket — if it exceeds the limit.
-async function readBodyWithSizeLimit(response: Response, maxBytes: number, timeoutMs: number): Promise<string> {
+async function readBodyWithSizeLimit(
+  response: Response,
+  maxBytes: number,
+  timeoutMs: number,
+  limits: ResolvedTransferLimits
+): Promise<string> {
   const reader = response.body?.getReader()
   if (!reader) {
     return ''
@@ -102,7 +152,7 @@ async function readBodyWithSizeLimit(response: Response, maxBytes: number, timeo
         if (total > maxBytes) {
           throw new Error(`Response body exceeds the maximum allowed size of ${maxBytes} bytes`)
         }
-        const tooSlow = tooSlowToContinue(total, startedAt)
+        const tooSlow = tooSlowToContinue(total, startedAt, limits)
         if (tooSlow) {
           throw tooSlow
         }
@@ -124,8 +174,17 @@ async function readBodyWithSizeLimit(response: Response, maxBytes: number, timeo
   return Buffer.concat(chunks).toString('utf8')
 }
 
-export async function fetchJson(url: string, fetcher: IFetchComponent, init?: RequestOptions): Promise<any> {
-  const bodyReadTimeout = init?.timeout ?? DEFAULT_BODY_READ_TIMEOUT_IN_MS
+export async function fetchJson(
+  url: string,
+  fetcher: IFetchComponent,
+  init?: RequestOptions & {
+    /** Bounds for this request's body read. Resolved from the defaults when omitted. */
+    transferLimits?: TransferLimits
+  }
+): Promise<any> {
+  const { transferLimits, ...requestInit } = init ?? {}
+  const limits = resolveTransferLimits(transferLimits)
+  const bodyReadTimeout = requestInit.timeout ?? DEFAULT_BODY_READ_TIMEOUT_IN_MS
 
   // JSON endpoints do not follow redirects at all.
   //
@@ -143,7 +202,7 @@ export async function fetchJson(url: string, fetcher: IFetchComponent, init?: Re
   //
   // No known catalyst JSON endpoint redirects. If one legitimately must, the fix is a redirect-aware
   // fetch component, not a check here that cannot bind to the request's own resolution.
-  const response = await fetcher.fetch(url, { ...init, redirect: 'manual' })
+  const response = await fetcher.fetch(url, { ...requestInit, redirect: 'manual' })
 
   if (response.status >= 300 && response.status < 400) {
     await response.body?.cancel().catch(() => undefined)
@@ -160,7 +219,7 @@ export async function fetchJson(url: string, fetcher: IFetchComponent, init?: Re
     throw new Error('Error fetching ' + url + '. Status code was: ' + response.status)
   }
 
-  const body = await readBodyWithSizeLimit(response, MAX_JSON_RESPONSE_SIZE_IN_BYTES, bodyReadTimeout)
+  const body = await readBodyWithSizeLimit(response, MAX_JSON_RESPONSE_SIZE_IN_BYTES, bodyReadTimeout, limits)
   if (body === '') {
     throw new Error('Error fetching ' + url + '. The response body was empty.')
   }
@@ -310,8 +369,10 @@ export async function saveContentFileToDisk(
   originalUrlString: string,
   destinationFilename: string,
   hash: string,
-  checkHash: boolean = true
+  checkHash: boolean = true,
+  transferLimits?: TransferLimits
 ): Promise<void> {
+  const limits = resolveTransferLimits(transferLimits)
   const tmpFolder = path.dirname(destinationFilename)
   await ensureFolderExists(tmpFolder)
 
@@ -325,7 +386,7 @@ export async function saveContentFileToDisk(
   }
 
   try {
-    await downloadFile(originalUrlString, metricsLabels, components, tmpFileName)
+    await downloadFile(originalUrlString, metricsLabels, components, tmpFileName, limits)
 
     // make files not executable
     await fs.promises.chmod(tmpFileName, 0o644)
@@ -388,10 +449,6 @@ const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308])
 // Abort a download after this many milliseconds of socket inactivity. Healthy downloads keep the
 // socket busy, so this only trips on stalled connections (e.g. a server that stops sending bytes).
 const DOWNLOAD_INACTIVITY_TIMEOUT_MS = 30_000
-// Hard cap on the number of bytes written to disk (after decompression). Protects against gzip
-// bombs and otherwise unbounded responses that could exhaust the disk.
-const MAX_DOWNLOADED_FILE_SIZE_IN_BYTES = 1024 * 1024 * 1024 // 1 GiB
-
 function isNonPublicIPv4(address: string): boolean {
   const [first, second] = address.split('.').map(Number)
   if (first === 0) return true // 0.0.0.0/8 "this network"
@@ -569,9 +626,10 @@ export function createRedirectSafeLookup(allowedHostname: string): LookupFunctio
  * {@link tooSlowToContinue}. The clock starts when the response headers arrive, which is the right
  * origin for measuring body throughput.
  */
-export function createTransferLimiter(maxBytes: number): Transform {
+export function createTransferLimiter(limits: ResolvedTransferLimits): Transform {
   let total = 0
   const startedAt = Date.now()
+  const maxBytes = limits.maxDownloadedFileSizeInBytes
   return new Transform({
     transform(chunk, _encoding, callback) {
       total += chunk.length
@@ -579,7 +637,7 @@ export function createTransferLimiter(maxBytes: number): Transform {
         callback(new Error(`Downloaded file exceeds the maximum allowed size of ${maxBytes} bytes`))
         return
       }
-      const tooSlow = tooSlowToContinue(total, startedAt)
+      const tooSlow = tooSlowToContinue(total, startedAt, limits)
       if (tooSlow) {
         callback(tooSlow)
         return
@@ -593,7 +651,8 @@ function downloadFile(
   originalUrlString: string,
   metricsLabels: ContentServerMetricLabels,
   components: { metrics?: SnapshotsFetcherComponents['metrics'] },
-  tmpFileName: string
+  tmpFileName: string,
+  limits: ResolvedTransferLimits
 ) {
   return new Promise<void>((resolve, reject) => {
     // One timer for the whole download instead of one per redirect hop: a hop that redirects never
@@ -700,7 +759,7 @@ function downloadFile(
           })
 
           const isGzip = response.headers['content-encoding'] === 'gzip'
-          const transferLimiter = createTransferLimiter(MAX_DOWNLOADED_FILE_SIZE_IN_BYTES)
+          const transferLimiter = createTransferLimiter(limits)
 
           const pipe = isGzip
             ? streamPipeline(response, zlib.createGunzip(), transferLimiter, file)
@@ -753,7 +812,7 @@ export function contentServerMetricLabels(contentServer: string): ContentServerM
  * @param maxBytes - Optional ceiling. Reject and destroy the stream once more than this many bytes
  *   have arrived, instead of buffering whatever the producer sends. Callers reading content-addressed
  *   files should pass one: the download cap alone allows a single file of
- *   {@link MAX_DOWNLOADED_FILE_SIZE_IN_BYTES}, and nothing stops several from being read at once.
+ *   `transferLimits.maxDownloadedFileSizeInBytes`, and nothing stops several from being read at once.
  */
 export function streamToBuffer(stream: Readable, maxBytes?: number): Promise<Buffer> {
   return new Promise((resolve, reject) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -487,17 +487,42 @@ const MAX_REDIRECTS = 10
 // download from such a peer burn its whole retry ladder. All of these are followed with GET, which is
 // what 303 mandates and what 307/308 preserve, since this client only ever issues GET.
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308])
+
+function ipv4ToInteger(address: string): number {
+  const [first, second, third, fourth] = address.split('.').map(Number)
+  return (((first << 24) >>> 0) + (second << 16) + (third << 8) + fourth) >>> 0
+}
+
+function ipv4MatchesPrefix(address: string, network: string, prefixLength: number): boolean {
+  const mask = prefixLength === 0 ? 0 : (0xffffffff << (32 - prefixLength)) >>> 0
+  return (ipv4ToInteger(address) & mask) === (ipv4ToInteger(network) & mask)
+}
+
+const NON_PUBLIC_IPV4_PREFIXES: ReadonlyArray<readonly [string, number]> = [
+  ['0.0.0.0', 8],
+  ['10.0.0.0', 8],
+  ['100.64.0.0', 10],
+  ['127.0.0.0', 8],
+  ['169.254.0.0', 16],
+  ['172.16.0.0', 12],
+  ['192.0.0.0', 24],
+  ['192.0.2.0', 24],
+  ['192.88.99.0', 24],
+  ['192.168.0.0', 16],
+  ['198.18.0.0', 15],
+  ['198.51.100.0', 24],
+  ['203.0.113.0', 24],
+  ['224.0.0.0', 3]
+]
+
 function isNonPublicIPv4(address: string): boolean {
-  const [first, second] = address.split('.').map(Number)
-  if (first === 0) return true // 0.0.0.0/8 "this network"
-  if (first === 10) return true // 10.0.0.0/8 private
-  if (first === 127) return true // loopback
-  if (first === 169 && second === 254) return true // link-local, incl. cloud metadata
-  if (first === 172 && second >= 16 && second <= 31) return true // 172.16.0.0/12 private
-  if (first === 192 && second === 168) return true // 192.168.0.0/16 private
-  if (first === 100 && second >= 64 && second <= 127) return true // 100.64.0.0/10 CGNAT
-  if (first >= 224) return true // multicast and reserved
-  return false
+  // These two anycast addresses are the only globally-reachable allocations inside 192.0.0.0/24.
+  if (address === '192.0.0.9' || address === '192.0.0.10') return false
+
+  // IANA IPv4 Special-Purpose Address Registry entries that are not globally reachable, plus
+  // multicast. Keeping the registry-shaped list explicit makes the security decision reviewable and
+  // avoids broad rules such as "all of 192/8" that would reject legitimate public servers.
+  return NON_PUBLIC_IPV4_PREFIXES.some(([network, prefixLength]) => ipv4MatchesPrefix(address, network, prefixLength))
 }
 
 /**
@@ -547,10 +572,46 @@ function parseIPv6ToBytes(address: string): Uint8Array | undefined {
   return bytes
 }
 
+function ipv6MatchesPrefix(address: Uint8Array, network: string, prefixLength: number): boolean {
+  const networkBytes = parseIPv6ToBytes(network)
+  if (!networkBytes) {
+    throw new Error(`Invalid internal IPv6 network literal: ${network}`)
+  }
+  const wholeBytes = Math.floor(prefixLength / 8)
+  for (let index = 0; index < wholeBytes; index++) {
+    if (address[index] !== networkBytes[index]) return false
+  }
+  const remainingBits = prefixLength % 8
+  if (remainingBits === 0) return true
+  const mask = (0xff << (8 - remainingBits)) & 0xff
+  return (address[wholeBytes] & mask) === (networkBytes[wholeBytes] & mask)
+}
+
+const PUBLIC_IETF_IPV6_EXCEPTIONS: ReadonlyArray<readonly [string, number]> = [
+  ['2001:1::1', 128],
+  ['2001:1::2', 128],
+  ['2001:1::3', 128],
+  ['2001:3::', 32],
+  ['2001:4:112::', 48],
+  ['2001:20::', 28],
+  ['2001:30::', 28]
+]
+
+const NON_PUBLIC_IPV6_PREFIXES: ReadonlyArray<readonly [string, number]> = [
+  ['64:ff9b:1::', 48],
+  ['100::', 64],
+  ['100:0:0:1::', 64],
+  ['2001::', 23],
+  ['2001:db8::', 32],
+  ['2002::', 16],
+  ['3fff::', 20],
+  ['5f00::', 16]
+]
+
 /**
- * True for addresses that are only reachable from inside our own network: RFC1918 private ranges,
- * loopback, link-local (which covers the cloud metadata endpoints at 169.254.169.254), carrier-grade
- * NAT, "this network", multicast/reserved space, and their IPv6 equivalents.
+ * True for addresses that are not globally reachable according to the IANA special-purpose address
+ * registries: private, loopback, link-local (including cloud metadata), documentation, benchmarking,
+ * discard-only, multicast/reserved space, and their IPv6 equivalents.
  *
  * Anything that is not a recognisable IP literal is reported as non-public: callers only ever pass
  * resolved addresses, so an unparseable value means something unexpected happened and refusing is the
@@ -575,7 +636,15 @@ export function isNonPublicAddress(address: string): boolean {
     if (bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0x80) return true // fe80::/10 link-local
     if ((bytes[0] & 0xfe) === 0xfc) return true // fc00::/7 unique local
     if (bytes[0] === 0xff) return true // ff00::/8 multicast
-    return false
+
+    // More-specific globally-reachable allocations inside IETF's otherwise non-global 2001::/23.
+    if (
+      PUBLIC_IETF_IPV6_EXCEPTIONS.some(([network, prefixLength]) => ipv6MatchesPrefix(bytes, network, prefixLength))
+    ) {
+      return false
+    }
+
+    return NON_PUBLIC_IPV6_PREFIXES.some(([network, prefixLength]) => ipv6MatchesPrefix(bytes, network, prefixLength))
   }
 
   return true

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -339,6 +339,25 @@ export function isUsableTimestamp(value: unknown): value is number {
  * here could refuse a hash assertHash would have happily verified, which would stop syncing content that
  * works today. This can only ever reject hashes that were going to fail anyway.
  */
+/**
+ * Makes a URL safe to put in an error or log line.
+ *
+ * Two problems, both of which only exist once redirects are in play: after a hop the URL is the server's
+ * text rather than ours, so its length is unbounded; and a URL can carry `user:password@`, which must
+ * never reach a log. Falls back to truncation alone for something unparseable, since that is already not
+ * a URL we should be echoing in full.
+ */
+export function sanitizeUrlForLog(value: string): string {
+  try {
+    const parsed = new URL(value)
+    parsed.username = ''
+    parsed.password = ''
+    return truncateForLog(parsed.toString())
+  } catch {
+    return truncateForLog(value)
+  }
+}
+
 export function isVerifiableContentHash(hash: string): boolean {
   return hash.startsWith('Qm') || hash.startsWith('ba')
 }
@@ -745,12 +764,17 @@ function downloadFile(
       try {
         url = new URL(redirectedUrl, baseUrl)
       } catch {
-        settleWithError(new Error(`Invalid redirect location ${JSON.stringify(redirectedUrl)} from ${baseUrl}`))
+        settleWithError(
+          new Error(
+            `Invalid redirect location ${truncateForLog(JSON.stringify(redirectedUrl))} from ` +
+              sanitizeUrlForLog(baseUrl)
+          )
+        )
         return
       }
       // Only http(s) is supported; reject other schemes (e.g. file:) a redirect could point to.
       if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-        settleWithError(new Error('Unsupported protocol in URL ' + url.toString()))
+        settleWithError(new Error('Unsupported protocol in URL ' + sanitizeUrlForLog(url.toString())))
         return
       }
       const httpModule = url.protocol === 'https:' ? https : http
@@ -795,8 +819,15 @@ function downloadFile(
           // Choices, writing its body to disk as though it were the file, and accepted a redirect
           // status that arrived without a Location header.
         } else if (!response.statusCode || response.statusCode < 200 || response.statusCode >= 300) {
-          response.resume()
-          settleWithError(new Error('Invalid response from ' + url + ' status: ' + response.statusCode))
+          // Destroyed, not drained, for the same reason as the redirect path above: this body is already
+          // being thrown away, and resume() keeps reading it to completion outside every transfer bound —
+          // the size caps and rate floor live in createDownloadTransforms, which this path never reaches.
+          // A server can therefore pair an error status with an endless body and keep the socket and the
+          // bandwidth after the promise has already rejected and the caller has moved on.
+          response.destroy()
+          settleWithError(
+            new Error('Invalid response from ' + sanitizeUrlForLog(url.toString()) + ' status: ' + response.statusCode)
+          )
           return
         } else {
           // Content-coding tokens are case-insensitive (RFC 9110 §8.4.1) and `x-gzip` is a legacy alias
@@ -816,12 +847,13 @@ function downloadFile(
           // surfacing as a hash mismatch after the retry ladder has been spent. Truncated because the
           // header value is the server's choice.
           if (declaredEncodings.length > 0 && !isGzip) {
-            response.resume()
+            // Destroyed rather than drained: see the status path above. The coding is chosen by the
+            // server, so draining here would be an attacker-selectable way back to an unbounded read.
+            response.destroy()
             settleWithError(
               new Error(
-                `Cannot decode ${url}: unsupported content-encoding ${truncateForLog(
-                  JSON.stringify(declaredEncodings.join(', '))
-                )}`
+                `Cannot decode ${sanitizeUrlForLog(url.toString())}: unsupported content-encoding ` +
+                  truncateForLog(JSON.stringify(declaredEncodings.join(', ')))
               )
             )
             return
@@ -847,7 +879,7 @@ function downloadFile(
 
       // Reject (instead of hanging forever) when the connection stalls before/while downloading.
       request.setTimeout(limits.downloadInactivityTimeoutInMs, () => {
-        request.destroy(new Error('Timeout while downloading ' + url.toString()))
+        request.destroy(new Error('Timeout while downloading ' + sanitizeUrlForLog(url.toString())))
       })
 
       request.on('error', function (err) {

--- a/test/assertHash.spec.ts
+++ b/test/assertHash.spec.ts
@@ -1,0 +1,41 @@
+import { assertHash } from '../src/utils'
+
+describe('assertHash', () => {
+  describe('when the hash uses an unrecognised algorithm prefix', () => {
+    it('should reject naming the unknown algorithm instead of reading the file', async () => {
+      await expect(assertHash('test/fixtures/entity-deployment.json', 'sha256-deadbeef')).rejects.toThrow(
+        'Unknown hashing algorithm for hash: sha256-deadbeef'
+      )
+    })
+  })
+
+  describe('when the hash is empty', () => {
+    it('should reject as an unknown algorithm', async () => {
+      await expect(assertHash('test/fixtures/entity-deployment.json', '')).rejects.toThrow(
+        'Unknown hashing algorithm'
+      )
+    })
+  })
+
+  describe('when a CIDv0 hash matches the file contents', () => {
+    it('should resolve', async () => {
+      await expect(
+        assertHash(
+          'test/fixtures/QmXx5dDq7nnPuCCP43Ngc7iq4kkqDfC5PEJGawUHYLGxUn',
+          'QmXx5dDq7nnPuCCP43Ngc7iq4kkqDfC5PEJGawUHYLGxUn'
+        )
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe('when a CIDv1 hash does not match the file contents', () => {
+    it('should reject reporting both the expected and the calculated hash', async () => {
+      await expect(
+        assertHash(
+          'test/fixtures/QmXx5dDq7nnPuCCP43Ngc7iq4kkqDfC5PEJGawUHYLGxUn',
+          'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu'
+        )
+      ).rejects.toThrow('hashes do not match')
+    })
+  })
+})

--- a/test/contentFilesBounds.spec.ts
+++ b/test/contentFilesBounds.spec.ts
@@ -1,4 +1,5 @@
 import { createInMemoryStorage, IContentStorageComponent } from '@dcl/catalyst-storage'
+import { hashV1 } from '@dcl/hashing'
 import { createReadStream } from 'fs'
 import { resolve } from 'path'
 import { Readable } from 'stream'
@@ -99,6 +100,74 @@ test('downloadEntityAndContentFiles when the entity content array is hostile or 
       await expect(download('entitytoomanycontentfiles', storage)).rejects.toThrow(
         'above the maximum of 25000'
       )
+    })
+  })
+})
+
+test('downloadEntityAndContentFiles when given an invalid contentFilesConcurrency', ({ components }) => {
+  const contentHash = 'QmazJLZfUmZgNMTdwWSmJRvw4dBfcjS9GuqkwkKGRWb4K6'
+  let entityId: string
+  let entityBytes: Buffer
+  let requestedFiles: number
+
+  beforeEach(async () => {
+    // Deliberately not a fixture id: test-component preloads every fixture into storage, so a fixture
+    // entity short-circuits on storage.exist and never issues a request — which would make the
+    // "no request was spent" assertion below pass whether the guard exists or not.
+    entityBytes = Buffer.from(
+      JSON.stringify({
+        type: 'profile',
+        metadata: { avatars: [] },
+        content: [{ file: 'body.png', hash: contentHash }]
+      })
+    )
+    entityId = await hashV1(entityBytes)
+    await components.storage.delete([entityId, contentHash])
+
+    requestedFiles = 0
+    components.router.get('/contents/:file', async (ctx) => {
+      requestedFiles++
+      return { body: ctx.params.file === entityId ? entityBytes.toString() : 'unused' }
+    })
+  })
+
+  describe.each([
+    ['zero', 0],
+    ['a negative', -1],
+    ['a fraction', 2.5]
+  ])('and it is %s', (_label: string, concurrency: number) => {
+    it('should throw naming the argument and the range it accepts', async () => {
+      await expect(
+        downloadEntityAndContentFiles(
+          components,
+          entityId,
+          [await components.getBaseUrl()],
+          new Map(),
+          'downloads',
+          1,
+          0,
+          concurrency
+        )
+      ).rejects.toThrow(`contentFilesConcurrency must be an integer >= 1, got ${concurrency}`)
+    })
+
+    // p-queue raises its own TypeError, but only once the entity file has been fetched and the content
+    // queue is about to be built.
+    it('should fail before spending any request', async () => {
+      await expect(
+        downloadEntityAndContentFiles(
+          components,
+          entityId,
+          [await components.getBaseUrl()],
+          new Map(),
+          'downloads',
+          1,
+          0,
+          concurrency
+        )
+      ).rejects.toThrow()
+
+      expect(requestedFiles).toEqual(0)
     })
   })
 })

--- a/test/contentFilesBounds.spec.ts
+++ b/test/contentFilesBounds.spec.ts
@@ -1,0 +1,104 @@
+import { createInMemoryStorage, IContentStorageComponent } from '@dcl/catalyst-storage'
+import { createReadStream } from 'fs'
+import { resolve } from 'path'
+import { Readable } from 'stream'
+import { downloadEntityAndContentFiles } from '../src'
+import { test } from './components'
+
+// A real, hash-addressed fixture, so the hash check on download passes.
+const realContentHash = 'QmazJLZfUmZgNMTdwWSmJRvw4dBfcjS9GuqkwkKGRWb4K6'
+
+test('downloadEntityAndContentFiles when the entity content array is hostile or redundant', ({ components }) => {
+  const contentFolder = resolve('downloads')
+  let contentRequests: string[]
+
+  async function storageWithEntity(entityId: string, content: unknown): Promise<IContentStorageComponent> {
+    const storage = createInMemoryStorage()
+    await storage.storeStream(entityId, Readable.from([Buffer.from(JSON.stringify({ type: 'scene', content }))]))
+    return storage
+  }
+
+  async function download(entityId: string, storage: IContentStorageComponent) {
+    return downloadEntityAndContentFiles(
+      { fetcher: components.fetcher, logs: components.logs, metrics: components.metrics, storage },
+      entityId,
+      [await components.getBaseUrl()],
+      new Map(),
+      contentFolder,
+      1, // maxRetries
+      0, // waitTimeBetweenRetries
+      10 // contentFilesConcurrency
+    )
+  }
+
+  it('prepares the endpoints', () => {
+    contentRequests = []
+    components.router.get('/contents/:file', async (ctx) => {
+      contentRequests.push(ctx.params.file)
+      return { body: createReadStream('test/fixtures/' + ctx.params.file) }
+    })
+  })
+
+  describe('when the same content hash is repeated many times', () => {
+    let storage: IContentStorageComponent
+
+    beforeEach(async () => {
+      contentRequests = []
+      storage = await storageWithEntity(
+        'entityrepeatedcontenthashes',
+        Array.from({ length: 50 }, (_unused, index) => ({ file: `file-${index}`, hash: realContentHash }))
+      )
+      await download('entityrepeatedcontenthashes', storage)
+    })
+
+    it('should download it once instead of queueing a job per entry', () => {
+      expect(contentRequests).toEqual([realContentHash])
+    })
+
+    it('should still store the file', async () => {
+      expect(await storage.exist(realContentHash)).toBe(true)
+    })
+  })
+
+  describe('when an entry declares a hash that is not a content address', () => {
+    let storage: IContentStorageComponent
+
+    beforeEach(async () => {
+      contentRequests = []
+      storage = await storageWithEntity('entityinvalidcontenthash', [
+        { file: 'good', hash: realContentHash },
+        { file: 'evil', hash: '../../etc/passwd' }
+      ])
+    })
+
+    it('should reject naming the entity rather than partially fetching it', async () => {
+      await expect(download('entityinvalidcontenthash', storage)).rejects.toThrow(
+        'Entity entityinvalidcontenthash declares an invalid content file hash'
+      )
+    })
+
+    it('should not download anything, since the manifest cannot be satisfied in full', async () => {
+      await download('entityinvalidcontenthash', storage).catch(() => undefined)
+
+      expect(contentRequests).toEqual([])
+    })
+  })
+
+  describe('when the content array is larger than one entity is allowed to declare', () => {
+    let storage: IContentStorageComponent
+
+    beforeEach(async () => {
+      contentRequests = []
+      storage = await storageWithEntity(
+        'entitytoomanycontentfiles',
+        Array.from({ length: 25_001 }, (_unused, index) => ({ file: `file-${index}`, hash: realContentHash }))
+      )
+    })
+
+    it('should reject rather than silently truncating the list', async () => {
+      await expect(download('entitytoomanycontentfiles', storage)).rejects.toThrow(
+        'above the maximum of 25000'
+      )
+    })
+  })
+})

--- a/test/decideSnapshotDeploymentFromProcessedSet.spec.ts
+++ b/test/decideSnapshotDeploymentFromProcessedSet.spec.ts
@@ -115,5 +115,40 @@ describe('decideSnapshotDeploymentFromProcessedSet', () => {
         expect(markSnapshotAsProcessed).not.toHaveBeenCalled()
       })
     })
+
+    describe('and marking it as processed is what makes another snapshot skippable', () => {
+      let processedSnapshots: Set<string>
+
+      beforeEach(async () => {
+        // A caller batching decisions shares one set. Marking must be reflected in it, or the snapshot
+        // that replaces the marked one is deployed for nothing.
+        processedSnapshots = new Set(['h0'])
+        await decideSnapshotDeploymentFromProcessedSet(
+          components,
+          processedSnapshots,
+          genesisTimestamp,
+          'h1',
+          genesisTimestamp + 1,
+          [['h0']]
+        )
+      })
+
+      it('should record the newly-processed snapshot in the set it was given', () => {
+        expect(processedSnapshots.has('h1')).toBe(true)
+      })
+
+      it('should then decide that the snapshot replacing it does not need deploying', async () => {
+        const result = await decideSnapshotDeploymentFromProcessedSet(
+          components,
+          processedSnapshots,
+          genesisTimestamp,
+          'h2',
+          genesisTimestamp + 2,
+          [['h1']]
+        )
+
+        expect(result).toBe(false)
+      })
+    })
   })
 })

--- a/test/deployEntitiesFromPointerChanges.spec.ts
+++ b/test/deployEntitiesFromPointerChanges.spec.ts
@@ -96,6 +96,34 @@ describe('deployEntitiesFromPointerChanges', () => {
       expect(markSnapshotAsProcessedSpy).not.toBeCalledWith(snapshotHash)
     })
   })
+
+  test('when an entity coming from pointer-changes is marked as deployed', ({ components }) => {
+    it('should count it against the origin of the server it came from', async () => {
+      const entity = { entityId: 'id1', entityType: 't1', pointers: ['p1'], localTimestamp: 0, authChain: [] }
+      mockDeployedEntitiesStreamWith([entity])
+      const deployerDeployingEverything: IDeployerComponent = {
+        scheduleEntityDeployment: async (scheduled: DeployableEntity) => {
+          await scheduled.markAsDeployed!()
+        },
+        onIdle: jest.fn(),
+        prepareForDeploymentsIn: jest.fn()
+      }
+      const incrementSpy = jest.spyOn(components.metrics, 'increment')
+
+      await deployEntitiesFromPointerChanges(
+        componentsWithDeployer(components, deployerDeployingEverything),
+        streamOptions,
+        server,
+        () => false,
+        () => {}
+      )
+
+      expect(incrementSpy).toBeCalledWith('dcl_entities_deployments_processed_total', {
+        remote_server: 'http://aserver.com',
+        source: 'pointer-changes'
+      })
+    })
+  })
 })
 
 function mockDeployedEntitiesStreamWith(entities: any[]) {

--- a/test/deployEntitiesFromSnapshot.spec.ts
+++ b/test/deployEntitiesFromSnapshot.spec.ts
@@ -40,6 +40,54 @@ describe('deployEntitiesFromSnapshot', () => {
     })
   })
 
+  test('when the snapshot yielded no entities because every line was unreadable', ({ components }) => {
+    it('does not save the snapshot as processed, so a later sync re-downloads and retries it', async () => {
+      // Indistinguishable from an empty snapshot without the report: the stream ends normally and the
+      // processed/streamed counters are both 0.
+      mockDeployedEntitiesStreamReporting([], 3)
+      const markSnapshotAsProcessedSpy = jest.spyOn(components.processedSnapshotStorage, 'markSnapshotAsProcessed')
+      await deployEntitiesFromSnapshot(
+        componentsWithDeployer(components, deployerMock),
+        streamOptions,
+        snapshotHash,
+        new Set(servers),
+        () => false
+      )
+      expect(markSnapshotAsProcessedSpy).not.toBeCalled()
+    })
+  })
+
+  test('when every streamed entity deployed but some lines were unreadable', ({ components }) => {
+    it('does not save the snapshot as processed, since the unread lines are missing entities', async () => {
+      const entity: DeployableEntity = {
+        entityId: 'id1',
+        entityType: 't1',
+        pointers: ['p1'],
+        entityTimestamp: 0,
+        authChain: [],
+        snapshotHash,
+        servers
+      } as any
+      const deployerDeployingEverything: IDeployerComponent = {
+        scheduleEntityDeployment: async (scheduled: DeployableEntity) => {
+          await scheduled.markAsDeployed!()
+        },
+        onIdle: jest.fn(),
+        prepareForDeploymentsIn: jest.fn()
+      }
+      mockDeployedEntitiesStreamReporting([entity], 1)
+      const markSnapshotAsProcessedSpy = jest.spyOn(components.processedSnapshotStorage, 'markSnapshotAsProcessed')
+      await deployEntitiesFromSnapshot(
+        componentsWithDeployer(components, deployerDeployingEverything),
+        streamOptions,
+        snapshotHash,
+        new Set(servers),
+        () => false
+      )
+      expect(markSnapshotAsProcessedSpy).not.toBeCalled()
+    })
+  })
+
   test('when the snapshot is not empty', ({ components }) => {
     it('streams and deployes its entities', async () => {
       const entity1 = { entityId: 'id1', entityType: 't1', pointers: ['p1'], entityTimestamp: 0, authChain: [], snapshotHash, servers }
@@ -242,6 +290,29 @@ function mockDeployedEntitiesStreamWith(entities: any[]) {
       }
       return
     })
+}
+
+// Same as mockDeployedEntitiesStreamWith, but also fills in the report the real stream populates so
+// the "snapshot was only partly readable" path can be exercised.
+function mockDeployedEntitiesStreamReporting(entities: any[], unusableLines: number) {
+  return jest
+    .spyOn(streamEntities, 'getDeployedEntitiesStreamFromSnapshot')
+    .mockImplementation(async function* gen(
+      _components: any,
+      _options: any,
+      _snapshotHash: any,
+      _servers: any,
+      _shouldStop: any,
+      report: any
+    ) {
+      for (const entity of entities) {
+        yield entity
+      }
+      if (report) {
+        report.unusableLines = unusableLines
+      }
+      return
+    } as any)
 }
 
 function componentsWithDeployer(components: TestComponents, deployer: IDeployerComponent):

--- a/test/deployEntitiesFromSnapshot.spec.ts
+++ b/test/deployEntitiesFromSnapshot.spec.ts
@@ -46,13 +46,17 @@ describe('deployEntitiesFromSnapshot', () => {
       // processed/streamed counters are both 0.
       mockDeployedEntitiesStreamReporting([], 3)
       const markSnapshotAsProcessedSpy = jest.spyOn(components.processedSnapshotStorage, 'markSnapshotAsProcessed')
-      await deployEntitiesFromSnapshot(
-        componentsWithDeployer(components, deployerMock),
-        streamOptions,
-        snapshotHash,
-        new Set(servers),
-        () => false
-      )
+      // Rejects so the caller keeps the advertising servers in snapshot bootstrap; resolving would let
+      // them advance past the range this snapshot covers.
+      await expect(
+        deployEntitiesFromSnapshot(
+          componentsWithDeployer(components, deployerMock),
+          streamOptions,
+          snapshotHash,
+          new Set(servers),
+          () => false
+        )
+      ).rejects.toThrow('could not be read as deployments')
       expect(markSnapshotAsProcessedSpy).not.toBeCalled()
     })
   })
@@ -77,13 +81,15 @@ describe('deployEntitiesFromSnapshot', () => {
       }
       mockDeployedEntitiesStreamReporting([entity], 1)
       const markSnapshotAsProcessedSpy = jest.spyOn(components.processedSnapshotStorage, 'markSnapshotAsProcessed')
-      await deployEntitiesFromSnapshot(
-        componentsWithDeployer(components, deployerDeployingEverything),
-        streamOptions,
-        snapshotHash,
-        new Set(servers),
-        () => false
-      )
+      await expect(
+        deployEntitiesFromSnapshot(
+          componentsWithDeployer(components, deployerDeployingEverything),
+          streamOptions,
+          snapshotHash,
+          new Set(servers),
+          () => false
+        )
+      ).rejects.toThrow('could not be read as deployments')
       expect(markSnapshotAsProcessedSpy).not.toBeCalled()
     })
   })

--- a/test/deployEntitiesFromSnapshot.spec.ts
+++ b/test/deployEntitiesFromSnapshot.spec.ts
@@ -103,7 +103,7 @@ describe('deployEntitiesFromSnapshot', () => {
         { entityId: 'id2', entityType: 't2', pointers: ['p2'], entityTimestamp: 1, authChain: [], snapshotHash, servers },
       ])
 
-      const entitiesToDeploy = []
+      const entitiesToDeploy: (() => Promise<void>)[] = []
       const deployerMock = {
         async scheduleEntityDeployment(entity: DeployableEntity) {
           if (entity.markAsDeployed) {

--- a/test/deployEntitiesFromSnapshot.spec.ts
+++ b/test/deployEntitiesFromSnapshot.spec.ts
@@ -94,6 +94,43 @@ describe('deployEntitiesFromSnapshot', () => {
     })
   })
 
+  test('when the deployer acknowledges one entity twice and never acknowledges another', ({ components }) => {
+    it('does not mark the snapshot as processed on the strength of the duplicate', async () => {
+      const entity1: any = {
+        entityId: 'id1', entityType: 't1', pointers: ['p1'], entityTimestamp: 0, authChain: [], snapshotHash, servers
+      }
+      const entity2: any = {
+        entityId: 'id2', entityType: 't2', pointers: ['p2'], entityTimestamp: 1, authChain: [], snapshotHash, servers
+      }
+      let scheduled = 0
+      const deployerAcknowledgingTwice: IDeployerComponent = {
+        scheduleEntityDeployment: async (scheduledEntity: DeployableEntity) => {
+          scheduled++
+          // The first entity never reports. The second reports twice, which is enough to make a
+          // call-counting guard see processed >= streamed and retire the snapshot with a hole in it.
+          if (scheduled === 2) {
+            await scheduledEntity.markAsDeployed!()
+            await scheduledEntity.markAsDeployed!()
+          }
+        },
+        onIdle: jest.fn(),
+        prepareForDeploymentsIn: jest.fn()
+      }
+      mockDeployedEntitiesStreamReporting([entity1, entity2], 0)
+      const markSnapshotAsProcessedSpy = jest.spyOn(components.processedSnapshotStorage, 'markSnapshotAsProcessed')
+
+      await deployEntitiesFromSnapshot(
+        componentsWithDeployer(components, deployerAcknowledgingTwice),
+        streamOptions,
+        snapshotHash,
+        new Set(servers),
+        () => false
+      )
+
+      expect(markSnapshotAsProcessedSpy).not.toBeCalled()
+    })
+  })
+
   test('when the snapshot is not empty', ({ components }) => {
     it('streams and deployes its entities', async () => {
       const entity1 = { entityId: 'id1', entityType: 't1', pointers: ['p1'], entityTimestamp: 0, authChain: [], snapshotHash, servers }

--- a/test/downloadContentEncoding.spec.ts
+++ b/test/downloadContentEncoding.spec.ts
@@ -1,0 +1,136 @@
+import * as zlib from 'zlib'
+import { hashV1 } from '@dcl/hashing'
+import { downloadFileWithRetries } from '../src/downloader'
+import { sleep } from '../src/utils'
+import { test } from './components'
+
+test('downloadFileWithRetries when a server declares its content-encoding in mixed case', ({ components }) => {
+  const targetFolder = 'downloads'
+  let payload: Buffer
+  let hash: string
+  // The route is registered exactly once and reads these. Registering it per-describe does not work: the
+  // router accumulates handlers within one suite and the first one registered wins, so every case would
+  // have been served by whichever describe ran first — and would have passed for that reason rather than
+  // for the behaviour under test.
+  let servedEncoding: string
+  let servedBody: Buffer
+
+  beforeEach(async () => {
+    payload = Buffer.from('the-file-contents-that-must-survive-a-round-trip')
+    hash = await hashV1(payload)
+    await components.storage.delete([hash])
+    servedEncoding = 'gzip'
+    servedBody = zlib.gzipSync(payload)
+    components.router.get('/contents/:file', async () => ({
+      headers: { 'content-encoding': servedEncoding },
+      body: servedBody
+    }))
+  })
+
+  describe.each([
+    ['GZip', 'GZip'],
+    ['GZIP', 'GZIP'],
+    ['gzip with surrounding whitespace', ' gzip '],
+    // Legacy alias, still emitted by some servers.
+    ['x-gzip', 'x-gzip']
+  ])('and the header value is %s', (_label: string, headerValue: string) => {
+    beforeEach(() => {
+      servedEncoding = headerValue
+      servedBody = zlib.gzipSync(payload)
+    })
+
+    // Matching the exact string 'gzip' wrote these to disk still compressed, so they failed hash
+    // verification and burned the whole retry ladder against a server that was behaving correctly.
+    it('should decompress it and store bytes matching the hash', async () => {
+      await downloadFileWithRetries(components, hash, targetFolder, [await components.getBaseUrl()], new Map(), 1, 0)
+
+      await expect(components.storage.exist(hash)).resolves.toBe(true)
+    })
+  })
+
+  describe('and the header declares identity', () => {
+    beforeEach(() => {
+      servedEncoding = 'identity'
+      servedBody = payload
+    })
+
+    it('should treat it as no coding applied rather than as one to undo', async () => {
+      await downloadFileWithRetries(components, hash, targetFolder, [await components.getBaseUrl()], new Map(), 1, 0)
+
+      await expect(components.storage.exist(hash)).resolves.toBe(true)
+    })
+  })
+
+  describe.each([
+    ['a coding this client cannot undo', 'br'],
+    ['several codings layered together', 'gzip, br']
+  ])('and the header declares %s', (_label: string, headerValue: string) => {
+    beforeEach(() => {
+      servedEncoding = headerValue
+      servedBody = payload
+    })
+
+    // Previously these were written to disk undecoded and surfaced as a hash mismatch once the retries
+    // were spent, which says nothing about the real cause.
+    it('should fail naming the unsupported coding rather than as a hash mismatch', async () => {
+      await expect(
+        downloadFileWithRetries(components, hash, targetFolder, [await components.getBaseUrl()], new Map(), 1, 0)
+      ).rejects.toThrow('unsupported content-encoding')
+    })
+  })
+})
+
+test('downloadFileWithRetries when a second caller joins an in-flight download', ({ components }) => {
+  const targetFolder = 'downloads'
+  let payload: Buffer
+  let hash: string
+  let requestCount: number
+
+  beforeEach(async () => {
+    payload = Buffer.from('x'.repeat(4096))
+    hash = await hashV1(payload)
+    await components.storage.delete([hash])
+    requestCount = 0
+    components.router.get('/contents/:file', async () => {
+      requestCount++
+      await sleep(150)
+      return { body: payload }
+    })
+  })
+
+  // Documents the de-duplication contract: the key is the hash alone, so a joiner inherits the bounds of
+  // whoever started the transfer. A stricter second caller does not get its own transfer — the hash is a
+  // content address, so a separate download would spend real bandwidth reaching a byte-identical result.
+  it('should serve both callers from one transfer, on the first caller"s limits', async () => {
+    const generous = downloadFileWithRetries(
+      components,
+      hash,
+      targetFolder,
+      [await components.getBaseUrl()],
+      new Map(),
+      1,
+      0,
+      undefined,
+      { maxDownloadedFileSizeInBytes: 1024 * 1024 }
+    )
+
+    // Long enough for the first call to clear its storage check and register the in-flight job.
+    await sleep(30)
+
+    const stricter = downloadFileWithRetries(
+      components,
+      hash,
+      targetFolder,
+      [await components.getBaseUrl()],
+      new Map(),
+      1,
+      0,
+      undefined,
+      // Would have refused the 4 KiB payload had it run its own transfer.
+      { maxDownloadedFileSizeInBytes: 8 }
+    )
+
+    await expect(Promise.all([generous, stricter])).resolves.toBeDefined()
+    expect(requestCount).toEqual(1)
+  })
+})

--- a/test/downloadContentEncoding.spec.ts
+++ b/test/downloadContentEncoding.spec.ts
@@ -1,4 +1,6 @@
 import * as zlib from 'zlib'
+import { Readable } from 'stream'
+import future from 'fp-future'
 import { hashV1 } from '@dcl/hashing'
 import { downloadFileWithRetries } from '../src/downloader'
 import { sleep } from '../src/utils'
@@ -85,23 +87,27 @@ test('downloadFileWithRetries when a second caller joins an in-flight download',
   let payload: Buffer
   let hash: string
   let requestCount: number
+  let firstRequestStarted: ReturnType<typeof future<void>>
+  let releaseResponse: ReturnType<typeof future<void>>
+  let outcome: unknown[]
 
   beforeEach(async () => {
     payload = Buffer.from('x'.repeat(4096))
     hash = await hashV1(payload)
     await components.storage.delete([hash])
     requestCount = 0
+    firstRequestStarted = future<void>()
+    releaseResponse = future<void>()
+
     components.router.get('/contents/:file', async () => {
       requestCount++
-      await sleep(150)
+      firstRequestStarted.resolve()
+      // Held open until both callers have been started, so the second one genuinely arrives while the
+      // first transfer is in flight rather than after it has finished.
+      await releaseResponse
       return { body: payload }
     })
-  })
 
-  // Documents the de-duplication contract: the key is the hash alone, so a joiner inherits the bounds of
-  // whoever started the transfer. A stricter second caller does not get its own transfer — the hash is a
-  // content address, so a separate download would spend real bandwidth reaching a byte-identical result.
-  it('should serve both callers from one transfer, on the first caller"s limits', async () => {
     const generous = downloadFileWithRetries(
       components,
       hash,
@@ -114,8 +120,9 @@ test('downloadFileWithRetries when a second caller joins an in-flight download',
       { maxDownloadedFileSizeInBytes: 1024 * 1024 }
     )
 
-    // Long enough for the first call to clear its storage check and register the in-flight job.
-    await sleep(30)
+    // The barrier is the handler being entered, not a sleep: the request cannot happen before the first
+    // caller has registered its in-flight job, so there is no timing left to guess at.
+    await firstRequestStarted
 
     const stricter = downloadFileWithRetries(
       components,
@@ -130,7 +137,72 @@ test('downloadFileWithRetries when a second caller joins an in-flight download',
       { maxDownloadedFileSizeInBytes: 8 }
     )
 
-    await expect(Promise.all([generous, stricter])).resolves.toBeDefined()
+    releaseResponse.resolve()
+    outcome = await Promise.all([generous, stricter])
+  })
+
+  // Documents the de-duplication contract: the key is the hash alone, so a joiner inherits the bounds of
+  // whoever started the transfer. A stricter second caller does not get its own transfer — the hash is a
+  // content address, so a separate download would spend real bandwidth reaching a byte-identical result.
+  it('should satisfy both callers rather than failing the stricter one on its own cap', () => {
+    expect(outcome).toHaveLength(2)
+  })
+
+  it('should have made a single request for the two callers', () => {
     expect(requestCount).toEqual(1)
+  })
+})
+
+test('downloadFileWithRetries when an unsupported-encoding response keeps streaming', ({ components }) => {
+  const targetFolder = 'downloads'
+  let hash: string
+  let bytesPulledFromBody: number
+  let bodyClosed: ReturnType<typeof future<void>>
+
+  beforeEach(async () => {
+    hash = await hashV1(Buffer.from('irrelevant, this response is never usable'))
+    await components.storage.delete([hash])
+    bytesPulledFromBody = 0
+    bodyClosed = future<void>()
+
+    // Declares a coding this client cannot undo, then streams without end. The generator counts what is
+    // actually pulled from it, which is the observable difference between abandoning the body and draining
+    // it: resume() would keep consuming this in the background long after the promise rejected.
+    components.router.get('/contents/:file', async () => {
+      const endless = new Readable({
+        read() {
+          bytesPulledFromBody += 1024
+          this.push(Buffer.alloc(1024, 1))
+        }
+      })
+      endless.on('close', () => bodyClosed.resolve())
+      return { headers: { 'content-encoding': 'br' }, body: endless }
+    })
+  })
+
+  it('should reject naming the unsupported coding', async () => {
+    await expect(
+      downloadFileWithRetries(components, hash, targetFolder, [await components.getBaseUrl()], new Map(), 1, 0)
+    ).rejects.toThrow('unsupported content-encoding')
+  })
+
+  it('should close the response body rather than leave it streaming', async () => {
+    await expect(
+      downloadFileWithRetries(components, hash, targetFolder, [await components.getBaseUrl()], new Map(), 1, 0)
+    ).rejects.toThrow()
+
+    await expect(bodyClosed).resolves.toBeUndefined()
+  })
+
+  it('should stop pulling bytes from it once the download has been rejected', async () => {
+    await expect(
+      downloadFileWithRetries(components, hash, targetFolder, [await components.getBaseUrl()], new Map(), 1, 0)
+    ).rejects.toThrow()
+
+    const pulledWhenRejected = bytesPulledFromBody
+    await sleep(300)
+
+    // Draining leaves this climbing after the caller has moved on; abandoning it does not.
+    expect(bytesPulledFromBody).toEqual(pulledWhenRejected)
   })
 })

--- a/test/downloadFileJobDeduplication.spec.ts
+++ b/test/downloadFileJobDeduplication.spec.ts
@@ -161,4 +161,33 @@ test('downloadFileWithRetries when the same hash is requested concurrently', ({ 
       expect(await storage.exist(contentHash)).toBe(true)
     })
   })
+  describe('and several callers are waiting on a job that then fails', () => {
+    let storage: IContentStorageComponent
+    let workingServer: string
+    let brokenServer: string
+
+    beforeEach(async () => {
+      requestCount = 0
+      storage = createInMemoryStorage()
+      workingServer = await components.getBaseUrl()
+      // Nothing listens here, so the shared job fails against it.
+      brokenServer = 'http://127.0.0.1:1'
+    })
+
+    it('should have the woken waiters join one replacement rather than each starting its own', async () => {
+      const waiters = 4
+      const results = await Promise.allSettled([
+        // Registered first, so the others join it — and it is the one that fails.
+        downloadFileWithRetries({ storage }, contentHash, resolve('downloads'), [brokenServer], new Map(), 1, 0),
+        ...Array.from({ length: waiters }, () =>
+          downloadFileWithRetries({ storage }, contentHash, resolve('downloads'), [workingServer], new Map(), 2, 0)
+        )
+      ])
+
+      expect(results.filter((r) => r.status === 'fulfilled')).toHaveLength(waiters)
+      // All four waiters wake together when the shared job rejects. Without the joining loop each starts
+      // its own transfer of the same hash; with it, the first registers a replacement and the rest join.
+      expect(requestCount).toEqual(1)
+    })
+  })
 })

--- a/test/downloadFileJobDeduplication.spec.ts
+++ b/test/downloadFileJobDeduplication.spec.ts
@@ -53,6 +53,61 @@ test('downloadFileWithRetries when the same hash is requested concurrently', ({ 
     })
   })
 
+  describe('and each caller holds a different storage component', () => {
+    let firstStorage: IContentStorageComponent
+    let secondStorage: IContentStorageComponent
+    let baseUrl: string
+
+    beforeEach(async () => {
+      requestCount = 0
+      firstStorage = createInMemoryStorage()
+      secondStorage = createInMemoryStorage()
+      baseUrl = await components.getBaseUrl()
+    })
+
+    it('should not share one job between them, since a job only stores into its own storage', async () => {
+      await Promise.all([
+        downloadFileWithRetries({ storage: firstStorage }, contentHash, resolve('downloads'), [baseUrl], new Map(), 3, 0),
+        downloadFileWithRetries({ storage: secondStorage }, contentHash, resolve('downloads'), [baseUrl], new Map(), 3, 0)
+      ])
+
+      // Sharing would leave the joiner believing the download succeeded while its storage stayed empty.
+      expect([await firstStorage.exist(contentHash), await secondStorage.exist(contentHash)]).toEqual([true, true])
+    })
+
+    it('should transfer the file once per storage', async () => {
+      await Promise.all([
+        downloadFileWithRetries({ storage: firstStorage }, contentHash, resolve('downloads'), [baseUrl], new Map(), 3, 0),
+        downloadFileWithRetries({ storage: secondStorage }, contentHash, resolve('downloads'), [baseUrl], new Map(), 3, 0)
+      ])
+
+      expect(requestCount).toBe(2)
+    })
+  })
+
+  describe('and the job they share fails against its own candidate servers', () => {
+    let storage: IContentStorageComponent
+    let workingServer: string
+    let brokenServer: string
+
+    beforeEach(async () => {
+      requestCount = 0
+      storage = createInMemoryStorage()
+      workingServer = await components.getBaseUrl()
+      // Nothing listens here, so every attempt against it fails.
+      brokenServer = 'http://127.0.0.1:1'
+    })
+
+    it('should let the joining caller retry with its own servers rather than inherit the failure', async () => {
+      const [failing, joining] = await Promise.allSettled([
+        downloadFileWithRetries({ storage }, contentHash, resolve('downloads'), [brokenServer], new Map(), 1, 0),
+        downloadFileWithRetries({ storage }, contentHash, resolve('downloads'), [workingServer], new Map(), 2, 0)
+      ])
+
+      expect([failing.status, joining.status]).toEqual(['rejected', 'fulfilled'])
+    })
+  })
+
   describe('and the target temp folder does not exist yet', () => {
     let storage: IContentStorageComponent
     let baseUrl: string

--- a/test/downloadFileJobDeduplication.spec.ts
+++ b/test/downloadFileJobDeduplication.spec.ts
@@ -108,6 +108,36 @@ test('downloadFileWithRetries when the same hash is requested concurrently', ({ 
     })
   })
 
+  describe('and a caller that fell back settles after a replacement job was registered', () => {
+    let storage: IContentStorageComponent
+    let workingServer: string
+    let brokenServer: string
+
+    beforeEach(async () => {
+      requestCount = 0
+      storage = createInMemoryStorage()
+      workingServer = await components.getBaseUrl()
+      brokenServer = 'http://127.0.0.1:1'
+    })
+
+    it('should not evict the replacement from the in-flight map', async () => {
+      // The failing caller registers first; the joiner falls through and registers its own job. When
+      // the first one finally settles it must clear only its own slot, or a later caller would miss
+      // the replacement and start a duplicate transfer of the same file.
+      await Promise.allSettled([
+        downloadFileWithRetries({ storage }, contentHash, resolve('downloads'), [brokenServer], new Map(), 1, 0),
+        downloadFileWithRetries({ storage }, contentHash, resolve('downloads'), [workingServer], new Map(), 2, 0)
+      ])
+
+      const requestsAfterFirstRound = requestCount
+
+      // Already stored by the successful job, so this must short-circuit rather than transfer again.
+      await downloadFileWithRetries({ storage }, contentHash, resolve('downloads'), [workingServer], new Map(), 2, 0)
+
+      expect(requestCount).toBe(requestsAfterFirstRound)
+    })
+  })
+
   describe('and the target temp folder does not exist yet', () => {
     let storage: IContentStorageComponent
     let baseUrl: string

--- a/test/downloadFileJobDeduplication.spec.ts
+++ b/test/downloadFileJobDeduplication.spec.ts
@@ -1,0 +1,79 @@
+import { createInMemoryStorage, IContentStorageComponent } from '@dcl/catalyst-storage'
+import { createReadStream, mkdirSync, rmSync } from 'fs'
+import { resolve } from 'path'
+import { downloadFileWithRetries } from '../src/downloader'
+import { sleep } from '../src/utils'
+import { test } from './components'
+
+// A real hash-addressed fixture, so the post-download hash check passes.
+const contentHash = 'QmazJLZfUmZgNMTdwWSmJRvw4dBfcjS9GuqkwkKGRWb4K6'
+
+test('downloadFileWithRetries when the same hash is requested concurrently', ({ components }) => {
+  let requestCount: number
+
+  it('prepares the endpoints', () => {
+    requestCount = 0
+    components.router.get('/contents/:file', async (ctx) => {
+      requestCount++
+      // Hold the response open so both callers are in flight at the same time.
+      await sleep(40)
+      return { body: createReadStream('test/fixtures/' + ctx.params.file) }
+    })
+  })
+
+  describe('and both callers target different temp folders', () => {
+    let storage: IContentStorageComponent
+    let baseUrl: string
+
+    beforeEach(async () => {
+      requestCount = 0
+      storage = createInMemoryStorage()
+      baseUrl = await components.getBaseUrl()
+      // Both folders must exist: whichever caller registers the shared job first is the one that
+      // writes, and the assertion should be about the request count, not about a missing directory.
+      mkdirSync(resolve('downloads/nested'), { recursive: true })
+    })
+
+    it('should transfer the file once, because storage is keyed by hash and not by path', async () => {
+      await Promise.all([
+        downloadFileWithRetries({ storage }, contentHash, resolve('downloads'), [baseUrl], new Map(), 3, 0),
+        downloadFileWithRetries({ storage }, contentHash, resolve('downloads/nested'), [baseUrl], new Map(), 3, 0)
+      ])
+
+      expect(requestCount).toBe(1)
+    })
+
+    it('should leave the file available in storage for both callers', async () => {
+      await Promise.all([
+        downloadFileWithRetries({ storage }, contentHash, resolve('downloads'), [baseUrl], new Map(), 3, 0),
+        downloadFileWithRetries({ storage }, contentHash, resolve('downloads/nested'), [baseUrl], new Map(), 3, 0)
+      ])
+
+      expect(await storage.exist(contentHash)).toBe(true)
+    })
+  })
+
+  describe('and the target temp folder does not exist yet', () => {
+    let storage: IContentStorageComponent
+    let baseUrl: string
+    let missingFolder: string
+
+    beforeEach(async () => {
+      requestCount = 0
+      storage = createInMemoryStorage()
+      baseUrl = await components.getBaseUrl()
+      missingFolder = resolve('downloads/does-not-exist-yet/deeper')
+      rmSync(resolve('downloads/does-not-exist-yet'), { recursive: true, force: true })
+    })
+
+    afterEach(() => {
+      rmSync(resolve('downloads/does-not-exist-yet'), { recursive: true, force: true })
+    })
+
+    it('should create the folder instead of failing every download with ENOENT', async () => {
+      await downloadFileWithRetries({ storage }, contentHash, missingFolder, [baseUrl], new Map(), 1, 0)
+
+      expect(await storage.exist(contentHash)).toBe(true)
+    })
+  })
+})

--- a/test/downloadFileWithRedirects.spec.ts
+++ b/test/downloadFileWithRedirects.spec.ts
@@ -23,6 +23,64 @@ test('downloadFile redirect handling', ({ components }) => {
       status: 302,
       headers: { location: 'file:///etc/passwd' }
     }))
+
+    // The other standard redirect codes, all common in front of object storage.
+    components.router.get('/see-other', async () => ({ status: 303, headers: { location: '/target' } }))
+    components.router.get('/temporary', async () => ({ status: 307, headers: { location: '/target' } }))
+    components.router.get('/permanent', async () => ({ status: 308, headers: { location: '/target' } }))
+    components.router.get('/target', async () => ({ body: content.toString() }))
+
+    // 300 carries a list of choices, not the content, and a redirect without a Location is unusable.
+    components.router.get('/multiple-choices', async () => ({ status: 300, body: 'not the content' }))
+    components.router.get('/redirect-without-location', async () => ({ status: 302 }))
+  })
+
+  describe.each([
+    ['303 See Other', '/see-other'],
+    ['307 Temporary Redirect', '/temporary'],
+    ['308 Permanent Redirect', '/permanent']
+  ])('when the server answers with %s', (_label: string, path: string) => {
+    it('should follow it and download the content', async () => {
+      const hash = `redirect${path.replace(/\W/g, '')}`
+      await saveContentFileToDisk(
+        { metrics, storage: components.storage },
+        (await components.getBaseUrl()) + path,
+        resolve(contentFolder, hash),
+        hash,
+        false
+      )
+
+      const stored = await streamToBuffer(await (await components.storage.retrieve(hash))!.asStream())
+      expect(stored).toEqual(content)
+    })
+  })
+
+  describe('when the server answers with 300 Multiple Choices', () => {
+    it('should reject rather than storing the choices document as the content', async () => {
+      await expect(
+        saveContentFileToDisk(
+          { metrics, storage: components.storage },
+          (await components.getBaseUrl()) + '/multiple-choices',
+          resolve(contentFolder, 'multiple-choices'),
+          'multiple-choices',
+          false
+        )
+      ).rejects.toThrow('status: 300')
+    })
+  })
+
+  describe('when a redirect status arrives without a Location header', () => {
+    it('should reject instead of treating the empty body as the content', async () => {
+      await expect(
+        saveContentFileToDisk(
+          { metrics, storage: components.storage },
+          (await components.getBaseUrl()) + '/redirect-without-location',
+          resolve(contentFolder, 'no-location'),
+          'no-location',
+          false
+        )
+      ).rejects.toThrow('status: 302')
+    })
   })
 
   describe('when a relative redirect is followed', () => {

--- a/test/downloadFileWithRedirects.spec.ts
+++ b/test/downloadFileWithRedirects.spec.ts
@@ -33,6 +33,28 @@ test('downloadFile redirect handling', ({ components }) => {
     // 300 carries a list of choices, not the content, and a redirect without a Location is unusable.
     components.router.get('/multiple-choices', async () => ({ status: 300, body: 'not the content' }))
     components.router.get('/redirect-without-location', async () => ({ status: 302 }))
+
+    // A redirect that also carries a sizeable body, which is thrown away rather than read.
+    components.router.get('/redirect-with-body', async () => ({
+      status: 302,
+      headers: { location: '/target' },
+      body: 'x'.repeat(512 * 1024)
+    }))
+  })
+
+  describe('when a redirect response also carries a body', () => {
+    it('should follow it and store the target content, not the discarded redirect body', async () => {
+      await saveContentFileToDisk(
+        { metrics, storage: components.storage },
+        (await components.getBaseUrl()) + '/redirect-with-body',
+        resolve(contentFolder, 'redirect-with-body'),
+        'redirect-with-body',
+        false
+      )
+
+      const stored = await streamToBuffer(await (await components.storage.retrieve('redirect-with-body'))!.asStream())
+      expect(stored).toEqual(content)
+    })
   })
 
   describe.each([

--- a/test/downloadProfileAvatars.spec.ts
+++ b/test/downloadProfileAvatars.spec.ts
@@ -52,6 +52,45 @@ test('downloadEntityAndContentFiles when the profile metadata has a malformed sh
     })
   })
 
+  describe('and the avatar snapshots value is a long string instead of an object', () => {
+    let entityId: string
+    let requestedFiles: number
+
+    beforeEach(async () => {
+      requestedFiles = 0
+      components.router.get('/contents/:file', async () => {
+        requestedFiles++
+        return { body: 'unused' }
+      })
+      entityId = await storeEntity(components.storage, {
+        type: 'profile',
+        // Object.values on a string yields one entry per character, and each single character passes
+        // content-hash validation — so this used to become one queued download per character.
+        metadata: { avatars: [{ avatar: { snapshots: 'a'.repeat(5000) } }] }
+      })
+    })
+
+    it('should return the parsed entity without expanding the string into downloads', async () => {
+      await expect(
+        downloadEntityAndContentFiles(components, entityId, [await components.getBaseUrl()], new Map(), targetFolder, 1, 0)
+      ).resolves.toMatchObject({ type: 'profile' })
+    })
+
+    it('should not request a single content file for it', async () => {
+      await downloadEntityAndContentFiles(
+        components,
+        entityId,
+        [await components.getBaseUrl()],
+        new Map(),
+        targetFolder,
+        1,
+        0
+      )
+
+      expect(requestedFiles).toBe(0)
+    })
+  })
+
   describe('and the avatars property is not an array', () => {
     let entityId: string
 

--- a/test/downloadProfileAvatars.spec.ts
+++ b/test/downloadProfileAvatars.spec.ts
@@ -1,0 +1,164 @@
+import { Readable } from 'stream'
+import { downloadEntityAndContentFiles } from '../src'
+import { hashV1 } from '@dcl/hashing'
+import { test } from './components'
+
+// Builds a stored entity file whose content hash matches its bytes, so downloadEntityAndContentFiles
+// passes the content-hash verification step and reaches the profile-avatar handling under test.
+async function storeEntity(
+  storage: { storeStream(id: string, stream: Readable): Promise<void> },
+  entity: Record<string, unknown>
+): Promise<string> {
+  const bytes = Buffer.from(JSON.stringify(entity))
+  const entityId = await hashV1(bytes)
+  await storage.storeStream(entityId, Readable.from(bytes))
+  return entityId
+}
+
+test('downloadEntityAndContentFiles when the profile metadata has a malformed shape', ({ components }) => {
+  const targetFolder = 'downloads'
+
+  describe('when an avatars entry is missing its `avatar` object', () => {
+    let entityId: string
+
+    beforeEach(async () => {
+      entityId = await storeEntity(components.storage, {
+        type: 'profile',
+        metadata: { avatars: [{ name: 'a-profile-without-an-avatar-object' }] }
+      })
+    })
+
+    it('should return the parsed entity without attempting any avatar download', async () => {
+      await expect(
+        downloadEntityAndContentFiles(components, entityId, [await components.getBaseUrl()], new Map(), targetFolder, 1, 0)
+      ).resolves.toMatchObject({ type: 'profile' })
+    })
+  })
+
+  describe('and the avatar snapshots hold a non-string value', () => {
+    let entityId: string
+
+    beforeEach(async () => {
+      entityId = await storeEntity(components.storage, {
+        type: 'profile',
+        metadata: { avatars: [{ avatar: { snapshots: { body: 12345, face256: null } } }] }
+      })
+    })
+
+    it('should return the parsed entity without attempting any avatar download', async () => {
+      await expect(
+        downloadEntityAndContentFiles(components, entityId, [await components.getBaseUrl()], new Map(), targetFolder, 1, 0)
+      ).resolves.toMatchObject({ type: 'profile' })
+    })
+  })
+
+  describe('and the avatars property is not an array', () => {
+    let entityId: string
+
+    beforeEach(async () => {
+      entityId = await storeEntity(components.storage, {
+        type: 'profile',
+        metadata: { avatars: { body: 'not-an-array' } }
+      })
+    })
+
+    it('should return the parsed entity without attempting any avatar download', async () => {
+      await expect(
+        downloadEntityAndContentFiles(components, entityId, [await components.getBaseUrl()], new Map(), targetFolder, 1, 0)
+      ).resolves.toMatchObject({ type: 'profile' })
+    })
+  })
+
+  describe('and the content property is not an array', () => {
+    let entityId: string
+
+    beforeEach(async () => {
+      entityId = await storeEntity(components.storage, {
+        type: 'profile',
+        metadata: { avatars: [] },
+        content: { file: 'body.png' }
+      })
+    })
+
+    it('should return the parsed entity without throwing on the content iteration', async () => {
+      await expect(
+        downloadEntityAndContentFiles(components, entityId, [await components.getBaseUrl()], new Map(), targetFolder, 1, 0)
+      ).resolves.toMatchObject({ type: 'profile' })
+    })
+  })
+})
+
+test('downloadEntityAndContentFiles when the entity vanishes from storage after the download', ({ components }) => {
+  const targetFolder = 'downloads'
+  const entityId = 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu'
+
+  beforeEach(() => {
+    // The download reports success but the file is not there to read back: a storage-level
+    // inconsistency, not a corrupt file, so it must not be mistaken for a hash failure.
+    jest.spyOn(components.storage, 'retrieve').mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should reject reporting that the entity could not be retrieved', async () => {
+    await expect(
+      downloadEntityAndContentFiles(components, entityId, [await components.getBaseUrl()], new Map(), targetFolder, 1, 0)
+    ).rejects.toThrow(`Entity file ${entityId} could not be retrieved from storage after download`)
+  })
+})
+
+test('downloadEntityAndContentFiles when a profile references an avatar snapshot missing from content', ({
+  components
+}) => {
+  const targetFolder = 'downloads'
+  const snapshotHash = 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu'
+  let entityId: string
+  let requestedFiles: string[]
+
+  beforeEach(async () => {
+    requestedFiles = []
+    entityId = await storeEntity(components.storage, {
+      type: 'profile',
+      metadata: {
+        avatars: [
+          {
+            avatar: {
+              snapshots: {
+                body: `https://peer.decentraland.org/content/contents/${snapshotHash}`,
+                face256: null
+              }
+            }
+          }
+        ]
+      },
+      content: []
+    })
+  })
+
+  it('prepares the endpoints', () => {
+    components.router.get('/contents/:file', async (ctx) => {
+      requestedFiles.push(ctx.params.file)
+      return { body: 'the-file-contents' }
+    })
+  })
+
+  it('should extract the hash from the snapshot URL and download it', async () => {
+    // The snapshot fixture is already in the in-memory storage, so it short-circuits before any
+    // request; delete it first to force the download path that exercises the URL extraction.
+    await components.storage.delete([snapshotHash])
+
+    await downloadEntityAndContentFiles(
+      components,
+      entityId,
+      [await components.getBaseUrl()],
+      new Map(),
+      targetFolder,
+      1,
+      0
+    )
+
+    expect(requestedFiles).toEqual([snapshotHash])
+  })
+})

--- a/test/downloadProfileAvatars.spec.ts
+++ b/test/downloadProfileAvatars.spec.ts
@@ -227,3 +227,97 @@ test('downloadEntityAndContentFiles when a profile references an avatar snapshot
     expect(requestedFiles).toEqual([snapshotHash])
   })
 })
+
+test('downloadEntityAndContentFiles when a profile declares avatar snapshots and a bad content hash', ({
+  components
+}) => {
+  const targetFolder = 'downloads'
+  let requestedFiles: number
+
+  beforeEach(() => {
+    requestedFiles = 0
+    components.router.get('/contents/:file', async () => {
+      requestedFiles++
+      return { body: 'unused' }
+    })
+  })
+
+  it('should reject without spending the avatar budget first', async () => {
+    const entityId = await storeEntity(components.storage, {
+      type: 'profile',
+      metadata: {
+        avatars: [
+          {
+            avatar: {
+              // Deliberately NOT fixture hashes: test-component preloads every fixture into storage, so a
+              // fixture-named snapshot short-circuits on storage.exist and never reaches the network —
+              // which would make this assertion pass whatever the ordering is.
+              snapshots: {
+                body: `ba${'a'.repeat(57)}`,
+                face: `ba${'b'.repeat(57)}`
+              }
+            }
+          }
+        ]
+      },
+      // One unusable required hash means the entity can never be accepted, so none of the avatar
+      // fallback downloads above were ever worth starting.
+      content: [{ file: 'good.png', hash: 'QmazJLZfUmZgNMTdwWSmJRvw4dBfcjS9GuqkwkKGRWb4K6' }, { file: 'evil', hash: '../../etc/passwd' }]
+    })
+
+    await expect(
+      downloadEntityAndContentFiles(components, entityId, [await components.getBaseUrl()], new Map(), targetFolder, 1, 0)
+    ).rejects.toThrow('declares an invalid content file hash')
+
+    expect(requestedFiles).toEqual(0)
+  })
+})
+
+test('downloadEntityAndContentFiles when a profile declares more avatar snapshots than the cap', ({ components }) => {
+  const targetFolder = 'downloads'
+  let warnings: Array<{ message: string; extra?: any }>
+
+  beforeEach(() => {
+    warnings = []
+    components.router.get('/contents/:file', async () => ({ body: 'unused' }))
+    jest.spyOn(components.logs, 'getLogger').mockReturnValue({
+      log: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn((message: string, extra?: any) => warnings.push({ message, extra }))
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should log that the list was truncated, not silently drop the rest', async () => {
+    // 1001 distinct snapshot hashes against a cap of 1000. Without a signal an operator cannot tell this
+    // apart from a profile that simply had nothing missing.
+    const snapshots: Record<string, string> = {}
+    for (let index = 0; index < 1001; index++) {
+      snapshots[`slot${index}`] = `ba${String(index).padStart(57, '0')}`
+    }
+    const entityId = await storeEntity(components.storage, {
+      type: 'profile',
+      metadata: { avatars: [{ avatar: { snapshots } }] },
+      content: []
+    })
+
+    await downloadEntityAndContentFiles(
+      components,
+      entityId,
+      [await components.getBaseUrl()],
+      new Map(),
+      targetFolder,
+      1,
+      0
+    )
+
+    expect(warnings.map((entry) => entry.message)).toContain(
+      'Profile declared more avatar snapshots than will be fetched; the rest were dropped.'
+    )
+  })
+})

--- a/test/downloadProfileAvatars.spec.ts
+++ b/test/downloadProfileAvatars.spec.ts
@@ -111,7 +111,10 @@ test('downloadEntityAndContentFiles when the profile metadata has a malformed sh
   describe.each([
     ['an object', { file: 'body.png' }],
     ['a string', 'body.png'],
-    ['a number', 42]
+    ['a number', 42],
+    // Rejected too: @dcl/schemas declares content as a required array, so a present-but-null field is
+    // not something a conforming server sends, and reading it as "no content" is a guess.
+    ['null', null]
   ])('and the content property is %s rather than an array', (_label: string, content: unknown) => {
     let entityId: string
 
@@ -134,14 +137,12 @@ test('downloadEntityAndContentFiles when the profile metadata has a malformed sh
     })
   })
 
-  describe.each([
-    ['undefined', undefined],
-    ['null', null]
-  ])('and the content property is %s', (_label: string, content: unknown) => {
+  describe('and the content property is absent altogether', () => {
     let entityId: string
 
     beforeEach(async () => {
-      entityId = await storeEntity(components.storage, { type: 'profile', metadata: { avatars: [] }, content })
+      // Absence is the one case that can be read as "no content files" without guessing.
+      entityId = await storeEntity(components.storage, { type: 'profile', metadata: { avatars: [] } })
     })
 
     it('should treat it as an entity with no content files', async () => {

--- a/test/downloadProfileAvatars.spec.ts
+++ b/test/downloadProfileAvatars.spec.ts
@@ -108,18 +108,43 @@ test('downloadEntityAndContentFiles when the profile metadata has a malformed sh
     })
   })
 
-  describe('and the content property is not an array', () => {
+  describe.each([
+    ['an object', { file: 'body.png' }],
+    ['a string', 'body.png'],
+    ['a number', 42]
+  ])('and the content property is %s rather than an array', (_label: string, content: unknown) => {
     let entityId: string
 
     beforeEach(async () => {
       entityId = await storeEntity(components.storage, {
         type: 'profile',
         metadata: { avatars: [] },
-        content: { file: 'body.png' }
+        content
       })
     })
 
-    it('should return the parsed entity without throwing on the content iteration', async () => {
+    // This used to resolve: every reader of content[] guards with Array.isArray and falls back to "no
+    // content", so a malformed manifest was reported as a fully downloaded entity whose dependencies had
+    // never been fetched — and it would then be deployed as complete. Not iterating it is not the same as
+    // there being nothing to iterate.
+    it('should reject rather than reporting an entity with no content files', async () => {
+      await expect(
+        downloadEntityAndContentFiles(components, entityId, [await components.getBaseUrl()], new Map(), targetFolder, 1, 0)
+      ).rejects.toThrow('declares a content field that is not an array')
+    })
+  })
+
+  describe.each([
+    ['undefined', undefined],
+    ['null', null]
+  ])('and the content property is %s', (_label: string, content: unknown) => {
+    let entityId: string
+
+    beforeEach(async () => {
+      entityId = await storeEntity(components.storage, { type: 'profile', metadata: { avatars: [] }, content })
+    })
+
+    it('should treat it as an entity with no content files', async () => {
       await expect(
         downloadEntityAndContentFiles(components, entityId, [await components.getBaseUrl()], new Map(), targetFolder, 1, 0)
       ).resolves.toMatchObject({ type: 'profile' })

--- a/test/downloadRedirectRebinding.spec.ts
+++ b/test/downloadRedirectRebinding.spec.ts
@@ -1,0 +1,98 @@
+import { createTestMetricsComponent } from '@dcl/metrics'
+import { createServer, Server } from 'http'
+import { resolve } from 'path'
+import { metricsDefinitions } from '../src/metrics'
+import { saveContentFileToDisk, sleepUnlessStopped } from '../src/utils'
+
+const metrics = createTestMetricsComponent(metricsDefinitions)
+const contentFolder = resolve('downloads')
+
+// A stand-in storage that records what it was given.
+function recordingStorage() {
+  const stored: string[] = []
+  return {
+    stored,
+    async storeStream(id: string) {
+      stored.push(id)
+    }
+  } as any
+}
+
+describe('downloadFile when a host rebinds between the initial request and a same-host redirect', () => {
+  let server: Server
+  let port: number
+
+  beforeEach(async () => {
+    server = createServer((request, response) => {
+      if (request.url?.startsWith('/start')) {
+        // Same host, same origin — passes every origin and hostname check.
+        response.writeHead(302, { location: `/internal` })
+        response.end()
+        return
+      }
+      response.writeHead(200)
+      response.end('the-internal-response')
+    })
+    await new Promise<void>((ok) => server.listen(0, '127.0.0.1', () => ok()))
+    port = (server.address() as any).port
+  })
+
+  afterEach(async () => {
+    server.closeAllConnections?.()
+    await new Promise<void>((ok) => server.close(() => ok()))
+  })
+
+  describe('and the original host was already a private address', () => {
+    it('should keep working, so loopback-based local development and tests are unaffected', async () => {
+      const storage = recordingStorage()
+
+      await saveContentFileToDisk(
+        { metrics, storage },
+        `http://127.0.0.1:${port}/start`,
+        resolve(contentFolder, 'rebind-local'),
+        'rebind-local',
+        false
+      )
+
+      expect(storage.stored).toEqual(['rebind-local'])
+    })
+  })
+})
+
+describe('sleepUnlessStopped', () => {
+  describe('when the stop signal is never raised', () => {
+    it('should wait for the full duration', async () => {
+      const startedAt = Date.now()
+
+      await sleepUnlessStopped(200, () => false)
+
+      expect(Date.now() - startedAt).toBeGreaterThanOrEqual(190)
+    })
+  })
+
+  describe('when the stop signal is raised while waiting', () => {
+    it('should return well before the full duration', async () => {
+      let stopping = false
+      setTimeout(() => {
+        stopping = true
+      }, 60)
+      const startedAt = Date.now()
+
+      // Without this, every retry backoff and poll interval is added to shutdown latency, because
+      // callers now await the running work instead of only signalling it.
+      await sleepUnlessStopped(3000, () => stopping)
+
+      expect(Date.now() - startedAt).toBeLessThan(1000)
+    })
+  })
+
+  describe('when no stop predicate is supplied', () => {
+    it('should behave like a plain sleep', async () => {
+      const startedAt = Date.now()
+
+      await sleepUnlessStopped(120)
+
+      expect(Date.now() - startedAt).toBeGreaterThanOrEqual(110)
+    })
+  })
+})

--- a/test/downloadRedirectRebinding.spec.ts
+++ b/test/downloadRedirectRebinding.spec.ts
@@ -1,18 +1,24 @@
 import { createTestMetricsComponent } from '@dcl/metrics'
 import { createServer, Server } from 'http'
 import { resolve } from 'path'
+import { Readable } from 'stream'
 import { metricsDefinitions } from '../src/metrics'
-import { saveContentFileToDisk, sleepUnlessStopped } from '../src/utils'
+import { saveContentFileToDisk, sleepUnlessStopped, streamToBuffer } from '../src/utils'
 
 const metrics = createTestMetricsComponent(metricsDefinitions)
 const contentFolder = resolve('downloads')
 
-// A stand-in storage that records what it was given.
+// A stand-in storage that records what it was given. It must *consume* the stream, as a real
+// IContentStorageComponent does: saveContentFileToDisk removes the temp file as soon as storeStream
+// resolves, so a stub that leaves the stream unread lets the file vanish before the lazily-opened
+// ReadStream can open it — an ENOENT that surfaces as an unhandled stream error in whichever test
+// happens to be running by then.
 function recordingStorage() {
   const stored: string[] = []
   return {
     stored,
-    async storeStream(id: string) {
+    async storeStream(id: string, stream: Readable) {
+      await streamToBuffer(stream)
       stored.push(id)
     }
   } as any

--- a/test/downloadRedirectSsrf.spec.ts
+++ b/test/downloadRedirectSsrf.spec.ts
@@ -1,0 +1,84 @@
+import { createTestMetricsComponent } from '@dcl/metrics'
+import { resolve } from 'path'
+import { metricsDefinitions } from '../src/metrics'
+import { isNonPublicAddress, saveContentFileToDisk } from '../src/utils'
+import { test } from './components'
+
+describe('isNonPublicAddress', () => {
+  describe('when the address is reachable only from inside a network', () => {
+    it.each([
+      ['10.0.0.1', 'RFC1918 10/8'],
+      ['172.16.5.4', 'RFC1918 172.16/12'],
+      ['172.31.255.255', 'RFC1918 172.16/12 upper bound'],
+      ['192.168.1.1', 'RFC1918 192.168/16'],
+      ['127.0.0.1', 'loopback'],
+      ['169.254.169.254', 'link-local cloud metadata'],
+      ['0.0.0.0', 'this network'],
+      ['100.64.0.1', 'carrier-grade NAT'],
+      ['224.0.0.1', 'multicast'],
+      ['::1', 'IPv6 loopback'],
+      ['fe80::1', 'IPv6 link-local'],
+      ['fd00::1', 'IPv6 unique local'],
+      ['::ffff:10.0.0.1', 'IPv4-mapped private address']
+    ])('should return true for %s (%s)', (address) => {
+      expect(isNonPublicAddress(address)).toBe(true)
+    })
+  })
+
+  describe('when the address is publicly routable', () => {
+    it.each([['8.8.8.8'], ['1.1.1.1'], ['172.15.0.1'], ['172.32.0.1'], ['192.167.0.1'], ['99.99.99.99'], ['2606:4700::1']])(
+      'should return false for %s',
+      (address) => {
+        expect(isNonPublicAddress(address)).toBe(false)
+      }
+    )
+  })
+})
+
+test('downloadFile when a remote server redirects the download elsewhere', ({ components }) => {
+  const metrics = createTestMetricsComponent(metricsDefinitions)
+  const contentFolder = resolve('downloads')
+
+  it('prepares the endpoints', () => {
+    // The cloud metadata endpoint, as a literal IP. Nothing resolves, so only the direct hostname
+    // check can catch this one.
+    components.router.get('/to-metadata', async () => ({
+      status: 302,
+      headers: { location: 'http://169.254.169.254/latest/meta-data/iam/security-credentials/' }
+    }))
+    // A private address behind a hostname. The test server binds 0.0.0.0, so `localhost` is a
+    // *different* host that resolves to loopback — which is what the DNS guard has to catch.
+    components.router.get('/to-loopback-hostname', async () => ({
+      status: 302,
+      headers: { location: `http://localhost:${new URL(await components.getBaseUrl()).port}/whatever` }
+    }))
+  })
+
+  describe('and the redirect points at a link-local address', () => {
+    it('should refuse to follow it instead of issuing the request', async () => {
+      await expect(
+        saveContentFileToDisk(
+          { metrics, storage: components.storage },
+          (await components.getBaseUrl()) + '/to-metadata',
+          resolve(contentFolder, 'ssrf-metadata'),
+          'ssrf-metadata',
+          false
+        )
+      ).rejects.toThrow('not a public address')
+    })
+  })
+
+  describe('and the redirect points at a hostname that resolves to a private address', () => {
+    it('should refuse to follow it', async () => {
+      await expect(
+        saveContentFileToDisk(
+          { metrics, storage: components.storage },
+          (await components.getBaseUrl()) + '/to-loopback-hostname',
+          resolve(contentFolder, 'ssrf-hostname'),
+          'ssrf-hostname',
+          false
+        )
+      ).rejects.toThrow('not a public address')
+    })
+  })
+})

--- a/test/downloadRedirectSsrf.spec.ts
+++ b/test/downloadRedirectSsrf.spec.ts
@@ -17,9 +17,22 @@ describe('isNonPublicAddress', () => {
       ['100.64.0.1', 'carrier-grade NAT'],
       ['224.0.0.1', 'multicast'],
       ['::1', 'IPv6 loopback'],
+      ['::', 'IPv6 unspecified'],
       ['fe80::1', 'IPv6 link-local'],
+      ['febf::1', 'IPv6 link-local upper bound'],
+      ['fc00::1', 'IPv6 unique local'],
       ['fd00::1', 'IPv6 unique local'],
-      ['::ffff:10.0.0.1', 'IPv4-mapped private address']
+      ['ff02::1', 'IPv6 multicast'],
+      ['::ffff:10.0.0.1', 'IPv4-mapped private address, dotted form'],
+      // WHATWG URL rewrites every IPv4-mapped literal into compressed hex, so these are the forms
+      // that actually reach the guard. Asserting only the dotted form above is what let a bypass
+      // through CI previously.
+      ['::ffff:7f00:1', 'IPv4-mapped 127.0.0.1 as URL emits it'],
+      ['::ffff:a9fe:a9fe', 'IPv4-mapped 169.254.169.254 (cloud metadata) as URL emits it'],
+      ['::ffff:a00:1', 'IPv4-mapped 10.0.0.1 as URL emits it'],
+      ['::7f00:1', 'deprecated IPv4-compatible loopback'],
+      ['0:0:0:0:0:ffff:7f00:1', 'fully expanded IPv4-mapped loopback'],
+      ['not-an-ip', 'unparseable input is refused rather than trusted']
     ])('should return true for %s (%s)', (address) => {
       expect(isNonPublicAddress(address)).toBe(true)
     })
@@ -52,6 +65,13 @@ test('downloadFile when a remote server redirects the download elsewhere', ({ co
       status: 302,
       headers: { location: `http://localhost:${new URL(await components.getBaseUrl()).port}/whatever` }
     }))
+    // The bracketed IPv4-mapped form of 127.0.0.1. URL normalises it to [::ffff:7f00:1].
+    components.router.get('/to-mapped-loopback', async () => ({
+      status: 302,
+      headers: { location: `http://[::ffff:127.0.0.1]:${new URL(await components.getBaseUrl()).port}/whatever` }
+    }))
+    // Location values the URL parser rejects outright.
+    components.router.get('/to-unparseable', async () => ({ status: 302, headers: { location: 'http://[' } }))
   })
 
   describe('and the redirect points at a link-local address', () => {
@@ -79,6 +99,36 @@ test('downloadFile when a remote server redirects the download elsewhere', ({ co
           false
         )
       ).rejects.toThrow('not a public address')
+    })
+  })
+
+  describe('and the redirect uses the IPv4-mapped IPv6 form of a private address', () => {
+    it('should refuse to follow it, not just the dotted-quad spelling', async () => {
+      await expect(
+        saveContentFileToDisk(
+          { metrics, storage: components.storage },
+          (await components.getBaseUrl()) + '/to-mapped-loopback',
+          resolve(contentFolder, 'ssrf-mapped'),
+          'ssrf-mapped',
+          false
+        )
+      ).rejects.toThrow('not a public address')
+    })
+  })
+
+  describe('and the redirect location cannot be parsed as a URL', () => {
+    it('should reject rather than crash the process with an uncaught TypeError', async () => {
+      // The redirect is handled inside the HTTP response listener, so a throw there escapes the
+      // enclosing Promise and becomes an uncaughtException.
+      await expect(
+        saveContentFileToDisk(
+          { metrics, storage: components.storage },
+          (await components.getBaseUrl()) + '/to-unparseable',
+          resolve(contentFolder, 'ssrf-unparseable'),
+          'ssrf-unparseable',
+          false
+        )
+      ).rejects.toThrow('Invalid redirect location')
     })
   })
 })

--- a/test/downloadRedirectSsrf.spec.ts
+++ b/test/downloadRedirectSsrf.spec.ts
@@ -15,6 +15,12 @@ describe('isNonPublicAddress', () => {
       ['169.254.169.254', 'link-local cloud metadata'],
       ['0.0.0.0', 'this network'],
       ['100.64.0.1', 'carrier-grade NAT'],
+      ['192.0.0.1', 'IETF protocol assignments'],
+      ['192.0.2.1', 'IPv4 documentation TEST-NET-1'],
+      ['192.88.99.1', 'deprecated 6to4 relay anycast'],
+      ['198.18.0.1', 'IPv4 benchmarking'],
+      ['198.51.100.1', 'IPv4 documentation TEST-NET-2'],
+      ['203.0.113.1', 'IPv4 documentation TEST-NET-3'],
       ['224.0.0.1', 'multicast'],
       ['::1', 'IPv6 loopback'],
       ['::', 'IPv6 unspecified'],
@@ -23,6 +29,14 @@ describe('isNonPublicAddress', () => {
       ['fc00::1', 'IPv6 unique local'],
       ['fd00::1', 'IPv6 unique local'],
       ['ff02::1', 'IPv6 multicast'],
+      ['64:ff9b:1::1', 'IPv6 local translation'],
+      ['100::1', 'IPv6 discard-only'],
+      ['100:0:0:1::1', 'IPv6 dummy prefix'],
+      ['2001:2::1', 'IPv6 benchmarking'],
+      ['2001:db8::1', 'IPv6 documentation'],
+      ['2002::1', 'IPv6 6to4'],
+      ['3fff::1', 'IPv6 documentation'],
+      ['5f00::1', 'IPv6 segment-routing SIDs'],
       ['::ffff:10.0.0.1', 'IPv4-mapped private address, dotted form'],
       // WHATWG URL rewrites every IPv4-mapped literal into compressed hex, so these are the forms
       // that actually reach the guard. Asserting only the dotted form above is what let a bypass
@@ -39,7 +53,23 @@ describe('isNonPublicAddress', () => {
   })
 
   describe('when the address is publicly routable', () => {
-    it.each([['8.8.8.8'], ['1.1.1.1'], ['172.15.0.1'], ['172.32.0.1'], ['192.167.0.1'], ['99.99.99.99'], ['2606:4700::1']])(
+    it.each([
+      ['8.8.8.8'],
+      ['1.1.1.1'],
+      ['172.15.0.1'],
+      ['172.32.0.1'],
+      ['192.0.0.9'],
+      ['192.0.0.10'],
+      ['192.167.0.1'],
+      ['99.99.99.99'],
+      ['64:ff9b::808:808'],
+      ['2001:1::1'],
+      ['2001:3::1'],
+      ['2001:4:112::1'],
+      ['2001:20::1'],
+      ['2001:30::1'],
+      ['2606:4700::1']
+    ])(
       'should return false for %s',
       (address) => {
         expect(isNonPublicAddress(address)).toBe(false)

--- a/test/downloadRetryServerRotation.spec.ts
+++ b/test/downloadRetryServerRotation.spec.ts
@@ -1,0 +1,78 @@
+import { createInMemoryStorage, IContentStorageComponent } from '@dcl/catalyst-storage'
+import { createReadStream } from 'fs'
+import { resolve } from 'path'
+import { downloadFileWithRetries } from '../src/downloader'
+import { test } from './components'
+
+// A real hash-addressed fixture, so the post-download hash check passes.
+const contentHash = 'QmazJLZfUmZgNMTdwWSmJRvw4dBfcjS9GuqkwkKGRWb4K6'
+
+test('downloadFileWithRetries when the first server it picks fails', ({ components }) => {
+  const targetFolder = resolve('downloads')
+  let requestsPerHost: Map<string, number>
+  let failingHost: string
+
+  it('prepares the endpoints', () => {
+    requestsPerHost = new Map()
+
+    components.router.get('/contents/:file', async (ctx) => {
+      const host = ctx.request.headers.get('host') ?? 'unknown'
+      requestsPerHost.set(host, (requestsPerHost.get(host) ?? 0) + 1)
+      if (host === failingHost) {
+        return { status: 503, body: 'this server is down' }
+      }
+      return { body: createReadStream('test/fixtures/' + ctx.params.file) }
+    })
+  })
+
+  describe('and another server is available', () => {
+    let storage: IContentStorageComponent
+    let servers: string[]
+
+    beforeEach(async () => {
+      storage = createInMemoryStorage()
+      requestsPerHost = new Map()
+      const baseUrl = await components.getBaseUrl()
+      const { host, origin } = new URL(baseUrl)
+      // The same test server under two names, so "another server" is reachable while one host 503s.
+      const alias = origin.replace('0.0.0.0', 'localhost')
+      failingHost = host
+      servers = [baseUrl, alias]
+    })
+
+    it('should retry against the other server and complete the download', async () => {
+      await downloadFileWithRetries({ storage }, contentHash, targetFolder, servers, new Map(), 5, 0)
+
+      expect(await storage.exist(contentHash)).toBe(true)
+    })
+
+    it('should stop retrying the server that failed', async () => {
+      await downloadFileWithRetries({ storage }, contentHash, targetFolder, servers, new Map(), 5, 0)
+
+      // The failing host is dropped from the candidate list after its first failure, so it is asked
+      // at most once no matter how many retries remain.
+      expect(requestsPerHost.get(failingHost) ?? 0).toBeLessThanOrEqual(1)
+    })
+  })
+
+  describe('and it is the only server available', () => {
+    let storage: IContentStorageComponent
+    let servers: string[]
+
+    beforeEach(async () => {
+      storage = createInMemoryStorage()
+      requestsPerHost = new Map()
+      const baseUrl = await components.getBaseUrl()
+      failingHost = new URL(baseUrl).host
+      servers = [baseUrl]
+    })
+
+    it('should keep retrying it and then reject once the retries are exhausted', async () => {
+      await expect(
+        downloadFileWithRetries({ storage }, contentHash, targetFolder, servers, new Map(), 3, 0)
+      ).rejects.toThrow()
+
+      expect(requestsPerHost.get(failingHost)).toBe(3)
+    })
+  })
+})

--- a/test/exponential-fallof-retry.spec.ts
+++ b/test/exponential-fallof-retry.spec.ts
@@ -379,6 +379,66 @@ describe('createExponentialFallofRetry', () => {
     })
   })
 
+  describe.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['not a number', Number.NaN],
+    ['infinite', Number.POSITIVE_INFINITY]
+  ])('when retryTimeExponent is %s', (_description: string, retryTimeExponent: number) => {
+    let logger: any
+
+    beforeEach(async () => {
+      const config = createConfigComponent({})
+      const logs = await createLogComponent({ config })
+      logger = logs.getLogger('logger')
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('should reject it before it can collapse the retry delay into a busy loop', () => {
+      expect(() =>
+        createExponentialFallofRetry(logger, {
+          async action() {},
+          retryTime: 10,
+          retryTimeExponent
+        })
+      ).toThrow('options.retryTimeExponent must be a finite number >= 1')
+    })
+  })
+
+  describe.each([
+    ['retryTime', Number.NaN],
+    ['retryTime', Number.POSITIVE_INFINITY],
+    ['maxInterval', Number.NaN],
+    ['maxInterval', Number.POSITIVE_INFINITY],
+    ['healthyRunTime', Number.NaN],
+    ['healthyRunTime', Number.POSITIVE_INFINITY]
+  ])('when %s is non-finite', (field: string, value: number) => {
+    let logger: any
+
+    beforeEach(async () => {
+      const config = createConfigComponent({})
+      const logs = await createLogComponent({ config })
+      logger = logs.getLogger('logger')
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('should reject it instead of passing it to a timer', () => {
+      expect(() =>
+        createExponentialFallofRetry(logger, {
+          async action() {},
+          retryTime: 10,
+          [field]: value
+        })
+      ).toThrow(`options.${field} must be a finite number`)
+    })
+  })
+
   describe('when start() is called while the component is already running', () => {
     let logger: any
     let attempts: number

--- a/test/exponential-fallof-retry.spec.ts
+++ b/test/exponential-fallof-retry.spec.ts
@@ -73,6 +73,254 @@ describe('createExponentialFallofRetry', () => {
     })
   })
 
+  describe('the retry interval', () => {
+    let logger: any
+    let scheduledIntervals: number[]
+
+    beforeEach(() => {
+      scheduledIntervals = []
+      // The computed interval is only observable through the "Retrying in Xms" line. Reading it is
+      // deterministic, unlike timing the gaps between attempts.
+      logger = {
+        log: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        info: jest.fn((message: string) => {
+          const match = typeof message === 'string' && message.match(/^Retrying in ([\d.]+)ms/)
+          if (match) {
+            scheduledIntervals.push(Number(match[1]))
+          }
+        })
+      }
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    describe('when the action fails repeatedly and then completes successfully', () => {
+      let component: ReturnType<typeof createExponentialFallofRetry>
+      let reachedFourthAttempt: ReturnType<typeof future<void>>
+
+      beforeEach(async () => {
+        reachedFourthAttempt = future<void>()
+        let attempt = 0
+
+        component = createExponentialFallofRetry(logger, {
+          async action() {
+            attempt++
+            if (attempt === 4) {
+              reachedFourthAttempt.resolve()
+              // Hold the loop here so the assertions read a settled list of intervals.
+              await sleep(10_000)
+              return
+            }
+            throw new Error('synthetic failure')
+          },
+          retryTime: 20,
+          retryTimeExponent: 3,
+          maxInterval: 100_000
+        })
+
+        void component.start()
+        await reachedFourthAttempt
+        await component.stop()
+      })
+
+      it('should grow while the action keeps failing', () => {
+        expect(scheduledIntervals.slice(0, 3)).toEqual([60, 180, 540])
+      })
+    })
+
+    describe('and a successful run follows the failures', () => {
+      let component: ReturnType<typeof createExponentialFallofRetry>
+      let reachedFifthAttempt: ReturnType<typeof future<void>>
+
+      beforeEach(async () => {
+        reachedFifthAttempt = future<void>()
+        let attempt = 0
+
+        component = createExponentialFallofRetry(logger, {
+          async action() {
+            attempt++
+            // fail, fail, succeed, then fail again
+            if (attempt === 3) return
+            if (attempt >= 5) {
+              reachedFifthAttempt.resolve()
+              await sleep(10_000)
+              return
+            }
+            throw new Error('synthetic failure')
+          },
+          retryTime: 20,
+          retryTimeExponent: 3,
+          maxInterval: 100_000
+        })
+
+        void component.start()
+        await reachedFifthAttempt
+        await component.stop()
+      })
+
+      it('should drop back to the base interval instead of staying at the grown one', () => {
+        // 60 and 180 from the two failures, then back to 20 after the success, then 60 again.
+        expect(scheduledIntervals.slice(0, 4)).toEqual([60, 180, 20, 60])
+      })
+    })
+
+    describe('and the action fails but had been running for longer than healthyRunTime', () => {
+      let component: ReturnType<typeof createExponentialFallofRetry>
+      let reachedThirdAttempt: ReturnType<typeof future<void>>
+
+      beforeEach(async () => {
+        reachedThirdAttempt = future<void>()
+        let attempt = 0
+
+        component = createExponentialFallofRetry(logger, {
+          async action() {
+            attempt++
+            if (attempt >= 3) {
+              reachedThirdAttempt.resolve()
+              await sleep(10_000)
+              return
+            }
+            // Stays up well past healthyRunTime before failing, like a stream that only ends on error.
+            await sleep(60)
+            throw new Error('synthetic failure after a healthy run')
+          },
+          retryTime: 20,
+          retryTimeExponent: 3,
+          maxInterval: 100_000,
+          healthyRunTime: 40
+        })
+
+        void component.start()
+        await reachedThirdAttempt
+        await component.stop()
+      })
+
+      it('should keep the base interval, so isolated failures after healthy runs do not compound', () => {
+        expect(scheduledIntervals.slice(0, 2)).toEqual([20, 20])
+      })
+    })
+  })
+
+  describe('when retryTime is zero', () => {
+    let logger: any
+    let attempts: number
+
+    beforeEach(async () => {
+      const config = createConfigComponent({})
+      const logs = await createLogComponent({ config })
+      logger = logs.getLogger('logger')
+      attempts = 0
+
+      const component = createExponentialFallofRetry(logger, {
+        async action() {
+          attempts++
+          throw new Error('synthetic failure')
+        },
+        retryTime: 0
+      })
+
+      await component.start()
+    })
+
+    it('should run the action once and stop iterating instead of spinning', () => {
+      expect(attempts).toBe(1)
+    })
+  })
+
+  describe('when maxInterval is negative', () => {
+    let logger: any
+
+    beforeEach(async () => {
+      const config = createConfigComponent({})
+      const logs = await createLogComponent({ config })
+      logger = logs.getLogger('logger')
+    })
+
+    it('should throw at construction time', () => {
+      expect(() =>
+        createExponentialFallofRetry(logger, {
+          async action() {},
+          retryTime: 10,
+          maxInterval: -1
+        })
+      ).toThrow('options.maxInterval must be >= 0')
+    })
+  })
+
+  describe('when retryTime is negative', () => {
+    let logger: any
+
+    beforeEach(async () => {
+      const config = createConfigComponent({})
+      const logs = await createLogComponent({ config })
+      logger = logs.getLogger('logger')
+    })
+
+    it('should throw at construction time rather than busy-spinning on zero-length sleeps', () => {
+      expect(() =>
+        createExponentialFallofRetry(logger, {
+          async action() {},
+          retryTime: -1
+        })
+      ).toThrow('options.retryTime must be >= 0')
+    })
+  })
+
+  describe('when healthyRunTime is negative', () => {
+    let logger: any
+
+    beforeEach(async () => {
+      const config = createConfigComponent({})
+      const logs = await createLogComponent({ config })
+      logger = logs.getLogger('logger')
+    })
+
+    it('should throw at construction time', () => {
+      expect(() =>
+        createExponentialFallofRetry(logger, {
+          async action() {},
+          retryTime: 10,
+          healthyRunTime: -1
+        })
+      ).toThrow('options.healthyRunTime must be >= 0')
+    })
+  })
+
+  describe('when start() is called while the component is already running', () => {
+    let logger: any
+    let attempts: number
+
+    beforeEach(async () => {
+      const config = createConfigComponent({})
+      const logs = await createLogComponent({ config })
+      logger = logs.getLogger('logger')
+      attempts = 0
+
+      const component = createExponentialFallofRetry(logger, {
+        async action() {
+          attempts++
+          await sleep(50)
+        },
+        retryTime: 10_000,
+        exitOnSuccess: true
+      })
+
+      const firstStart = component.start()
+      // A second start() must not begin a parallel loop.
+      const secondStart = component.start()
+      await Promise.all([firstStart, secondStart])
+    })
+
+    it('should not start a second loop', () => {
+      expect(attempts).toBe(1)
+    })
+  })
+
   describe('when the action succeeds and exitOnSuccess is enabled', () => {
     let logger: any
 

--- a/test/exponential-fallof-retry.spec.ts
+++ b/test/exponential-fallof-retry.spec.ts
@@ -39,8 +39,11 @@ describe('createExponentialFallofRetry', () => {
     expect(totalCount).toEqual(10)
     await component.stop()
     await startPromise
-    expect(component.getRetryCount()).toEqual(11)
-    expect(totalCount).toEqual(11)
+    // stop() lands while the loop is in its retry sleep. It used to wake up and run the action one
+    // more time before noticing, because `started` was only re-checked after the action; it is now
+    // re-checked straight after the sleep, so the count stays where it was.
+    expect(component.getRetryCount()).toEqual(10)
+    expect(totalCount).toEqual(10)
   })
 
   describe('when stop() is called while the component is sleeping between retries', () => {
@@ -203,6 +206,35 @@ describe('createExponentialFallofRetry', () => {
       it('should keep the base interval, so isolated failures after healthy runs do not compound', () => {
         expect(scheduledIntervals.slice(0, 2)).toEqual([20, 20])
       })
+    })
+  })
+
+  describe('when start() is called after stop()', () => {
+    let logger: any
+    let attempts: number
+
+    beforeEach(async () => {
+      const config = createConfigComponent({})
+      const logs = await createLogComponent({ config })
+      logger = logs.getLogger('logger')
+      attempts = 0
+    })
+
+    it('should refuse to start, rather than run a loop that can never be stopped again', async () => {
+      const component = createExponentialFallofRetry(logger, {
+        async action() {
+          attempts++
+        },
+        retryTime: 5
+      })
+
+      await component.stop()
+      // Without a terminal stopped flag this resolves never: `started` is false, so the guard lets the
+      // loop in, and its only exit is `if (!started) return` — which start() has just set back to true.
+      await component.start()
+      await sleep(50)
+
+      expect(attempts).toBe(0)
     })
   })
 

--- a/test/exponential-fallof-retry.spec.ts
+++ b/test/exponential-fallof-retry.spec.ts
@@ -172,6 +172,62 @@ describe('createExponentialFallofRetry', () => {
       })
     })
 
+    describe('and retryTime is longer than the default one-day ceiling', () => {
+      let component: ReturnType<typeof createExponentialFallofRetry>
+      let firstActionFinished: ReturnType<typeof future<void>>
+      const fourteenDays: number = 86_400_000 * 14
+
+      beforeEach(async () => {
+        firstActionFinished = future<void>()
+
+        component = createExponentialFallofRetry(logger, {
+          async action() {
+            firstActionFinished.resolve()
+          },
+          // Mirrors the synchronizer's post-bootstrap snapshot re-sync, which sets no maxInterval.
+          retryTime: fourteenDays,
+          retryTimeExponent: 1
+        })
+
+        void component.start()
+        await firstActionFinished
+        // The interval is logged synchronously once the action settles, before the sleep starts.
+        await sleep(10)
+        await component.stop()
+      })
+
+      it('should schedule the configured interval rather than truncating it to one day', () => {
+        expect(scheduledIntervals[0]).toEqual(fourteenDays)
+      })
+    })
+
+    describe('and maxInterval is shorter than the configured retryTime', () => {
+      let component: ReturnType<typeof createExponentialFallofRetry>
+      let firstActionFinished: ReturnType<typeof future<void>>
+
+      beforeEach(async () => {
+        firstActionFinished = future<void>()
+
+        component = createExponentialFallofRetry(logger, {
+          async action() {
+            firstActionFinished.resolve()
+          },
+          retryTime: 50_000,
+          retryTimeExponent: 1,
+          maxInterval: 1_000
+        })
+
+        void component.start()
+        await firstActionFinished
+        await sleep(10)
+        await component.stop()
+      })
+
+      it('should still schedule the configured retryTime, since the ceiling only bounds growth', () => {
+        expect(scheduledIntervals[0]).toEqual(50_000)
+      })
+    })
+
     describe('and the action fails but had been running for longer than healthyRunTime', () => {
       let component: ReturnType<typeof createExponentialFallofRetry>
       let reachedThirdAttempt: ReturnType<typeof future<void>>

--- a/test/fetchJson.spec.ts
+++ b/test/fetchJson.spec.ts
@@ -1,0 +1,59 @@
+import { fetchJson } from '../src/utils'
+import { test } from './components'
+
+test('fetchJson', ({ components }) => {
+  it('prepares the endpoints', () => {
+    components.router.get('/empty', async (): Promise<any> => ({ status: 204 }))
+    components.router.get('/not-found', async (): Promise<any> => ({ status: 404, body: 'nope' }))
+    components.router.get('/server-error', async (): Promise<any> => ({ status: 500, body: 'boom' }))
+    components.router.get('/ok', async (): Promise<any> => ({ body: { hello: 'world' } }))
+  })
+
+  describe('when the response has no body', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+    })
+
+    it('should reject reporting the empty body rather than a JSON parse error', async () => {
+      await expect(fetchJson(`${baseUrl}/empty`, components.fetcher)).rejects.toThrow('The response body was empty')
+    })
+  })
+
+  describe('when the server answers with a client error', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+    })
+
+    it('should reject reporting the status code', async () => {
+      await expect(fetchJson(`${baseUrl}/not-found`, components.fetcher)).rejects.toThrow('Status code was: 404')
+    })
+  })
+
+  describe('when the server answers with a server error', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+    })
+
+    it('should reject reporting the status code', async () => {
+      await expect(fetchJson(`${baseUrl}/server-error`, components.fetcher)).rejects.toThrow('Status code was: 500')
+    })
+  })
+
+  describe('when the server answers with a JSON document', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+    })
+
+    it('should resolve with the parsed body', async () => {
+      await expect(fetchJson(`${baseUrl}/ok`, components.fetcher)).resolves.toEqual({ hello: 'world' })
+    })
+  })
+})

--- a/test/fetchJsonPaginated.spec.ts
+++ b/test/fetchJsonPaginated.spec.ts
@@ -417,4 +417,50 @@ test('fetchJsonPaginated when the server returns a malformed or endless feed', (
       expect(pagesServed).toBeLessThanOrEqual(2)
     })
   })
+  describe('and the initial url carries a fragment', () => {
+    let baseUrl: string
+    let pagesServed: number
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+      pagesServed = 0
+      // Points `next` at the same resource without a fragment. Unless the initial url is normalised the
+      // same way `next` is, page 1 is remembered as the fragment-bearing string and this reads as new.
+      components.router.get('/initial-fragment', async (): Promise<any> => {
+        pagesServed++
+        return { body: { deltas: [`page${pagesServed}`], pagination: { next: '?page=1' } } }
+      })
+    })
+
+    // Named for the outcome rather than the mechanism: without normalisation the loop is still caught,
+    // just one wasted fetch later, so this assertion holds either way. The fetch count below is the one
+    // that discriminates.
+    it('should still end in a detected loop rather than running to the page cap', async () => {
+      await expect(
+        drain(
+          fetchJsonPaginated(
+            components,
+            `${baseUrl}/initial-fragment?page=1#top`,
+            ($) => $.deltas,
+            'dcl_catalysts_pointer_changes_response_time_seconds'
+          )
+        )
+      ).rejects.toThrow('Pagination loop')
+    })
+
+    it('should fetch the page once rather than twice', async () => {
+      await expect(
+        drain(
+          fetchJsonPaginated(
+            components,
+            `${baseUrl}/initial-fragment?page=1#top`,
+            ($) => $.deltas,
+            'dcl_catalysts_pointer_changes_response_time_seconds'
+          )
+        )
+      ).rejects.toThrow()
+
+      expect(pagesServed).toEqual(1)
+    })
+  })
 })

--- a/test/fetchJsonPaginated.spec.ts
+++ b/test/fetchJsonPaginated.spec.ts
@@ -374,4 +374,47 @@ test('fetchJsonPaginated when the server returns a malformed or endless feed', (
       expect(elements).toEqual(['only'])
     })
   })
+  describe('and the pagination link differs from the current page only by fragment', () => {
+    let baseUrl: string
+    let pagesServed: number
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+      pagesServed = 0
+      // Fragments are never sent to a server, so every one of these fetches the same network resource —
+      // but as distinct strings they used to slip past the visited-URL check.
+      components.router.get('/fragment-loop', async (): Promise<any> => {
+        pagesServed++
+        return { body: { deltas: [], pagination: { next: `?page=1#frag${pagesServed}` } } }
+      })
+    })
+
+    it('should detect it as a loop instead of re-fetching the same page', async () => {
+      await expect(
+        drain(
+          fetchJsonPaginated(
+            components,
+            `${baseUrl}/fragment-loop?page=1`,
+            ($) => $.deltas,
+            'dcl_catalysts_pointer_changes_response_time_seconds'
+          )
+        )
+      ).rejects.toThrow('Pagination loop')
+    })
+
+    it('should stop after re-fetching it at most once, not up to the page cap', async () => {
+      await expect(
+        drain(
+          fetchJsonPaginated(
+            components,
+            `${baseUrl}/fragment-loop?page=1`,
+            ($) => $.deltas,
+            'dcl_catalysts_pointer_changes_response_time_seconds'
+          )
+        )
+      ).rejects.toThrow()
+
+      expect(pagesServed).toBeLessThanOrEqual(2)
+    })
+  })
 })

--- a/test/fetchJsonPaginated.spec.ts
+++ b/test/fetchJsonPaginated.spec.ts
@@ -262,4 +262,62 @@ test('fetchJsonPaginated when the server returns a malformed or endless feed', (
       expect(elements).toEqual(['first', 'second'])
     })
   })
+  describe.each([
+    ['a number', 123],
+    ['an object', { href: '/next' }],
+    ['a boolean', true]
+  ])('and the pagination link is %s instead of a string', (_label: string, next: unknown) => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+      components.router.get('/wrong-typed-next', async (): Promise<any> => ({
+        body: { deltas: ['only'], pagination: { next } }
+      }))
+    })
+
+    it('should reject rather than read it as the end of the feed', async () => {
+      // Every other malformed link here already fails — too long, unparseable, cross-origin,
+      // path-changing. Treating a wrong type as an ending made a truncated feed indistinguishable from a
+      // complete one.
+      await expect(
+        drain(
+          fetchJsonPaginated(
+            components,
+            `${baseUrl}/wrong-typed-next`,
+            ($) => $.deltas,
+            'dcl_catalysts_pointer_changes_response_time_seconds'
+          )
+        )
+      ).rejects.toThrow('expected a string')
+    })
+  })
+
+  describe.each([
+    ['absent', undefined],
+    ['null', null],
+    ['an empty string', '']
+  ])('and the pagination link is %s', (_label: string, next: unknown) => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+      components.router.get('/no-next', async (): Promise<any> => ({
+        body: { deltas: ['only'], pagination: { next } }
+      }))
+    })
+
+    it('should treat it as the end of the feed', async () => {
+      const elements = await drain(
+        fetchJsonPaginated(
+          components,
+          `${baseUrl}/no-next`,
+          ($) => $.deltas,
+          'dcl_catalysts_pointer_changes_response_time_seconds'
+        )
+      )
+
+      expect(elements).toEqual(['only'])
+    })
+  })
 })

--- a/test/fetchJsonPaginated.spec.ts
+++ b/test/fetchJsonPaginated.spec.ts
@@ -114,6 +114,34 @@ test('fetchJsonPaginated when the server returns a malformed or endless feed', (
     })
   })
 
+  describe('and the pagination link points at another origin', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+      // A remote server steering us at an internal address, using this process as the client.
+      components.router.get('/cross-origin', async (): Promise<any> => ({
+        body: {
+          deltas: [],
+          pagination: { next: 'http://169.254.169.254/latest/meta-data/' }
+        }
+      }))
+    })
+
+    it('should refuse to follow it rather than issue a request to that host', async () => {
+      await expect(
+        drain(
+          fetchJsonPaginated(
+            components,
+            `${baseUrl}/cross-origin`,
+            ($) => $.deltas,
+            'dcl_catalysts_pointer_changes_response_time_seconds'
+          )
+        )
+      ).rejects.toThrow('Refusing to follow a cross-origin pagination link')
+    })
+  })
+
   describe('and the response carries no pagination key at all', () => {
     let baseUrl: string
 

--- a/test/fetchJsonPaginated.spec.ts
+++ b/test/fetchJsonPaginated.spec.ts
@@ -320,4 +320,58 @@ test('fetchJsonPaginated when the server returns a malformed or endless feed', (
       expect(elements).toEqual(['only'])
     })
   })
+  describe.each([
+    ['true', true],
+    ['a string', 'more'],
+    ['a number', 42],
+    ['an array', ['?from=2']]
+  ])('and the pagination container is %s instead of an object', (_label: string, pagination: unknown) => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+      components.router.get('/wrong-typed-pagination', async (): Promise<any> => ({
+        body: { deltas: ['only'], pagination }
+      }))
+    })
+
+    it('should reject rather than reading a container it cannot parse as the end of the feed', async () => {
+      // Reading `.next` off `true` or `"more"` yields undefined, which the truthiness check then ended the
+      // feed on — the same "a shape we cannot read means there is no more" hazard as a wrong-typed link.
+      await expect(
+        drain(
+          fetchJsonPaginated(
+            components,
+            `${baseUrl}/wrong-typed-pagination`,
+            ($) => $.deltas,
+            'dcl_catalysts_pointer_changes_response_time_seconds'
+          )
+        )
+      ).rejects.toThrow('expected an object')
+    })
+  })
+
+  describe('and the pagination container is an empty object', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+      components.router.get('/empty-pagination', async (): Promise<any> => ({
+        body: { deltas: ['only'], pagination: {} }
+      }))
+    })
+
+    it('should treat it as the end of the feed, which is how a real last page looks', async () => {
+      const elements = await drain(
+        fetchJsonPaginated(
+          components,
+          `${baseUrl}/empty-pagination`,
+          ($) => $.deltas,
+          'dcl_catalysts_pointer_changes_response_time_seconds'
+        )
+      )
+
+      expect(elements).toEqual(['only'])
+    })
+  })
 })

--- a/test/fetchJsonPaginated.spec.ts
+++ b/test/fetchJsonPaginated.spec.ts
@@ -20,14 +20,11 @@ test('fetchJsonPaginated when the server returns a malformed or endless feed', (
       pagesServed++
       return { body: { deltas: [], pagination: { next: '/endless' } } }
     })
-    // Two pages that point at each other.
-    components.router.get('/cycle-a', async (): Promise<any> => {
+    // Two pages that point at each other. They differ only by query string, because a `next` that
+    // changes the path is refused before the cycle detection could ever see it.
+    components.router.get('/cycle', async (): Promise<any> => {
       pagesServed++
-      return { body: { deltas: [], pagination: { next: '/cycle-b' } } }
-    })
-    components.router.get('/cycle-b', async (): Promise<any> => {
-      pagesServed++
-      return { body: { deltas: [], pagination: { next: '/cycle-a' } } }
+      return { body: { deltas: [], pagination: { next: pagesServed % 2 === 1 ? '?p=b' : '?p=a' } } }
     })
     components.router.get('/null-deltas', async (): Promise<any> => ({ body: { deltas: null, pagination: {} } }))
     components.router.get('/null-body', async (): Promise<any> => ({
@@ -75,7 +72,14 @@ test('fetchJsonPaginated when the server returns a malformed or endless feed', (
 
     it('should detect the cycle after revisiting the first page', async () => {
       await expect(
-        drain(fetchJsonPaginated(components, `${baseUrl}/cycle-a`, ($) => $.deltas, 'dcl_catalysts_pointer_changes_response_time_seconds'))
+        drain(
+          fetchJsonPaginated(
+            components,
+            `${baseUrl}/cycle?p=a`,
+            ($) => $.deltas,
+            'dcl_catalysts_pointer_changes_response_time_seconds'
+          )
+        )
       ).rejects.toThrow('Pagination loop')
 
       expect(pagesServed).toBe(2)
@@ -139,6 +143,84 @@ test('fetchJsonPaginated when the server returns a malformed or endless feed', (
           )
         )
       ).rejects.toThrow('Refusing to follow a cross-origin pagination link')
+    })
+  })
+
+  describe('and the pagination link keeps the origin but points at another path', () => {
+    let baseUrl: string
+    let pivotWasRequested: boolean
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+      pivotWasRequested = false
+      // Same host and port, so the origin check passes. This is what a hostile server needs in order to
+      // aim a rebound address at an endpoint of its choosing rather than the one we meant to poll:
+      // rebinding itself cannot be defended against on this path (IFetchComponent exposes no DNS
+      // lookup), but the path is ours to hold fixed.
+      components.router.get('/path-pivot', async (): Promise<any> => ({
+        body: { deltas: [], pagination: { next: '/internal-admin?x=1' } }
+      }))
+      components.router.get('/internal-admin', async (): Promise<any> => {
+        pivotWasRequested = true
+        return { body: { deltas: [], pagination: {} } }
+      })
+    })
+
+    it('should refuse to follow it', async () => {
+      await expect(
+        drain(
+          fetchJsonPaginated(
+            components,
+            `${baseUrl}/path-pivot`,
+            ($) => $.deltas,
+            'dcl_catalysts_pointer_changes_response_time_seconds'
+          )
+        )
+      ).rejects.toThrow('Refusing to follow a pagination link that changes the path')
+    })
+
+    it('should never issue a request to the path the server chose', async () => {
+      await expect(
+        drain(
+          fetchJsonPaginated(
+            components,
+            `${baseUrl}/path-pivot`,
+            ($) => $.deltas,
+            'dcl_catalysts_pointer_changes_response_time_seconds'
+          )
+        )
+      ).rejects.toThrow()
+
+      expect(pivotWasRequested).toBe(false)
+    })
+  })
+
+  describe('and the pagination link varies only the query string', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+      pagesServed = 0
+      // The shape real catalysts return: `?from=…&entityId=…` against the same endpoint.
+      components.router.get('/query-only', async (): Promise<any> => {
+        pagesServed++
+        return pagesServed === 1
+          ? { body: { deltas: ['page1'], pagination: { next: '?from=11&entityId=ba00' } } }
+          : { body: { deltas: ['page2'], pagination: {} } }
+      })
+    })
+
+    it('should follow it, since pagination legitimately only moves the query', async () => {
+      const elements = await drain(
+        fetchJsonPaginated(
+          components,
+          `${baseUrl}/query-only?from=0`,
+          ($) => $.deltas,
+          'dcl_catalysts_pointer_changes_response_time_seconds'
+        )
+      )
+
+      expect(elements).toEqual(['page1', 'page2'])
     })
   })
 

--- a/test/fetchJsonPaginated.spec.ts
+++ b/test/fetchJsonPaginated.spec.ts
@@ -1,0 +1,155 @@
+import { fetchJsonPaginated } from '../src/client'
+import { test } from './components'
+
+async function drain<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const collected: T[] = []
+  for await (const element of iterable) {
+    collected.push(element)
+  }
+  return collected
+}
+
+test('fetchJsonPaginated when the server returns a malformed or endless feed', ({ components }) => {
+  let pagesServed: number
+
+  it('prepares the endpoints', () => {
+    pagesServed = 0
+
+    // Points `next` back at itself, so a caller that trusts the link paginates forever.
+    components.router.get('/endless', async (): Promise<any> => {
+      pagesServed++
+      return { body: { deltas: [], pagination: { next: '/endless' } } }
+    })
+    // Two pages that point at each other.
+    components.router.get('/cycle-a', async (): Promise<any> => {
+      pagesServed++
+      return { body: { deltas: [], pagination: { next: '/cycle-b' } } }
+    })
+    components.router.get('/cycle-b', async (): Promise<any> => {
+      pagesServed++
+      return { body: { deltas: [], pagination: { next: '/cycle-a' } } }
+    })
+    components.router.get('/null-deltas', async (): Promise<any> => ({ body: { deltas: null, pagination: {} } }))
+    components.router.get('/null-body', async (): Promise<any> => ({
+      body: 'null',
+      headers: { 'content-type': 'application/json' }
+    }))
+    components.router.get('/two-pages', async (): Promise<any> => {
+      pagesServed++
+      return pagesServed === 1
+        ? { body: { deltas: ['first'], pagination: { next: '/two-pages?page=2' } } }
+        : { body: { deltas: ['second'], pagination: {} } }
+    })
+  })
+
+  describe('when a page links back to itself', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      pagesServed = 0
+      baseUrl = await components.getBaseUrl()
+    })
+
+    it('should reject with a pagination loop error instead of fetching forever', async () => {
+      await expect(
+        drain(fetchJsonPaginated(components, `${baseUrl}/endless`, ($) => $.deltas, 'dcl_catalysts_pointer_changes_response_time_seconds'))
+      ).rejects.toThrow('Pagination loop')
+    })
+
+    it('should stop after serving only the first page', async () => {
+      await expect(
+        drain(fetchJsonPaginated(components, `${baseUrl}/endless`, ($) => $.deltas, 'dcl_catalysts_pointer_changes_response_time_seconds'))
+      ).rejects.toThrow()
+
+      expect(pagesServed).toBe(1)
+    })
+  })
+
+  describe('and two pages point at each other', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      pagesServed = 0
+      baseUrl = await components.getBaseUrl()
+    })
+
+    it('should detect the cycle after revisiting the first page', async () => {
+      await expect(
+        drain(fetchJsonPaginated(components, `${baseUrl}/cycle-a`, ($) => $.deltas, 'dcl_catalysts_pointer_changes_response_time_seconds'))
+      ).rejects.toThrow('Pagination loop')
+
+      expect(pagesServed).toBe(2)
+    })
+  })
+
+  describe('and the element list is not an array', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+    })
+
+    it('should reject naming the expected shape instead of throwing a TypeError', async () => {
+      await expect(
+        drain(
+          fetchJsonPaginated(components, `${baseUrl}/null-deltas`, ($) => $.deltas, 'dcl_catalysts_pointer_changes_response_time_seconds')
+        )
+      ).rejects.toThrow('expected an array of elements')
+    })
+  })
+
+  describe('and the body is a bare null document', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+    })
+
+    it('should reject naming the expected shape instead of throwing a TypeError', async () => {
+      await expect(
+        drain(
+          fetchJsonPaginated(components, `${baseUrl}/null-body`, ($) => $.deltas, 'dcl_catalysts_pointer_changes_response_time_seconds')
+        )
+      ).rejects.toThrow('expected a JSON object')
+    })
+  })
+
+  describe('and the response carries no pagination key at all', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+      components.router.get('/no-pagination', async (): Promise<any> => ({ body: { deltas: ['only'] } }))
+    })
+
+    it('should yield its elements and stop after the single page', async () => {
+      const elements = await drain(
+        fetchJsonPaginated(
+          components,
+          `${baseUrl}/no-pagination`,
+          ($) => $.deltas,
+          'dcl_catalysts_pointer_changes_response_time_seconds'
+        )
+      )
+
+      expect(elements).toEqual(['only'])
+    })
+  })
+
+  describe('and the feed paginates normally', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      pagesServed = 0
+      baseUrl = await components.getBaseUrl()
+    })
+
+    it('should still follow every distinct page and yield all elements', async () => {
+      const elements = await drain(
+        fetchJsonPaginated(components, `${baseUrl}/two-pages`, ($) => $.deltas, 'dcl_catalysts_pointer_changes_response_time_seconds')
+      )
+
+      expect(elements).toEqual(['first', 'second'])
+    })
+  })
+})

--- a/test/fetchJsonRedirectsAndStalls.spec.ts
+++ b/test/fetchJsonRedirectsAndStalls.spec.ts
@@ -38,23 +38,43 @@ test('fetchJson redirect handling', ({ components }) => {
     it('should refuse to follow it instead of returning the other origin body', async () => {
       await expect(
         fetchJson(`${await components.getBaseUrl()}/redirect-to-internal`, components.fetcher)
-      ).rejects.toThrow('Refusing to follow a cross-origin redirect')
+      ).rejects.toThrow('Refusing to follow a redirect')
     })
   })
 
   describe('when a server redirects within its own origin', () => {
-    it('should follow it and return the final body', async () => {
+    it('should refuse to follow it as well', async () => {
+      // Same-origin is not safe either: a URL origin is a hostname, not an address, so a hostile host
+      // can answer the first request from a public IP and rebind that same hostname to loopback before
+      // the redirect is fetched. `IFetchComponent` gives no way to pin the request's own DNS
+      // resolution, so the only complete answer on this path is to not follow redirects at all.
       await expect(
         fetchJson(`${await components.getBaseUrl()}/redirect-same-origin`, components.fetcher)
-      ).resolves.toEqual({ followed: true })
+      ).rejects.toThrow('Refusing to follow a redirect')
+    })
+
+    it('should not fetch the redirect target', async () => {
+      // Proven by the target being a distinct route: if it had been followed the call would have
+      // resolved with its body instead of rejecting.
+      await expect(
+        fetchJson(`${await components.getBaseUrl()}/redirect-same-origin`, components.fetcher)
+      ).rejects.toThrow()
     })
   })
 
   describe('when a redirect response carries no location header', () => {
-    it('should reject naming the missing location', async () => {
+    it('should still reject rather than treat it as a normal response', async () => {
       await expect(
         fetchJson(`${await components.getBaseUrl()}/redirect-without-location`, components.fetcher)
-      ).rejects.toThrow('without a location')
+      ).rejects.toThrow('Refusing to follow a redirect')
+    })
+  })
+
+  describe('when the response is a normal success', () => {
+    it('should be unaffected by the redirect refusal', async () => {
+      await expect(
+        fetchJson(`${await components.getBaseUrl()}/redirect-target`, components.fetcher)
+      ).resolves.toEqual({ followed: true })
     })
   })
 })

--- a/test/fetchJsonRedirectsAndStalls.spec.ts
+++ b/test/fetchJsonRedirectsAndStalls.spec.ts
@@ -59,32 +59,73 @@ test('fetchJson redirect handling', ({ components }) => {
   })
 })
 
-describe('fetchJson when a server sends headers and then stops sending the body', () => {
-  let stalledServer: Server
-  let stalledUrl: string
+describe('fetchJson body read deadline', () => {
+  let server: Server
+  let baseUrl: string
+  // Streams `chunks` slices of a valid JSON document, `gapMs` apart, then closes.
+  let chunks: string[]
+  let gapMs: number
+  // When true the server sends one chunk and then goes silent without closing the socket.
+  let stallForever: boolean
 
   beforeEach(async () => {
-    stalledServer = createServer((_request, response) => {
+    chunks = []
+    gapMs = 0
+    stallForever = false
+
+    server = createServer(async (_request, response) => {
       response.writeHead(200, { 'content-type': 'application/json' })
-      // A partial document, then silence — the socket is never closed.
-      response.write('{"deltas":[')
+      if (stallForever) {
+        response.write('{"deltas":[')
+        return
+      }
+      for (const chunk of chunks) {
+        response.write(chunk)
+        await new Promise((ok) => setTimeout(ok, gapMs))
+      }
+      response.end()
     })
-    await new Promise<void>((ok) => stalledServer.listen(0, '127.0.0.1', () => ok()))
-    stalledUrl = `http://127.0.0.1:${(stalledServer.address() as any).port}/stalled`
+    await new Promise<void>((ok) => server.listen(0, '127.0.0.1', () => ok()))
+    baseUrl = `http://127.0.0.1:${(server.address() as any).port}/body`
   })
 
   afterEach(async () => {
-    stalledServer.closeAllConnections?.()
-    await new Promise<void>((ok) => stalledServer.close(() => ok()))
+    server.closeAllConnections?.()
+    await new Promise<void>((ok) => server.close(() => ok()))
   })
 
-  it('should time out reading the body rather than hanging forever', async () => {
-    // The fetch component's own timeout only bounds time-to-headers, so without a deadline on the body
-    // read this promise never settles — and a pending promise never reaches the reconnection logic.
-    const { createFetchComponent } = await import('@dcl/fetch-component')
+  describe('when the server sends headers and then stops sending the body', () => {
+    beforeEach(() => {
+      stallForever = true
+    })
 
-    await expect(fetchJson(stalledUrl, createFetchComponent(), { timeout: 500 })).rejects.toThrow(
-      'while reading the response body'
-    )
+    it('should reject once no data has arrived for the timeout', async () => {
+      // The fetch component's own timeout only bounds time-to-headers, so without a deadline here the
+      // promise never settles — and a pending promise never reaches the reconnection logic.
+      const { createFetchComponent } = await import('@dcl/fetch-component')
+
+      await expect(fetchJson(baseUrl, createFetchComponent(), { timeout: 400 })).rejects.toThrow(
+        'without receiving response body data'
+      )
+    })
+  })
+
+  describe('when the server streams slowly but keeps making progress', () => {
+    beforeEach(() => {
+      // Six chunks 150ms apart is ~900ms of streaming, well past the 400ms timeout, but the gap between
+      // chunks never reaches it.
+      chunks = ['{"del', 'tas":', '[1,', '2,', '3]', '}']
+      gapMs = 150
+    })
+
+    it('should complete rather than abort a healthy slow transfer', async () => {
+      // A total deadline instead of an inactivity one would reject this — which is what would break
+      // bootstrap against a slow-but-healthy content server serving a large snapshot list.
+      const { createFetchComponent } = await import('@dcl/fetch-component')
+
+      await expect(fetchJson(baseUrl, createFetchComponent(), { timeout: 400 })).resolves.toEqual({
+        deltas: [1, 2, 3]
+      })
+    })
   })
 })

--- a/test/fetchJsonRedirectsAndStalls.spec.ts
+++ b/test/fetchJsonRedirectsAndStalls.spec.ts
@@ -112,10 +112,11 @@ describe('fetchJson body read deadline', () => {
 
   describe('when the server streams slowly but keeps making progress', () => {
     beforeEach(() => {
-      // Six chunks 150ms apart is ~900ms of streaming, well past the 400ms timeout, but the gap between
-      // chunks never reaches it.
+      // Six chunks 100ms apart is ~600ms of streaming, comfortably past the 1000ms timeout in total,
+      // while each individual gap stays an order of magnitude below it — so a loaded CI runner
+      // stretching a gap cannot turn this into a false failure.
       chunks = ['{"del', 'tas":', '[1,', '2,', '3]', '}']
-      gapMs = 150
+      gapMs = 100
     })
 
     it('should complete rather than abort a healthy slow transfer', async () => {
@@ -123,7 +124,7 @@ describe('fetchJson body read deadline', () => {
       // bootstrap against a slow-but-healthy content server serving a large snapshot list.
       const { createFetchComponent } = await import('@dcl/fetch-component')
 
-      await expect(fetchJson(baseUrl, createFetchComponent(), { timeout: 400 })).resolves.toEqual({
+      await expect(fetchJson(baseUrl, createFetchComponent(), { timeout: 1000 })).resolves.toEqual({
         deltas: [1, 2, 3]
       })
     })

--- a/test/fetchJsonRedirectsAndStalls.spec.ts
+++ b/test/fetchJsonRedirectsAndStalls.spec.ts
@@ -1,0 +1,90 @@
+import { createServer, Server } from 'http'
+import { fetchJson } from '../src/utils'
+import { test } from './components'
+
+test('fetchJson redirect handling', ({ components }) => {
+  // A second server on loopback stands in for an internal service the syncing process should never be
+  // steered at by a remote content server.
+  let internalServer: Server
+  let internalUrl: string
+
+  beforeAll(async () => {
+    internalServer = createServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' })
+      response.end(JSON.stringify({ internal: 'a-secret-only-reachable-from-inside' }))
+    })
+    await new Promise<void>((ok) => internalServer.listen(0, '127.0.0.1', () => ok()))
+    internalUrl = `http://127.0.0.1:${(internalServer.address() as any).port}/metadata`
+  })
+
+  afterAll(async () => {
+    await new Promise<void>((ok) => internalServer.close(() => ok()))
+  })
+
+  it('prepares the endpoints', () => {
+    components.router.get('/redirect-to-internal', async (): Promise<any> => ({
+      status: 302,
+      headers: { location: internalUrl }
+    }))
+    components.router.get('/redirect-same-origin', async (): Promise<any> => ({
+      status: 302,
+      headers: { location: '/redirect-target' }
+    }))
+    components.router.get('/redirect-target', async (): Promise<any> => ({ body: { followed: true } }))
+    components.router.get('/redirect-without-location', async (): Promise<any> => ({ status: 302 }))
+  })
+
+  describe('when a server redirects the request to another origin', () => {
+    it('should refuse to follow it instead of returning the other origin body', async () => {
+      await expect(
+        fetchJson(`${await components.getBaseUrl()}/redirect-to-internal`, components.fetcher)
+      ).rejects.toThrow('Refusing to follow a cross-origin redirect')
+    })
+  })
+
+  describe('when a server redirects within its own origin', () => {
+    it('should follow it and return the final body', async () => {
+      await expect(
+        fetchJson(`${await components.getBaseUrl()}/redirect-same-origin`, components.fetcher)
+      ).resolves.toEqual({ followed: true })
+    })
+  })
+
+  describe('when a redirect response carries no location header', () => {
+    it('should reject naming the missing location', async () => {
+      await expect(
+        fetchJson(`${await components.getBaseUrl()}/redirect-without-location`, components.fetcher)
+      ).rejects.toThrow('without a location')
+    })
+  })
+})
+
+describe('fetchJson when a server sends headers and then stops sending the body', () => {
+  let stalledServer: Server
+  let stalledUrl: string
+
+  beforeEach(async () => {
+    stalledServer = createServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' })
+      // A partial document, then silence — the socket is never closed.
+      response.write('{"deltas":[')
+    })
+    await new Promise<void>((ok) => stalledServer.listen(0, '127.0.0.1', () => ok()))
+    stalledUrl = `http://127.0.0.1:${(stalledServer.address() as any).port}/stalled`
+  })
+
+  afterEach(async () => {
+    stalledServer.closeAllConnections?.()
+    await new Promise<void>((ok) => stalledServer.close(() => ok()))
+  })
+
+  it('should time out reading the body rather than hanging forever', async () => {
+    // The fetch component's own timeout only bounds time-to-headers, so without a deadline on the body
+    // read this promise never settles — and a pending promise never reaches the reconnection logic.
+    const { createFetchComponent } = await import('@dcl/fetch-component')
+
+    await expect(fetchJson(stalledUrl, createFetchComponent(), { timeout: 500 })).rejects.toThrow(
+      'while reading the response body'
+    )
+  })
+})

--- a/test/fetchJsonSizeLimit.spec.ts
+++ b/test/fetchJsonSizeLimit.spec.ts
@@ -1,0 +1,47 @@
+import { Readable } from 'stream'
+import { fetchJson } from '../src/utils'
+import { test } from './components'
+
+// The cap in src/utils.ts is 50 MiB; stream just past it so the guard trips without buffering the
+// whole body in the test process.
+const MEGABYTE = 1024 * 1024
+const BYTES_TO_SERVE = 51 * MEGABYTE
+// Few, large chunks: the guard trips on the running total, so bigger pushes reach the limit with far
+// less stream/socket overhead than 1 MiB at a time.
+const CHUNK_SIZE = 8 * MEGABYTE
+
+test('fetchJson when the server streams a body larger than the allowed maximum', ({ components }) => {
+  it('prepares the endpoints', () => {
+    components.router.get('/huge', async (): Promise<any> => {
+      const chunk = Buffer.alloc(CHUNK_SIZE, 0x20)
+      let sent = 0
+      return {
+        headers: { 'content-type': 'application/json' },
+        body: new Readable({
+          read() {
+            if (sent >= BYTES_TO_SERVE) {
+              this.push(null)
+              return
+            }
+            sent += chunk.length
+            this.push(chunk)
+          }
+        })
+      }
+    })
+  })
+
+  describe('when the body exceeds the maximum allowed size', () => {
+    let baseUrl: string
+
+    beforeEach(async () => {
+      baseUrl = await components.getBaseUrl()
+    })
+
+    it('should reject naming the size limit instead of buffering the whole response', async () => {
+      await expect(fetchJson(`${baseUrl}/huge`, components.fetcher)).rejects.toThrow(
+        'Response body exceeds the maximum allowed size'
+      )
+    })
+  })
+})

--- a/test/fetchJsonTransferRate.spec.ts
+++ b/test/fetchJsonTransferRate.spec.ts
@@ -1,0 +1,57 @@
+import { Readable } from 'stream'
+import { IFetchComponent } from '@dcl/core-commons'
+import { fetchJson } from '../src/utils'
+
+// A fetcher whose body arrives as a single small chunk. Everything about the timing is decided by the
+// stubbed clock below, so this stays a unit test with no sockets and no real waiting.
+function fetcherReturning(payload: string): IFetchComponent {
+  return {
+    fetch: async () =>
+      new Response(Readable.toWeb(Readable.from([Buffer.from(payload)])) as ReadableStream, {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+  } as any
+}
+
+describe('fetchJson', () => {
+  describe('when a peer sends headers and then delivers the body too slowly to count as progress', () => {
+    let clockSpy: jest.SpyInstance
+    let error: Error | undefined
+
+    beforeEach(async () => {
+      const realNow = Date.now()
+      let calls = 0
+      // The body read records its start on one Date.now() call and measures elapsed time on the next, so
+      // stepping the clock a grace period per call is what makes a prompt body look like a stalled one.
+      clockSpy = jest.spyOn(Date, 'now').mockImplementation(() => realNow + calls++ * 70_000)
+
+      error = undefined
+      try {
+        await fetchJson('http://localhost/unused', fetcherReturning('{"ok":true}'))
+      } catch (thrown: any) {
+        error = thrown
+      }
+    })
+
+    afterEach(() => {
+      clockSpy.mockRestore()
+    })
+
+    it('should reject rather than buffer a body that is not really arriving', () => {
+      expect(error).toBeDefined()
+    })
+
+    it('should reject with the transfer-rate failure, not a parse or timeout error', () => {
+      expect(error!.message).toContain('below the minimum of 4096 bytes/s')
+    })
+  })
+
+  describe('when a peer delivers the body promptly', () => {
+    it('should parse and return it', async () => {
+      await expect(fetchJson('http://localhost/unused', fetcherReturning('{"ok":true}'))).resolves.toEqual({
+        ok: true
+      })
+    })
+  })
+})

--- a/test/getSnapshots.spec.ts
+++ b/test/getSnapshots.spec.ts
@@ -38,8 +38,15 @@ test('getSnapshots when the response mixes valid and invalid snapshot metadata',
   })
 
   it('returns only the valid snapshots, sorted newest first', async () => {
-    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+    const { snapshots } = await getSnapshots(components, await components.getBaseUrl(), 10)
     expect(snapshots).toEqual([newerValidSnapshot, validSnapshot])
+  })
+
+  it('should report how many entries it had to discard, so the caller knows the list is incomplete', async () => {
+    const { discardedEntries } = await getSnapshots(components, await components.getBaseUrl(), 10)
+
+    // Each discarded entry stood for a time range nothing in the surviving list covers.
+    expect(discardedEntries).toEqual(6)
   })
 })
 
@@ -60,7 +67,7 @@ test('getSnapshots when a snapshot reports the unused informational fields with 
   it('should still return the snapshot, since nothing reads those fields', async () => {
     // Rejecting the entry would silently stop this server from ever being synced from, over a value
     // the package never looks at.
-    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+    const { snapshots } = await getSnapshots(components, await components.getBaseUrl(), 10)
 
     expect(snapshots).toEqual([snapshotWithStringCount])
   })
@@ -99,13 +106,13 @@ test('getSnapshots when a snapshot reports a time range that is not usable arith
   })
 
   it('should keep only the finite, non-negative, non-inverted range', async () => {
-    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+    const { snapshots } = await getSnapshots(components, await components.getBaseUrl(), 10)
 
     expect(snapshots).toEqual([validSnapshot])
   })
 
   it('should reject every value that cannot be a plausible instant', async () => {
-    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+    const { snapshots } = await getSnapshots(components, await components.getBaseUrl(), 10)
 
     // Every rejected value above is finite and non-negative; that is exactly why finiteness was not a
     // sufficient test on its own.
@@ -113,7 +120,7 @@ test('getSnapshots when a snapshot reports a time range that is not usable arith
   })
 
   it('should never yield a non-finite endTimestamp, which would poison the high-water mark', async () => {
-    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+    const { snapshots } = await getSnapshots(components, await components.getBaseUrl(), 10)
 
     expect(snapshots.every((snapshot) => Number.isFinite(snapshot.timeRange.endTimestamp))).toBe(true)
   })
@@ -144,7 +151,7 @@ test('getSnapshots when a snapshot claims to replace an implausible number of ot
   })
 
   it('should drop the entry above the cap and keep the one within it', async () => {
-    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+    const { snapshots } = await getSnapshots(components, await components.getBaseUrl(), 10)
 
     expect(snapshots).toEqual([withinTheCap])
   })
@@ -170,7 +177,7 @@ test('getSnapshots when the response contains many invalid entries', ({ componen
       error: errorMock
     })
 
-    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+    const { snapshots } = await getSnapshots(components, await components.getBaseUrl(), 10)
 
     expect(snapshots).toEqual([])
     // 100 per-entry errors + 1 summary line

--- a/test/getSnapshots.spec.ts
+++ b/test/getSnapshots.spec.ts
@@ -81,12 +81,18 @@ test('getSnapshots when a snapshot reports a time range that is not usable arith
     // Served as raw text, because JSON.stringify would turn Infinity into null and hide the case. A JSON
     // body cannot carry NaN at all (`{"a":NaN}` is a syntax error), but the number grammar has no range
     // limit, so a large exponent parses straight to Infinity.
+    // Far past the allowed clock skew, but a perfectly ordinary finite number.
+    const farFuture = Date.now() + 400 * 24 * 60 * 60 * 1000
     components.router.get('/snapshots', async () => ({
       body: `[
         {"hash":"${validSnapshot.hash}","timeRange":{"initTimestamp":0,"endTimestamp":100},"replacedSnapshotHashes":[]},
         {"hash":"ba${'b'.repeat(57)}","timeRange":{"initTimestamp":0,"endTimestamp":1e999}},
         {"hash":"ba${'c'.repeat(57)}","timeRange":{"initTimestamp":-5,"endTimestamp":-1}},
-        {"hash":"ba${'d'.repeat(57)}","timeRange":{"initTimestamp":500,"endTimestamp":100}}
+        {"hash":"ba${'d'.repeat(57)}","timeRange":{"initTimestamp":500,"endTimestamp":100}},
+        {"hash":"ba${'e'.repeat(57)}","timeRange":{"initTimestamp":0,"endTimestamp":1e308}},
+        {"hash":"ba${'f'.repeat(57)}","timeRange":{"initTimestamp":0,"endTimestamp":9007199254740993}},
+        {"hash":"ba${'g'.repeat(57)}","timeRange":{"initTimestamp":0,"endTimestamp":100.5}},
+        {"hash":"ba${'h'.repeat(57)}","timeRange":{"initTimestamp":0,"endTimestamp":${farFuture}}}
       ]`,
       headers: { 'content-type': 'application/json' }
     }))
@@ -96,6 +102,14 @@ test('getSnapshots when a snapshot reports a time range that is not usable arith
     const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
 
     expect(snapshots).toEqual([validSnapshot])
+  })
+
+  it('should reject every value that cannot be a plausible instant', async () => {
+    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+
+    // Every rejected value above is finite and non-negative; that is exactly why finiteness was not a
+    // sufficient test on its own.
+    expect(snapshots.map((snapshot) => snapshot.hash)).toEqual([validSnapshot.hash])
   })
 
   it('should never yield a non-finite endTimestamp, which would poison the high-water mark', async () => {

--- a/test/getSnapshots.spec.ts
+++ b/test/getSnapshots.spec.ts
@@ -105,6 +105,37 @@ test('getSnapshots when a snapshot reports a time range that is not usable arith
   })
 })
 
+test('getSnapshots when a snapshot claims to replace an implausible number of others', ({ components }) => {
+  const withinTheCap = {
+    hash: 'bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha',
+    timeRange: { initTimestamp: 100, endTimestamp: 200 },
+    replacedSnapshotHashes: Array.from({ length: 1000 }, (_unused, index) => `ba${String(index).padStart(57, '0')}`)
+  }
+
+  it('prepares the endpoints', () => {
+    components.router.get('/snapshots', async () => ({
+      body: [
+        withinTheCap,
+        {
+          hash: validSnapshot.hash,
+          timeRange: { initTimestamp: 0, endTimestamp: 100 },
+          // One over the cap. Every entry would land in the batched processed-snapshots lookup.
+          replacedSnapshotHashes: Array.from(
+            { length: 1001 },
+            (_unused, index) => `bb${String(index).padStart(57, '0')}`
+          )
+        }
+      ]
+    }))
+  })
+
+  it('should drop the entry above the cap and keep the one within it', async () => {
+    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+
+    expect(snapshots).toEqual([withinTheCap])
+  })
+})
+
 test('getSnapshots when the response contains many invalid entries', ({ components }) => {
   const numberOfInvalidEntries = 150
 

--- a/test/getSnapshots.spec.ts
+++ b/test/getSnapshots.spec.ts
@@ -43,6 +43,29 @@ test('getSnapshots when the response mixes valid and invalid snapshot metadata',
   })
 })
 
+test('getSnapshots when a snapshot reports the unused informational fields with an unexpected type', ({
+  components
+}) => {
+  const snapshotWithStringCount = {
+    hash: 'bafkreig6sfhegnp4okzecgx3v6gj6pohh5qzw6zjtrdqtggx64743rkmz4',
+    timeRange: { initTimestamp: 0, endTimestamp: 300 },
+    numberOfEntities: '5',
+    generationTimestamp: 'yesterday'
+  }
+
+  it('prepares the endpoints', () => {
+    components.router.get('/snapshots', async () => ({ body: [snapshotWithStringCount] }))
+  })
+
+  it('should still return the snapshot, since nothing reads those fields', async () => {
+    // Rejecting the entry would silently stop this server from ever being synced from, over a value
+    // the package never looks at.
+    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+
+    expect(snapshots).toEqual([snapshotWithStringCount])
+  })
+})
+
 test('getSnapshots when the response is not an array', ({ components }) => {
   it('prepares the endpoints', () => {
     components.router.get('/snapshots', async () => ({ body: { not: 'an array' } }))

--- a/test/getSnapshots.spec.ts
+++ b/test/getSnapshots.spec.ts
@@ -76,6 +76,35 @@ test('getSnapshots when the response is not an array', ({ components }) => {
   })
 })
 
+test('getSnapshots when a snapshot reports a time range that is not usable arithmetic', ({ components }) => {
+  it('prepares the endpoints', () => {
+    // Served as raw text, because JSON.stringify would turn Infinity into null and hide the case. A JSON
+    // body cannot carry NaN at all (`{"a":NaN}` is a syntax error), but the number grammar has no range
+    // limit, so a large exponent parses straight to Infinity.
+    components.router.get('/snapshots', async () => ({
+      body: `[
+        {"hash":"${validSnapshot.hash}","timeRange":{"initTimestamp":0,"endTimestamp":100},"replacedSnapshotHashes":[]},
+        {"hash":"ba${'b'.repeat(57)}","timeRange":{"initTimestamp":0,"endTimestamp":1e999}},
+        {"hash":"ba${'c'.repeat(57)}","timeRange":{"initTimestamp":-5,"endTimestamp":-1}},
+        {"hash":"ba${'d'.repeat(57)}","timeRange":{"initTimestamp":500,"endTimestamp":100}}
+      ]`,
+      headers: { 'content-type': 'application/json' }
+    }))
+  })
+
+  it('should keep only the finite, non-negative, non-inverted range', async () => {
+    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+
+    expect(snapshots).toEqual([validSnapshot])
+  })
+
+  it('should never yield a non-finite endTimestamp, which would poison the high-water mark', async () => {
+    const snapshots = await getSnapshots(components, await components.getBaseUrl(), 10)
+
+    expect(snapshots.every((snapshot) => Number.isFinite(snapshot.timeRange.endTimestamp))).toBe(true)
+  })
+})
+
 test('getSnapshots when the response contains many invalid entries', ({ components }) => {
   const numberOfInvalidEntries = 150
 

--- a/test/job-lifecycle-manager.spec.ts
+++ b/test/job-lifecycle-manager.spec.ts
@@ -55,7 +55,7 @@ test('job-manager-1', ({ components, stubComponents }) => {
   })
 
   afterAll(async () => {
-    await jobManager.stop()
+    await jobManager.stop!()
   })
 })
 
@@ -90,7 +90,57 @@ test('job-manager-stops-all', ({ components, stubComponents }) => {
   it('stopping the component kills all the jobs', async () => {
     jobManager.setDesiredJobs(new Set(['a', 'b', 'c']))
     expect(Array.from(jobManager.getRunningJobs())).toEqual(['a', 'b', 'c'])
-    await jobManager.stop()
+    await jobManager.stop!()
     expect(Array.from(jobManager.getRunningJobs())).toEqual([])
+  })
+})
+
+test('job-manager when a job name is removed and immediately re-added', ({ components }) => {
+  let jobManager: JobLifecycleManagerComponent & { stop?: () => Promise<void> }
+  let concurrentlyRunning: number
+  let maxConcurrentlyRunning: number
+
+  it('creates a manager whose jobs take a while to stop', () => {
+    concurrentlyRunning = 0
+    maxConcurrentlyRunning = 0
+
+    jobManager = createJobLifecycleManagerComponent(
+      { logs: components.logs },
+      {
+        jobManagerName: 'test-manager',
+        createJob() {
+          let shouldRun = true
+          return {
+            async start() {
+              concurrentlyRunning++
+              maxConcurrentlyRunning = Math.max(maxConcurrentlyRunning, concurrentlyRunning)
+              while (shouldRun) {
+                await sleep(5)
+              }
+              concurrentlyRunning--
+            },
+            async stop() {
+              // A stop that does not take effect instantly, like a stream that has to wind down.
+              await sleep(30)
+              shouldRun = false
+            }
+          }
+        }
+      }
+    )
+  })
+
+  it('should never run two jobs for the same name at once', async () => {
+    jobManager.setDesiredJobs(new Set(['a']))
+    jobManager.setDesiredJobs(new Set())
+    jobManager.setDesiredJobs(new Set(['a']))
+
+    await sleep(120)
+
+    expect(maxConcurrentlyRunning).toBe(1)
+  })
+
+  afterAll(async () => {
+    await jobManager.stop!()
   })
 })

--- a/test/job-queue-port.spec.ts
+++ b/test/job-queue-port.spec.ts
@@ -277,5 +277,49 @@ describe('createJobQueue', () => {
         await expect(queue.onSizeLessThan(limit)).rejects.toThrow(`limit must be an integer >= 1, got ${limit}`)
       })
     })
+    describe('when the queue has been stopped', () => {
+      let stoppedQueue: ReturnType<typeof createJobQueue>
+
+      beforeEach(async () => {
+        stoppedQueue = createJobQueue({ concurrency: 1 })
+        await stoppedQueue.stop!()
+      })
+
+      it('should refuse a new job rather than running it after the caller stopped the queue', () => {
+        expect(() => stoppedQueue.scheduleJob(async () => 'unused')).toThrow('no longer accepts jobs')
+      })
+
+      it('should refuse a new prioritised job too', () => {
+        expect(() => stoppedQueue.scheduleJobWithPriority(async () => 'unused', 1)).toThrow('no longer accepts jobs')
+      })
+
+      it('should refuse a new job with retries too', () => {
+        expect(() => stoppedQueue.scheduleJobWithRetries(async () => 'unused', 2)).toThrow('no longer accepts jobs')
+      })
+    })
+
+    describe('when a retry ladder is in flight as the queue is stopped', () => {
+      it('should stop re-enqueueing rather than making stop() chase its own retries', async () => {
+        const retryingQueue = createJobQueue({ concurrency: 1 })
+        let attempts = 0
+        const job = retryingQueue.scheduleJobWithRetries(async () => {
+          attempts++
+          // Each attempt takes a moment, so the ladder is genuinely still in flight when stop() lands.
+          // With an instant failure all 50 retries burn through before stop() is even called.
+          await sleep(15)
+          throw new Error('always fails')
+        }, 50)
+
+        // Let the ladder get going, then stop underneath it.
+        await sleep(40)
+        const attemptsAtStop = attempts
+        await retryingQueue.stop!()
+
+        await expect(job).rejects.toThrow()
+        // A ladder that kept re-enqueueing would have burned through all 50 attempts.
+        expect(attempts).toBeLessThan(50)
+        expect(attempts).toBeGreaterThanOrEqual(attemptsAtStop)
+      })
+    })
   })
 })

--- a/test/job-queue-port.spec.ts
+++ b/test/job-queue-port.spec.ts
@@ -204,6 +204,49 @@ describe('createJobQueue', () => {
       })
     })
 
+    describe('when a timed-out job keeps running after the queue gave up on it', () => {
+      let timedQueue: IJobQueue & { stop?: () => Promise<void> }
+      let stillRunning: boolean
+
+      beforeEach(() => {
+        stillRunning = false
+        timedQueue = createJobQueue({ autoStart: true, concurrency: 1, timeout: 40 }) as any
+      })
+
+      it('should not report idle until the abandoned execution has actually finished', async () => {
+        // Nothing can cancel a promise, so p-queue's timeout only stops it *counting* the task — the
+        // function carries on. onIdle() must still wait for it, or a consumer treats "idle" as
+        // "nothing is mutating state".
+        void timedQueue
+          .scheduleJob(async () => {
+            stillRunning = true
+            await sleep(300)
+            stillRunning = false
+          })
+          .catch(() => undefined)
+
+        await sleep(80) // past the 40ms timeout: the queue has already given up
+        await timedQueue.onIdle()
+
+        expect(stillRunning).toBe(false)
+      })
+
+      it('should not let stop() resolve while the abandoned execution is still running', async () => {
+        void timedQueue
+          .scheduleJob(async () => {
+            stillRunning = true
+            await sleep(300)
+            stillRunning = false
+          })
+          .catch(() => undefined)
+
+        await sleep(80)
+        await timedQueue.stop!()
+
+        expect(stillRunning).toBe(false)
+      })
+    })
+
     describe('when no retries are allowed', () => {
       it('should throw indicating that at least one retry is required', () => {
         expect(() => queue.scheduleJobWithRetries(async () => 'unused', 0)).toThrow(

--- a/test/job-queue-port.spec.ts
+++ b/test/job-queue-port.spec.ts
@@ -1,0 +1,215 @@
+import future from 'fp-future'
+import { createJobQueue, IJobQueue } from '../src/job-queue-port'
+import { sleep } from '../src/utils'
+
+describe('createJobQueue', () => {
+  describe('onSizeLessThan', () => {
+    let queue: IJobQueue
+
+    beforeEach(() => {
+      queue = createJobQueue({ autoStart: true, concurrency: 1 })
+    })
+
+    describe('when the queue is already below the limit', () => {
+      it('should resolve without waiting for a queue event', async () => {
+        await expect(queue.onSizeLessThan(1)).resolves.toBeUndefined()
+      })
+    })
+
+    describe('when several waiters are pending on different limits', () => {
+      let releaseJobs: ReturnType<typeof future<void>>
+      let resolvedWaiters: number[]
+
+      beforeEach(async () => {
+        releaseJobs = future<void>()
+        resolvedWaiters = []
+
+        // One running job plus three queued, so queue.size is 3 while the first job is blocked.
+        for (let index = 0; index < 4; index++) {
+          void queue.scheduleJob(async () => {
+            await releaseJobs
+          })
+        }
+
+        void queue.onSizeLessThan(3).then(() => resolvedWaiters.push(3))
+        void queue.onSizeLessThan(2).then(() => resolvedWaiters.push(2))
+        void queue.onSizeLessThan(1).then(() => resolvedWaiters.push(1))
+
+        await sleep(10)
+      })
+
+      it('should keep every waiter pending until the queue drains past its own limit', () => {
+        expect(resolvedWaiters).toEqual([])
+      })
+
+      it('should resolve the waiters in the order their limits are met', async () => {
+        releaseJobs.resolve()
+        await queue.onIdle()
+        await sleep(10)
+
+        expect(resolvedWaiters).toEqual([3, 2, 1])
+      })
+    })
+
+    describe('and a new waiter arrives after every previous waiter was resolved', () => {
+      let secondRoundResolved: boolean
+
+      beforeEach(async () => {
+        secondRoundResolved = false
+
+        // First round: block the queue, wait for it to drain, which detaches the shared listener.
+        const releaseFirstRound = future<void>()
+        for (let index = 0; index < 3; index++) {
+          void queue.scheduleJob(async () => {
+            await releaseFirstRound
+          })
+        }
+        const firstRoundWaiter = queue.onSizeLessThan(1)
+        releaseFirstRound.resolve()
+        await firstRoundWaiter
+
+        // Second round: the shared subscription must be re-attached for these new waiters.
+        const releaseSecondRound = future<void>()
+        for (let index = 0; index < 3; index++) {
+          void queue.scheduleJob(async () => {
+            await releaseSecondRound
+          })
+        }
+        void queue.onSizeLessThan(1).then(() => {
+          secondRoundResolved = true
+        })
+
+        await sleep(10)
+        releaseSecondRound.resolve()
+        await queue.onIdle()
+        await sleep(10)
+      })
+
+      it('should resolve the new waiter, having re-attached the shared subscription', () => {
+        expect(secondRoundResolved).toBe(true)
+      })
+    })
+  })
+
+  describe('scheduleJobWithPriority', () => {
+    let queue: IJobQueue
+    let completionOrder: string[]
+    let releaseBlocker: ReturnType<typeof future<void>>
+
+    beforeEach(() => {
+      completionOrder = []
+      releaseBlocker = future<void>()
+      queue = createJobQueue({ autoStart: true, concurrency: 1 })
+    })
+
+    it('should run the queued jobs in descending priority order', async () => {
+      // The blocker occupies the single concurrency slot, so the rest queue up and their relative
+      // priority decides who runs first once it is released.
+      const blocker = queue.scheduleJob(async () => {
+        completionOrder.push('blocker')
+        await releaseBlocker
+      })
+      const queued = [
+        queue.scheduleJobWithPriority(async () => completionOrder.push('low'), 0),
+        queue.scheduleJobWithPriority(async () => completionOrder.push('high'), 10),
+        queue.scheduleJobWithPriority(async () => completionOrder.push('medium'), 5)
+      ]
+
+      await sleep(10)
+      releaseBlocker.resolve()
+      await Promise.all([blocker, ...queued])
+
+      expect(completionOrder).toEqual(['blocker', 'high', 'medium', 'low'])
+    })
+  })
+
+  describe('scheduleJob', () => {
+    let queue: IJobQueue
+
+    beforeEach(() => {
+      queue = createJobQueue({ autoStart: true, concurrency: 1 })
+    })
+
+    it('should resolve with the value the job returns', async () => {
+      await expect(queue.scheduleJob(async () => 'the-value')).resolves.toBe('the-value')
+    })
+
+    it('should reject with the error the job throws', async () => {
+      await expect(
+        queue.scheduleJob(async () => {
+          throw new Error('the job failed')
+        })
+      ).rejects.toThrow('the job failed')
+    })
+  })
+
+  describe('scheduleJobWithRetries', () => {
+    let queue: IJobQueue
+
+    beforeEach(() => {
+      queue = createJobQueue({ autoStart: true, concurrency: 1 })
+    })
+
+    describe('when the job fails fewer times than the allowed retries', () => {
+      let attempts: number
+
+      beforeEach(() => {
+        attempts = 0
+      })
+
+      it('should resolve with the value of the first successful attempt', async () => {
+        const result = await queue.scheduleJobWithRetries(async () => {
+          attempts++
+          if (attempts < 3) {
+            throw new Error('transient failure')
+          }
+          return 'the-value'
+        }, 5)
+
+        expect(result).toBe('the-value')
+      })
+    })
+
+    describe('when the job keeps failing past the allowed retries', () => {
+      it('should reject with the last error', async () => {
+        await expect(
+          queue.scheduleJobWithRetries(async () => {
+            throw new Error('permanent failure')
+          }, 2)
+        ).rejects.toThrow('permanent failure')
+      })
+    })
+
+    describe('when a job exceeds the configured queue timeout', () => {
+      let timedQueue: IJobQueue
+
+      beforeEach(() => {
+        timedQueue = createJobQueue({ autoStart: true, concurrency: 1, timeout: 30 })
+      })
+
+      it('should surface the timeout as a failure and retry, rather than resolving as a success', async () => {
+        let attempts = 0
+
+        const result = await timedQueue.scheduleJobWithRetries(async () => {
+          attempts++
+          if (attempts === 1) {
+            // Exceeds the queue timeout. p-queue's default (throwOnTimeout: false) would resolve this
+            // job as if it had succeeded while it kept running in the background.
+            await sleep(200)
+          }
+          return `succeeded on attempt ${attempts}`
+        }, 3)
+
+        expect(result).toBe('succeeded on attempt 2')
+      })
+    })
+
+    describe('when no retries are allowed', () => {
+      it('should throw indicating that at least one retry is required', () => {
+        expect(() => queue.scheduleJobWithRetries(async () => 'unused', 0)).toThrow(
+          'At least one retry is required'
+        )
+      })
+    })
+  })
+})

--- a/test/job-queue-port.spec.ts
+++ b/test/job-queue-port.spec.ts
@@ -356,5 +356,32 @@ describe('createJobQueue', () => {
         await expect(job).resolves.toBe('done')
       })
     })
+    describe('when the queue is built with an invalid concurrency', () => {
+      describe.each([
+        ['zero', 0],
+        ['a negative', -1],
+        ['a fraction', 1.5],
+        // Required in the type because it was already required in fact: p-queue only falls back to
+        // unbounded concurrency when the key is absent, and the factory always passes it, so omitting it
+        // used to throw p-queue's own TypeError about its own option name.
+        ['omitted', undefined]
+      ])('and it is %s', (_label: string, concurrency: number | undefined) => {
+        it('should throw naming this package\'s option and the range it accepts', () => {
+          expect(() => createJobQueue({ concurrency } as any)).toThrow(
+            `concurrency must be an integer >= 1, got ${concurrency}`
+          )
+        })
+      })
+    })
+
+    describe('when the queue is built with an invalid timeout', () => {
+      it('should throw rather than let p-queue interpret it', () => {
+        expect(() => createJobQueue({ concurrency: 1, timeout: 0 })).toThrow('timeout must be an integer >= 1, got 0')
+      })
+
+      it('should still accept an omitted timeout, which means no timeout', () => {
+        expect(() => createJobQueue({ concurrency: 1 })).not.toThrow()
+      })
+    })
   })
 })

--- a/test/job-queue-port.spec.ts
+++ b/test/job-queue-port.spec.ts
@@ -247,11 +247,34 @@ describe('createJobQueue', () => {
       })
     })
 
-    describe('when no retries are allowed', () => {
-      it('should throw indicating that at least one retry is required', () => {
-        expect(() => queue.scheduleJobWithRetries(async () => 'unused', 0)).toThrow(
-          'At least one retry is required'
+    describe.each([
+      ['zero', 0],
+      // The previous bitwise guard coerced with `| 0`, so it let these through: 2.5 became 2, and -1
+      // stayed truthy and then behaved like no retries at all on the first failure.
+      ['a fraction', 2.5],
+      ['a negative', -1],
+      ['not a number', Number.NaN]
+    ])('when retries is %s', (_label: string, retries: number) => {
+      it('should throw naming the expected range', () => {
+        expect(() => queue.scheduleJobWithRetries(async () => 'unused', retries)).toThrow(
+          `retries must be an integer >= 1, got ${retries}`
         )
+      })
+    })
+
+    describe('when retries is a valid integer above the int32 range', () => {
+      it('should be accepted rather than refused by an overflowing coercion', () => {
+        // The previous guard computed `retries | 0`, which wraps this to 0 and rejected it.
+        expect(() => queue.scheduleJobWithRetries(async () => 'unused', 2 ** 32)).not.toThrow()
+      })
+    })
+
+    describe.each([
+      ['zero', 0],
+      ['a negative', -1]
+    ])('when onSizeLessThan is given %s as a limit', (_label: string, limit: number) => {
+      it('should reject rather than waiting for a size the queue can never reach', async () => {
+        await expect(queue.onSizeLessThan(limit)).rejects.toThrow(`limit must be an integer >= 1, got ${limit}`)
       })
     })
   })

--- a/test/job-queue-port.spec.ts
+++ b/test/job-queue-port.spec.ts
@@ -321,5 +321,40 @@ describe('createJobQueue', () => {
         expect(attempts).toBeGreaterThanOrEqual(attemptsAtStop)
       })
     })
+    describe('when the queue was built paused and has queued work at shutdown', () => {
+      let pausedQueue: ReturnType<typeof createJobQueue>
+      let job: Promise<string>
+      let ran: boolean
+      let stopOutcome: string
+
+      beforeEach(async () => {
+        ran = false
+        pausedQueue = createJobQueue({ concurrency: 1, autoStart: false })
+        job = pausedQueue.scheduleJob(async () => {
+          ran = true
+          return 'done'
+        })
+        // onIdle resolves on `pending === 0 && size === 0`, and a paused queue holds its jobs in `size`
+        // without starting them — so stop() used to wait on work that could never begin, and IJobQueue
+        // exposes no way to start it. The race is what keeps that failure a test failure instead of a
+        // suite that hangs until the jest timeout.
+        stopOutcome = await Promise.race([
+          pausedQueue.stop!().then(() => 'stopped'),
+          sleep(1500).then(() => 'hung')
+        ])
+      })
+
+      it('should not hang, having started the queue so its queued work can drain', () => {
+        expect(stopOutcome).toEqual('stopped')
+      })
+
+      it('should have run the queued job rather than abandoning it', () => {
+        expect(ran).toBe(true)
+      })
+
+      it('should settle the scheduled promise', async () => {
+        await expect(job).resolves.toBe('done')
+      })
+    })
   })
 })

--- a/test/jobLifecycleEdgeCases.spec.ts
+++ b/test/jobLifecycleEdgeCases.spec.ts
@@ -1,0 +1,251 @@
+import future from 'fp-future'
+import { createJobLifecycleManagerComponent, IJobWithLifecycle } from '../src/job-lifecycle-manager'
+import { createSerialJobRunner } from '../src/serial-job-runner'
+import { sleep } from '../src/utils'
+import { test } from './components'
+
+test('createJobLifecycleManagerComponent', ({ components }) => {
+  describe('when a replacement job is dropped again before its predecessor finished winding down', () => {
+    let started: string[]
+    let manager: ReturnType<typeof createJobLifecycleManagerComponent>
+    let releaseFirstJob: ReturnType<typeof future<void>>
+
+    beforeEach(async () => {
+      started = []
+      releaseFirstJob = future<void>()
+      let instances = 0
+
+      manager = createJobLifecycleManagerComponent(
+        { logs: components.logs },
+        {
+          jobManagerName: 'replacement-manager',
+          createJob(name: string) {
+            const instance = `${name}-${++instances}`
+            return {
+              async start() {
+                started.push(instance)
+                if (instance === 'a-1') {
+                  await releaseFirstJob
+                }
+              },
+              async stop() {
+                // Only signals; the run keeps going until releaseFirstJob settles.
+              }
+            }
+          }
+        }
+      )
+
+      manager.setDesiredJobs(new Set(['a'])) // a-1 starts and blocks
+      manager.setDesiredJobs(new Set()) // a-1 asked to stop, its run still pending
+      manager.setDesiredJobs(new Set(['a'])) // a-2 created, deferred behind a-1's run
+      manager.setDesiredJobs(new Set()) // a-2 dropped before it ever started
+
+      releaseFirstJob.resolve()
+      await sleep(30)
+    })
+
+    it('should never start the replacement that was dropped while it waited', () => {
+      expect(started).toEqual(['a-1'])
+    })
+
+    it('should report no running jobs', () => {
+      expect(Array.from(manager.getRunningJobs())).toEqual([])
+    })
+  })
+
+  describe('when a job ends on its own', () => {
+    let manager: ReturnType<typeof createJobLifecycleManagerComponent>
+
+    beforeEach(async () => {
+      manager = createJobLifecycleManagerComponent(
+        { logs: components.logs },
+        {
+          jobManagerName: 'short-lived-manager',
+          createJob() {
+            return {
+              async start() {
+                // returns immediately
+              },
+              async stop() {}
+            }
+          }
+        }
+      )
+
+      manager.setDesiredJobs(new Set(['a']))
+      await sleep(20)
+    })
+
+    it('should drop it from the running set without needing another setDesiredJobs call', () => {
+      expect(Array.from(manager.getRunningJobs())).toEqual([])
+    })
+  })
+
+  describe('when a job rejects as soon as it starts', () => {
+    let manager: ReturnType<typeof createJobLifecycleManagerComponent>
+
+    beforeEach(async () => {
+      manager = createJobLifecycleManagerComponent(
+        { logs: components.logs },
+        {
+          jobManagerName: 'failing-start-manager',
+          createJob() {
+            return {
+              async start() {
+                throw new Error('the job could not start')
+              },
+              async stop() {}
+            }
+          }
+        }
+      )
+
+      manager.setDesiredJobs(new Set(['a']))
+      await sleep(20)
+    })
+
+    it('should swallow the rejection and drop the job from the running set', () => {
+      expect(Array.from(manager.getRunningJobs())).toEqual([])
+    })
+
+    it('should allow the same name to be created again afterwards', async () => {
+      manager.setDesiredJobs(new Set(['a']))
+      await sleep(20)
+
+      expect(Array.from(manager.getRunningJobs())).toEqual([])
+    })
+  })
+
+  describe('when a job throws while the whole manager is stopping', () => {
+    let manager: ReturnType<typeof createJobLifecycleManagerComponent>
+
+    beforeEach(() => {
+      manager = createJobLifecycleManagerComponent(
+        { logs: components.logs },
+        {
+          jobManagerName: 'failing-stop-manager',
+          createJob(name: string) {
+            return {
+              async start() {
+                await sleep(10_000)
+              },
+              async stop() {
+                if (name === 'a') {
+                  throw new Error('could not stop a')
+                }
+              }
+            }
+          }
+        }
+      )
+    })
+
+    it('should keep stopping the remaining jobs and end with an empty running set', async () => {
+      manager.setDesiredJobs(new Set(['a', 'b']))
+
+      await manager.stop!()
+
+      expect(Array.from(manager.getRunningJobs())).toEqual([])
+    })
+  })
+})
+
+describe('createSerialJobRunner', () => {
+  let logger: any
+  let runner: ReturnType<typeof createSerialJobRunner>
+
+  beforeEach(() => {
+    logger = { log: jest.fn(), debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+    runner = createSerialJobRunner(logger)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when a job rejects while running', () => {
+    let secondJobStarted: boolean
+
+    beforeEach(async () => {
+      secondJobStarted = false
+
+      runner.enqueue({
+        async start() {
+          throw new Error('the job blew up')
+        },
+        async stop() {}
+      })
+      runner.enqueue({
+        async start() {
+          secondJobStarted = true
+        },
+        async stop() {}
+      })
+
+      await sleep(20)
+    })
+
+    it('should log the failure', () => {
+      expect(logger.error).toHaveBeenCalled()
+    })
+
+    it('should still run the next queued job', () => {
+      expect(secondJobStarted).toBe(true)
+    })
+  })
+
+  describe('when a job is enqueued after the runner was stopped', () => {
+    let lateJobStarted: boolean
+
+    beforeEach(async () => {
+      lateJobStarted = false
+      await runner.stop()
+
+      runner.enqueue({
+        async start() {
+          lateJobStarted = true
+        },
+        async stop() {}
+      })
+
+      await sleep(20)
+    })
+
+    it('should ignore it', () => {
+      expect(lateJobStarted).toBe(false)
+    })
+
+    it('should not count it as queued', () => {
+      expect(runner.size()).toBe(0)
+    })
+  })
+
+  describe('when jobs are queued behind a running one', () => {
+    let releaseRunningJob: ReturnType<typeof future<void>>
+
+    beforeEach(async () => {
+      releaseRunningJob = future<void>()
+      const blockingJob: IJobWithLifecycle = {
+        async start() {
+          await releaseRunningJob
+        },
+        async stop() {
+          releaseRunningJob.resolve()
+        }
+      }
+
+      runner.enqueue(blockingJob)
+      runner.enqueue({ async start() {}, async stop() {} })
+      await sleep(10)
+    })
+
+    afterEach(async () => {
+      await runner.stop()
+    })
+
+    it('should report the running job plus the queued ones', () => {
+      expect(runner.size()).toBe(2)
+    })
+  })
+})

--- a/test/paginationPageCap.spec.ts
+++ b/test/paginationPageCap.spec.ts
@@ -1,0 +1,60 @@
+import { fetchJsonPaginated } from '../src/client'
+import { test } from './components'
+
+async function drain<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const collected: T[] = []
+  for await (const element of iterable) {
+    collected.push(element)
+  }
+  return collected
+}
+
+test('fetchJsonPaginated when a server keeps advertising a next link', ({ components }) => {
+  let pagesServed: number
+  let baseUrl: string
+
+  beforeEach(async () => {
+    pagesServed = 0
+    baseUrl = await components.getBaseUrl()
+    components.router.get('/endless', async (): Promise<any> => {
+      pagesServed++
+      // Each page names a URL nothing has fetched yet, so the visited-URL loop check never fires and only
+      // the page cap can stop the walk.
+      return { body: { deltas: [], pagination: { next: `?page=${pagesServed}` } } }
+    })
+  })
+
+  describe('and the caller lowers the page cap', () => {
+    it('should stop at the configured cap rather than the 10,000 default', async () => {
+      await expect(
+        drain(
+          fetchJsonPaginated(
+            components,
+            `${baseUrl}/endless?page=0`,
+            ($) => $.deltas,
+            'dcl_catalysts_pointer_changes_response_time_seconds',
+            { maxPagesPerPaginatedCall: 5 }
+          )
+        )
+      ).rejects.toThrow('stopped after 5')
+    })
+
+    it('should have made only that many requests', async () => {
+      await expect(
+        drain(
+          fetchJsonPaginated(
+            components,
+            `${baseUrl}/endless?page=0`,
+            ($) => $.deltas,
+            'dcl_catalysts_pointer_changes_response_time_seconds',
+            { maxPagesPerPaginatedCall: 5 }
+          )
+        )
+      ).rejects.toThrow()
+
+      // The cap bounds the amplification a single poll can produce, which is the whole point of making it
+      // configurable: an operator who cannot tolerate 10,000 same-path requests per poll can say so.
+      expect(pagesServed).toEqual(5)
+    })
+  })
+})

--- a/test/pointerChangesRequestTimeout.spec.ts
+++ b/test/pointerChangesRequestTimeout.spec.ts
@@ -1,0 +1,109 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { IFetchComponent, RequestOptions } from '@dcl/core-commons'
+import { PointerChangesSyncDeployment } from '@dcl/schemas'
+import { fetchPointerChanges } from '../src/client'
+
+function createStubLogger(): ILoggerComponent.ILogger {
+  return { log: jest.fn(), debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+}
+
+function createJsonFetcher(body: unknown): IFetchComponent {
+  return {
+    async fetch(): Promise<Response> {
+      return new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } })
+    }
+  }
+}
+
+/**
+ * Stands in for a content server that accepts the connection and then stops sending anything.
+ *
+ * It only settles when the caller bounded the request: an unbounded request gets a promise that
+ * never resolves, exactly like the real stall. That makes "the request carries a timeout" observable
+ * as "the stream rejects" instead of "the test hangs".
+ */
+function createStalledFetcher(): IFetchComponent & { requestedTimeouts: (number | undefined)[] } {
+  const requestedTimeouts: (number | undefined)[] = []
+  return {
+    requestedTimeouts,
+    async fetch(_url: string | URL | Request, init?: RequestOptions): Promise<Response> {
+      requestedTimeouts.push(init?.timeout)
+      if (!init?.timeout) {
+        return new Promise<Response>(() => undefined)
+      }
+      throw new Error(`Request timed out after ${init.timeout}ms`)
+    }
+  }
+}
+
+describe('fetchPointerChanges', () => {
+  describe('when the content server accepts the connection but never responds', () => {
+    let fetcher: IFetchComponent & { requestedTimeouts: (number | undefined)[] }
+    let logger: ILoggerComponent.ILogger
+
+    beforeEach(() => {
+      fetcher = createStalledFetcher()
+      logger = createStubLogger()
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('should reject with a timeout instead of stalling the stream forever', async () => {
+      const deployments = fetchPointerChanges({ fetcher }, 'https://peer.example.com', 0, logger)
+
+      await expect(deployments[Symbol.asyncIterator]().next()).rejects.toThrow('Request timed out')
+    })
+
+    it('should bound the request with a positive timeout', async () => {
+      const deployments = fetchPointerChanges({ fetcher }, 'https://peer.example.com', 0, logger)
+
+      await expect(deployments[Symbol.asyncIterator]().next()).rejects.toThrow()
+      expect(fetcher.requestedTimeouts).toEqual([expect.any(Number)])
+    })
+  })
+
+  describe('when the feed mixes valid and schema-invalid deployments', () => {
+    let logger: ILoggerComponent.ILogger
+    let validDeployment: PointerChangesSyncDeployment
+    let yielded: PointerChangesSyncDeployment[]
+
+    beforeEach(async () => {
+      logger = createStubLogger()
+      validDeployment = {
+        entityId: 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu',
+        entityType: 'profile',
+        pointers: ['0x1'],
+        entityTimestamp: 5,
+        localTimestamp: 6,
+        authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+      } as PointerChangesSyncDeployment
+
+      const fetcher = createJsonFetcher({
+        deltas: [validDeployment, { entityId: 'missing-everything-else' }],
+        pagination: {}
+      })
+
+      yielded = []
+      for await (const deployment of fetchPointerChanges({ fetcher }, 'https://peer.example.com', 0, logger)) {
+        yielded.push(deployment)
+      }
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('should yield only the deployment that satisfies the schema', () => {
+      expect(yielded).toEqual([validDeployment])
+    })
+
+    it('should log the rejected deployment with the validation errors', () => {
+      expect(logger.error).toHaveBeenCalledWith(
+        'ERROR: Invalid entity deployment from /pointer-changes',
+        expect.objectContaining({ deployment: expect.any(String), error: expect.any(String) })
+      )
+    })
+  })
+})

--- a/test/pointerChangesSameTimestampDedup.spec.ts
+++ b/test/pointerChangesSameTimestampDedup.spec.ts
@@ -22,6 +22,15 @@ function delta(suffix: string, localTimestamp: number): PointerChangesSyncDeploy
   }
 }
 
+// Same entity id and timestamp, different signer. entityId is the hash of the entity file and does not
+// cover the authChain, so these are two distinct rows that no id-based key can tell apart.
+function deltaSignedBy(suffix: string, localTimestamp: number, signer: string): PointerChangesSyncDeployment {
+  return {
+    ...delta(suffix, localTimestamp),
+    authChain: [{ type: AuthLinkType.SIGNER, payload: signer, signature: '' }]
+  }
+}
+
 type PointerChangesPage = {
   deltas: PointerChangesSyncDeployment[]
   pagination: { next?: string }
@@ -100,6 +109,32 @@ test('getDeployedEntitiesStreamFromPointerChanges when rows repeat an entity at 
 
     it('should yield nothing the second time, spending one allowance per delivered row', async () => {
       await expect(streamUntil(3)).resolves.toEqual([idOf('1'), idOf('1')])
+    })
+  })
+
+  describe('and the later poll returns a new same-entity row before replaying the delivered one', () => {
+    beforeEach(() => {
+      // Poll 1 delivers the row signed by 0xA. Poll 2 returns the *new* row (0xB) first and the replay of
+      // 0xA second — nothing guarantees a server replays rows in the order it first sent them. Keyed by
+      // entity id, the new row spends 0xA's allowance and is suppressed, and the replay is then yielded:
+      // the stream keeps its high-water timestamp and silently loses a legitimate pointer-change.
+      served = [[deltaSignedBy('1', 1000, '0xA')], [deltaSignedBy('1', 1000, '0xB'), deltaSignedBy('1', 1000, '0xA')]]
+    })
+
+    it('should yield the new row rather than the replayed one', async () => {
+      const signers: string[] = []
+      for await (const deployment of getDeployedEntitiesStreamFromPointerChanges(
+        components,
+        { pointerChangesWaitTime: 1, fromTimestamp: 0 },
+        await components.getBaseUrl(),
+        () => pollsServed >= 3
+      )) {
+        signers.push(deployment.authChain[0].payload)
+      }
+
+      // Asserted on the signer, not the entity id: both rows share an id, so an id-only assertion cannot
+      // tell the new row from the replay and would pass either way.
+      expect(signers).toEqual(['0xA', '0xB'])
     })
   })
 })

--- a/test/pointerChangesSameTimestampDedup.spec.ts
+++ b/test/pointerChangesSameTimestampDedup.spec.ts
@@ -1,5 +1,5 @@
 import { AuthChain, AuthLinkType, PointerChangesSyncDeployment } from '@dcl/schemas'
-import { getDeployedEntitiesStreamFromPointerChanges } from '../src/stream-entities'
+import { boundaryRowFingerprint, getDeployedEntitiesStreamFromPointerChanges } from '../src/stream-entities'
 import { test } from './components'
 
 const authChain: AuthChain = [{ type: AuthLinkType.SIGNER, payload: '0x1', signature: '' }]
@@ -135,6 +135,81 @@ test('getDeployedEntitiesStreamFromPointerChanges when rows repeat an entity at 
       // Asserted on the signer, not the entity id: both rows share an id, so an id-only assertion cannot
       // tell the new row from the replay and would pass either way.
       expect(signers).toEqual(['0xA', '0xB'])
+    })
+  })
+})
+
+test('boundaryRowFingerprint', () => {
+  describe('when a row contains large remote-controlled pointer and auth-chain fields', () => {
+    let fingerprint: string
+
+    beforeEach(() => {
+      const largeRemoteValue = 'x'.repeat(1024 * 1024)
+      const deployment: PointerChangesSyncDeployment = {
+        ...deltaSignedBy('1', 1000, largeRemoteValue),
+        pointers: [largeRemoteValue],
+        authChain: [
+          {
+            type: AuthLinkType.SIGNER,
+            payload: largeRemoteValue,
+            signature: largeRemoteValue
+          }
+        ]
+      }
+      fingerprint = boundaryRowFingerprint(deployment)
+    })
+
+    afterEach(() => {
+      fingerprint = ''
+    })
+
+    it('should reduce the row to one fixed-size SHA-256 digest', () => {
+      expect(fingerprint).toMatch(/^[A-Za-z0-9_-]{43}$/)
+    })
+  })
+
+  describe('when equivalent rows list their pointers in a different order', () => {
+    let firstFingerprint: string
+    let reorderedFingerprint: string
+
+    beforeEach(() => {
+      const deployment: PointerChangesSyncDeployment = {
+        ...delta('1', 1000),
+        pointers: ['pointer-b', 'pointer-a']
+      }
+      firstFingerprint = boundaryRowFingerprint(deployment)
+      reorderedFingerprint = boundaryRowFingerprint({
+        ...deployment,
+        pointers: ['pointer-a', 'pointer-b']
+      })
+    })
+
+    afterEach(() => {
+      firstFingerprint = ''
+      reorderedFingerprint = ''
+    })
+
+    it('should produce the same digest', () => {
+      expect(reorderedFingerprint).toBe(firstFingerprint)
+    })
+  })
+
+  describe('when rows differ by an auth-chain signer', () => {
+    let firstFingerprint: string
+    let secondFingerprint: string
+
+    beforeEach(() => {
+      firstFingerprint = boundaryRowFingerprint(deltaSignedBy('1', 1000, '0xA'))
+      secondFingerprint = boundaryRowFingerprint(deltaSignedBy('1', 1000, '0xB'))
+    })
+
+    afterEach(() => {
+      firstFingerprint = ''
+      secondFingerprint = ''
+    })
+
+    it('should produce different digests so a new row is not suppressed as a replay', () => {
+      expect(secondFingerprint).not.toBe(firstFingerprint)
     })
   })
 })

--- a/test/pointerChangesSameTimestampDedup.spec.ts
+++ b/test/pointerChangesSameTimestampDedup.spec.ts
@@ -1,0 +1,83 @@
+import { getDeployedEntitiesStreamFromPointerChanges } from '../src/stream-entities'
+import { test } from './components'
+
+const authChain = [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+
+// entityId must be a real content-hash shape and entityTimestamp is required, or the delta is discarded
+// by PointerChangesSyncDeployment.validate before any de-duplication is reached.
+function delta(suffix: string, localTimestamp: number) {
+  return {
+    entityType: 'profile',
+    entityId: `ba${suffix.padStart(57, '0')}`,
+    entityTimestamp: localTimestamp,
+    localTimestamp,
+    authChain,
+    pointers: ['0x1']
+  }
+}
+
+function idOf(suffix: string): string {
+  return `ba${suffix.padStart(57, '0')}`
+}
+
+test('getDeployedEntitiesStreamFromPointerChanges when one response repeats an entity at the same timestamp', ({
+  components
+}) => {
+  let served: any[][]
+  let pollsServed: number
+
+  beforeEach(() => {
+    pollsServed = 0
+    served = []
+    components.router.get('/pointer-changes', async (): Promise<any> => {
+      const body = { deltas: served[pollsServed] ?? [], pagination: {} }
+      pollsServed++
+      return { body }
+    })
+  })
+
+  describe('and both rows are legitimate deltas for the same entity', () => {
+    beforeEach(() => {
+      // Two rows, same entityId, same localTimestamp, inside one response. A dedup set that grew as the
+      // poll ran would treat the second as a re-yield of the first and drop it.
+      served = [[delta('1', 1000), delta('1', 1000)]]
+    })
+
+    it('should yield both rather than collapsing the second', async () => {
+      const streamed: string[] = []
+      for await (const deployment of getDeployedEntitiesStreamFromPointerChanges(
+        components,
+        { pointerChangesWaitTime: 0, fromTimestamp: 0 },
+        await components.getBaseUrl()
+      )) {
+        streamed.push(deployment.entityId)
+      }
+
+      expect(streamed).toEqual([idOf('1'), idOf('1')])
+    })
+  })
+
+  describe('and a later poll re-returns the boundary row because `from` is inclusive', () => {
+    beforeEach(() => {
+      // Poll 1 delivers E1@1000. Poll 2 starts from 1000 inclusive and gets it again, plus a new entity
+      // at the same timestamp that has genuinely never been delivered.
+      served = [[delta('1', 1000)], [delta('1', 1000), delta('2', 1000)]]
+    })
+
+    it('should skip the re-returned row but still yield the new one', async () => {
+      const streamed: string[] = []
+      for await (const deployment of getDeployedEntitiesStreamFromPointerChanges(
+        components,
+        { pointerChangesWaitTime: 1, fromTimestamp: 0 },
+        await components.getBaseUrl(),
+        // Stops on the third poll, not the second: the predicate is consulted inside the delta loop too, so
+        // stopping at 2 would end the stream before poll 2's rows were consumed.
+        () => pollsServed >= 3
+      )) {
+        streamed.push(deployment.entityId)
+      }
+
+      expect(streamed).toEqual([idOf('1'), idOf('2')])
+    })
+  })
+})

--- a/test/pointerChangesSameTimestampDedup.spec.ts
+++ b/test/pointerChangesSameTimestampDedup.spec.ts
@@ -1,14 +1,20 @@
+import { AuthChain, AuthLinkType, PointerChangesSyncDeployment } from '@dcl/schemas'
 import { getDeployedEntitiesStreamFromPointerChanges } from '../src/stream-entities'
 import { test } from './components'
 
-const authChain = [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+const authChain: AuthChain = [{ type: AuthLinkType.SIGNER, payload: '0x1', signature: '' }]
 
-// entityId must be a real content-hash shape and entityTimestamp is required, or the delta is discarded
-// by PointerChangesSyncDeployment.validate before any de-duplication is reached.
-function delta(suffix: string, localTimestamp: number) {
+function idOf(suffix: string): string {
+  return `ba${suffix.padStart(57, '0')}`
+}
+
+// Typed as the schema the stream validates against, so a fixture that drifts out of shape fails to compile
+// rather than being silently discarded before de-duplication is ever reached — which is exactly how the
+// first version of this spec failed.
+function delta(suffix: string, localTimestamp: number): PointerChangesSyncDeployment {
   return {
     entityType: 'profile',
-    entityId: `ba${suffix.padStart(57, '0')}`,
+    entityId: idOf(suffix),
     entityTimestamp: localTimestamp,
     localTimestamp,
     authChain,
@@ -16,68 +22,84 @@ function delta(suffix: string, localTimestamp: number) {
   }
 }
 
-function idOf(suffix: string): string {
-  return `ba${suffix.padStart(57, '0')}`
+type PointerChangesPage = {
+  deltas: PointerChangesSyncDeployment[]
+  pagination: { next?: string }
 }
 
-test('getDeployedEntitiesStreamFromPointerChanges when one response repeats an entity at the same timestamp', ({
-  components
-}) => {
-  let served: any[][]
+test('getDeployedEntitiesStreamFromPointerChanges when rows repeat an entity at one timestamp', ({ components }) => {
+  let served: PointerChangesSyncDeployment[][]
   let pollsServed: number
 
   beforeEach(() => {
     pollsServed = 0
     served = []
-    components.router.get('/pointer-changes', async (): Promise<any> => {
-      const body = { deltas: served[pollsServed] ?? [], pagination: {} }
+    components.router.get('/pointer-changes', async () => {
+      const body: PointerChangesPage = { deltas: served[pollsServed] ?? [], pagination: {} }
       pollsServed++
       return { body }
     })
   })
 
-  describe('and both rows are legitimate deltas for the same entity', () => {
+  async function streamUntil(stopAfterPolls: number): Promise<string[]> {
+    const streamed: string[] = []
+    for await (const deployment of getDeployedEntitiesStreamFromPointerChanges(
+      components,
+      { pointerChangesWaitTime: 1, fromTimestamp: 0 },
+      await components.getBaseUrl(),
+      // Consulted inside the delta loop too, so stopping at N ends the stream before poll N's rows are
+      // consumed; every case here stops one poll later than the last one it cares about.
+      () => pollsServed >= stopAfterPolls
+    )) {
+      streamed.push(deployment.entityId)
+    }
+    return streamed
+  }
+
+  describe('and one response carries two rows for the same entity at the same timestamp', () => {
     beforeEach(() => {
-      // Two rows, same entityId, same localTimestamp, inside one response. A dedup set that grew as the
-      // poll ran would treat the second as a re-yield of the first and drop it.
+      // A suppression set that grew as the poll ran would treat the second row as a re-yield of the first.
       served = [[delta('1', 1000), delta('1', 1000)]]
     })
 
     it('should yield both rather than collapsing the second', async () => {
-      const streamed: string[] = []
-      for await (const deployment of getDeployedEntitiesStreamFromPointerChanges(
-        components,
-        { pointerChangesWaitTime: 0, fromTimestamp: 0 },
-        await components.getBaseUrl()
-      )) {
-        streamed.push(deployment.entityId)
-      }
-
-      expect(streamed).toEqual([idOf('1'), idOf('1')])
+      await expect(streamUntil(2)).resolves.toEqual([idOf('1'), idOf('1')])
     })
   })
 
   describe('and a later poll re-returns the boundary row because `from` is inclusive', () => {
     beforeEach(() => {
-      // Poll 1 delivers E1@1000. Poll 2 starts from 1000 inclusive and gets it again, plus a new entity
-      // at the same timestamp that has genuinely never been delivered.
       served = [[delta('1', 1000)], [delta('1', 1000), delta('2', 1000)]]
     })
 
-    it('should skip the re-returned row but still yield the new one', async () => {
-      const streamed: string[] = []
-      for await (const deployment of getDeployedEntitiesStreamFromPointerChanges(
-        components,
-        { pointerChangesWaitTime: 1, fromTimestamp: 0 },
-        await components.getBaseUrl(),
-        // Stops on the third poll, not the second: the predicate is consulted inside the delta loop too, so
-        // stopping at 2 would end the stream before poll 2's rows were consumed.
-        () => pollsServed >= 3
-      )) {
-        streamed.push(deployment.entityId)
-      }
+    it('should skip the re-returned row but still yield the new entity at that timestamp', async () => {
+      await expect(streamUntil(3)).resolves.toEqual([idOf('1'), idOf('2')])
+    })
+  })
 
-      expect(streamed).toEqual([idOf('1'), idOf('2')])
+  describe('and a later poll reveals an extra row for an entity already delivered at that timestamp', () => {
+    beforeEach(() => {
+      // Poll 1 delivers one row at t=1000. Poll 2 returns two rows for the same entity at the same
+      // timestamp: the one already delivered, plus one the server had not shown before. Membership cannot
+      // tell "seen once" from "seen twice", so a Set suppressed both and the extra row was lost.
+      served = [[delta('1', 1000)], [delta('1', 1000), delta('1', 1000)]]
+    })
+
+    it('should suppress only the row it already delivered and yield the extra one', async () => {
+      await expect(streamUntil(3)).resolves.toEqual([idOf('1'), idOf('1')])
+    })
+  })
+
+  describe('and a later poll re-returns exactly what was already delivered', () => {
+    beforeEach(() => {
+      served = [
+        [delta('1', 1000), delta('1', 1000)],
+        [delta('1', 1000), delta('1', 1000)]
+      ]
+    })
+
+    it('should yield nothing the second time, spending one allowance per delivered row', async () => {
+      await expect(streamUntil(3)).resolves.toEqual([idOf('1'), idOf('1')])
     })
   })
 })

--- a/test/pointerChangesSameTimestampDedup.spec.ts
+++ b/test/pointerChangesSameTimestampDedup.spec.ts
@@ -137,15 +137,64 @@ test('getDeployedEntitiesStreamFromPointerChanges when rows repeat an entity at 
       expect(signers).toEqual(['0xA', '0xB'])
     })
   })
+
+  describe('and one timestamp contains more distinct rows than the boundary tracker can retain', () => {
+    let fetchSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      served = [Array.from({ length: 10_001 }, (_, index) => delta(String(index), 1000))]
+      fetchSpy = jest.spyOn(components.fetcher, 'fetch').mockImplementation(async () => {
+        const body: PointerChangesPage = { deltas: served[pollsServed] ?? [], pagination: {} }
+        pollsServed++
+        return new Response(JSON.stringify(body))
+      })
+    })
+
+    afterEach(() => {
+      fetchSpy.mockRestore()
+    })
+
+    it('should fail the poll before yielding an untrackable row', async () => {
+      await expect(streamUntil(2)).rejects.toThrow('maximum boundary rows tracked per poll is 10000')
+    })
+  })
+
+  describe('and a schema-valid row has a pointer larger than the local structural limit', () => {
+    let fetchSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      served = [
+        [
+          {
+            ...delta('1', 1000),
+            pointers: ['x'.repeat(256 * 1024 + 1)]
+          }
+        ]
+      ]
+      fetchSpy = jest.spyOn(components.fetcher, 'fetch').mockImplementation(async () => {
+        const body: PointerChangesPage = { deltas: served[pollsServed] ?? [], pagination: {} }
+        pollsServed++
+        return new Response(JSON.stringify(body))
+      })
+    })
+
+    afterEach(() => {
+      fetchSpy.mockRestore()
+    })
+
+    it('should fail the poll instead of sorting and hashing the attacker-sized field', async () => {
+      await expect(streamUntil(2)).rejects.toThrow('pointer is 262145 bytes')
+    })
+  })
 })
 
 test('boundaryRowFingerprint', () => {
-  describe('when a row contains large remote-controlled pointer and auth-chain fields', () => {
-    let fingerprint: string
+  describe('when a row exceeds the local fingerprint-material limit', () => {
+    let deployment: PointerChangesSyncDeployment
 
     beforeEach(() => {
       const largeRemoteValue = 'x'.repeat(1024 * 1024)
-      const deployment: PointerChangesSyncDeployment = {
+      deployment = {
         ...deltaSignedBy('1', 1000, largeRemoteValue),
         pointers: [largeRemoteValue],
         authChain: [
@@ -156,7 +205,22 @@ test('boundaryRowFingerprint', () => {
           }
         ]
       }
-      fingerprint = boundaryRowFingerprint(deployment)
+    })
+
+    afterEach(() => {
+      deployment = undefined as any
+    })
+
+    it('should reject it before cloning or sorting its pointers', () => {
+      expect(() => boundaryRowFingerprint(deployment)).toThrow('above the maximum')
+    })
+  })
+
+  describe('when a row stays within every structural limit', () => {
+    let fingerprint: string
+
+    beforeEach(() => {
+      fingerprint = boundaryRowFingerprint(deltaSignedBy('1', 1000, 'x'.repeat(128 * 1024)))
     })
 
     afterEach(() => {

--- a/test/pointerChangesTimestampBounds.spec.ts
+++ b/test/pointerChangesTimestampBounds.spec.ts
@@ -1,0 +1,64 @@
+import { AuthLinkType } from '@dcl/schemas'
+import { getDeployedEntitiesStreamFromPointerChanges } from '../src/stream-entities'
+import { test } from './components'
+
+const authChain = [{ type: AuthLinkType.SIGNER, payload: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5', signature: '' }]
+
+function delta(entityId: string, localTimestamp: number, entityTimestamp = 1) {
+  return { entityType: 'profile', entityId, entityTimestamp, localTimestamp, authChain, pointers: ['0x1'] }
+}
+
+test('getDeployedEntitiesStreamFromPointerChanges when a delta carries an implausible timestamp', ({
+  components
+}) => {
+  // Every value here is accepted by PointerChangesSyncDeployment.validate: the schema rejects Infinity and
+  // negatives but bounds nothing above, and localTimestamp is what becomes the server's high-water mark.
+  const farFuture = Date.now() + 400 * 24 * 60 * 60 * 1000
+  const usable = delta('ba000000000000000000000000000000000000000000000000000000001', 5)
+
+  it('prepares the endpoints', () => {
+    components.router.get('/pointer-changes', async () => ({
+      body: {
+        deltas: [
+          usable,
+          delta('ba000000000000000000000000000000000000000000000000000000002', farFuture),
+          delta('ba000000000000000000000000000000000000000000000000000000003', 1e308),
+          delta('ba000000000000000000000000000000000000000000000000000000004', 9007199254740993),
+          delta('ba000000000000000000000000000000000000000000000000000000005', 100.5),
+          // entityTimestamp is checked too, since it is remote and compared against the genesis point.
+          delta('ba000000000000000000000000000000000000000000000000000000006', 6, farFuture)
+        ],
+        pagination: {}
+      }
+    }))
+  })
+
+  describe('when the stream is drained', () => {
+    let yielded: any[]
+
+    beforeEach(async () => {
+      yielded = []
+      const stream = getDeployedEntitiesStreamFromPointerChanges(
+        components,
+        { pointerChangesWaitTime: 0, fromTimestamp: 0 },
+        await components.getBaseUrl()
+      )
+      for await (const deployment of stream) {
+        yielded.push(deployment)
+      }
+    })
+
+    it('should yield only the deployment with a plausible timestamp', () => {
+      expect(yielded.map((deployment) => deployment.entityId)).toEqual([usable.entityId])
+    })
+
+    it('should never yield a timestamp that would pin the high-water mark out of reach', () => {
+      expect(
+        yielded.every(
+          (deployment) =>
+            Number.isSafeInteger(deployment.localTimestamp) && deployment.localTimestamp <= Date.now() + 86_400_000
+        )
+      ).toBe(true)
+    })
+  })
+})

--- a/test/processDeploymentsInStream.spec.ts
+++ b/test/processDeploymentsInStream.spec.ts
@@ -1,7 +1,7 @@
 import { ILoggerComponent } from '@well-known-components/interfaces'
 import { Readable } from 'stream'
 import { SyncDeployment } from '@dcl/schemas'
-import { processDeploymentsInStream } from '../src/file-processor'
+import { processDeploymentsInStream, SnapshotStreamReport } from '../src/file-processor'
 
 const validSnapshotLine = {
   entityId: 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu',
@@ -11,9 +11,13 @@ const validSnapshotLine = {
   authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
 }
 
-async function collect(stream: Readable, logger: ILoggerComponent.ILogger): Promise<SyncDeployment[]> {
+async function collect(
+  stream: Readable,
+  logger: ILoggerComponent.ILogger,
+  report?: SnapshotStreamReport
+): Promise<SyncDeployment[]> {
   const collected: SyncDeployment[] = []
-  for await (const deployment of processDeploymentsInStream(stream, logger)) {
+  for await (const deployment of processDeploymentsInStream(stream, logger, report)) {
     collected.push(deployment)
   }
   return collected
@@ -107,7 +111,8 @@ describe('processDeploymentsInStream', () => {
     let deployments: SyncDeployment[]
 
     beforeEach(async () => {
-      // The snapshot format prefixes a header line; anything not wrapped in braces is ignored silently.
+      // The header line and blank padding are part of the snapshot format, so they are framing rather
+      // than lines we failed to read.
       const lines = ['### Decentraland json snapshot', '', '   ', JSON.stringify(validSnapshotLine)].join('\n')
       deployments = await collect(Readable.from([Buffer.from(lines)]), logger)
     })
@@ -136,6 +141,97 @@ describe('processDeploymentsInStream', () => {
         'Too many invalid lines in snapshot file, suppressing further line errors',
         { suppressedAfter: '100' }
       )
+    })
+  })
+
+  describe('when a report is supplied and every line is readable', () => {
+    let report: SnapshotStreamReport
+
+    beforeEach(async () => {
+      report = { unusableLines: 0 }
+      const lines = ['### Decentraland json snapshot', '', JSON.stringify(validSnapshotLine)].join('\n')
+      await collect(Readable.from([Buffer.from(lines)]), logger, report)
+    })
+
+    it('should leave the unusable line count at zero so the snapshot can be marked processed', () => {
+      expect(report.unusableLines).toEqual(0)
+    })
+  })
+
+  describe('when a report is supplied and the file ends with a truncated line', () => {
+    let report: SnapshotStreamReport
+    let deployments: SyncDeployment[]
+
+    beforeEach(async () => {
+      report = { unusableLines: 0 }
+      const lines = [JSON.stringify(validSnapshotLine), '{"entityType":"pro'].join('\n')
+      deployments = await collect(Readable.from([Buffer.from(lines)]), logger, report)
+    })
+
+    it('should count the truncated line as unusable', () => {
+      expect(report.unusableLines).toEqual(1)
+    })
+
+    it('should log the unrecognized line instead of dropping it in silence', () => {
+      expect(logger.error).toHaveBeenCalledWith('ERROR: Unrecognized line in snapshot file', {
+        line: '{"entityType":"pro'
+      })
+    })
+
+    it('should still yield the deployments it could read', () => {
+      expect(deployments).toHaveLength(1)
+    })
+  })
+
+  describe('when a report is supplied and a line fails schema validation', () => {
+    let report: SnapshotStreamReport
+
+    beforeEach(async () => {
+      report = { unusableLines: 0 }
+      const lines = [JSON.stringify(validSnapshotLine), JSON.stringify({ not: 'a deployment' })].join('\n')
+      await collect(Readable.from([Buffer.from(lines)]), logger, report)
+    })
+
+    it('should count the invalid deployment as unusable', () => {
+      expect(report.unusableLines).toEqual(1)
+    })
+  })
+
+  describe('when a report is supplied and more lines are invalid than the log cap allows', () => {
+    let report: SnapshotStreamReport
+
+    beforeEach(async () => {
+      report = { unusableLines: 0 }
+      const lines = Array.from({ length: 150 }, (_unused, index) => JSON.stringify({ invalid: index })).join('\n')
+      await collect(Readable.from([Buffer.from(lines)]), logger, report)
+    })
+
+    it('should keep counting past the log cap so suppression cannot hide missing entities', () => {
+      expect(report.unusableLines).toEqual(150)
+    })
+  })
+
+  describe('when a single line exceeds the maximum allowed length', () => {
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      thrownError = undefined
+      // 12 MiB with no newline, against a 10 MiB cap.
+      const chunk = Buffer.alloc(1024 * 1024, 0x61)
+      async function* newlineless() {
+        for (let index = 0; index < 12; index++) {
+          yield chunk
+        }
+      }
+      try {
+        await collect(Readable.from(newlineless()), logger)
+      } catch (error: any) {
+        thrownError = error
+      }
+    })
+
+    it('should fail the snapshot rather than buffering the whole file into one string', () => {
+      expect(thrownError?.message).toEqual('Snapshot line exceeds the maximum allowed length of 10485760 bytes')
     })
   })
 })

--- a/test/processDeploymentsInStream.spec.ts
+++ b/test/processDeploymentsInStream.spec.ts
@@ -1,0 +1,141 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { Readable } from 'stream'
+import { SyncDeployment } from '@dcl/schemas'
+import { processDeploymentsInStream } from '../src/file-processor'
+
+const validSnapshotLine = {
+  entityId: 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu',
+  entityType: 'profile',
+  pointers: ['0x1'],
+  entityTimestamp: 5,
+  authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+}
+
+async function collect(stream: Readable, logger: ILoggerComponent.ILogger): Promise<SyncDeployment[]> {
+  const collected: SyncDeployment[] = []
+  for await (const deployment of processDeploymentsInStream(stream, logger)) {
+    collected.push(deployment)
+  }
+  return collected
+}
+
+describe('processDeploymentsInStream', () => {
+  let logger: ILoggerComponent.ILogger
+
+  beforeEach(() => {
+    logger = { log: jest.fn(), debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when a line is well-formed JSON but not a valid deployment', () => {
+    let deployments: SyncDeployment[]
+
+    beforeEach(async () => {
+      const lines = [JSON.stringify(validSnapshotLine), JSON.stringify({ not: 'a deployment' })].join('\n')
+      deployments = await collect(Readable.from([Buffer.from(lines)]), logger)
+    })
+
+    it('should yield only the valid deployment', () => {
+      expect(deployments).toHaveLength(1)
+    })
+
+    it('should log the invalid deployment with the validation errors', () => {
+      expect(logger.error).toHaveBeenCalledWith(
+        'ERROR: Invalid entity deployment in snapshot file',
+        expect.objectContaining({ deployment: expect.any(String), errors: expect.any(String) })
+      )
+    })
+  })
+
+  describe('when a line carries the extra localTimestamp of a pointer-changes deployment', () => {
+    let deployments: SyncDeployment[]
+
+    beforeEach(async () => {
+      // A pointer-changes deployment is a snapshot deployment plus localTimestamp, so the single
+      // snapshot check accepts it. This is what makes a separate pointer-changes branch unreachable.
+      const pointerChangesLine = { ...validSnapshotLine, localTimestamp: 7 }
+      deployments = await collect(Readable.from([Buffer.from(JSON.stringify(pointerChangesLine))]), logger)
+    })
+
+    it('should yield it', () => {
+      expect(deployments).toHaveLength(1)
+    })
+
+    it('should not log any error', () => {
+      expect(logger.error).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when a line has localTimestamp but is missing entityTimestamp', () => {
+    let deployments: SyncDeployment[]
+
+    beforeEach(async () => {
+      const { entityTimestamp: _dropped, ...withoutEntityTimestamp } = validSnapshotLine
+      const line = { ...withoutEntityTimestamp, localTimestamp: 7 }
+      deployments = await collect(Readable.from([Buffer.from(JSON.stringify(line))]), logger)
+    })
+
+    it('should reject it, since both deployment shapes require entityTimestamp', () => {
+      expect(deployments).toEqual([])
+    })
+  })
+
+  describe('when a line is not parseable JSON', () => {
+    let deployments: SyncDeployment[]
+
+    beforeEach(async () => {
+      const lines = ['{not json at all}', JSON.stringify(validSnapshotLine)].join('\n')
+      deployments = await collect(Readable.from([Buffer.from(lines)]), logger)
+    })
+
+    it('should skip it and still yield the following valid deployment', () => {
+      expect(deployments).toHaveLength(1)
+    })
+
+    it('should log a parse error for the malformed line', () => {
+      expect(logger.error).toHaveBeenCalledWith(
+        'ERROR: Could not parse line in snapshot file',
+        expect.objectContaining({ line: '{not json at all}' })
+      )
+    })
+  })
+
+  describe('when lines do not look like JSON objects at all', () => {
+    let deployments: SyncDeployment[]
+
+    beforeEach(async () => {
+      // The snapshot format prefixes a header line; anything not wrapped in braces is ignored silently.
+      const lines = ['### Decentraland json snapshot', '', '   ', JSON.stringify(validSnapshotLine)].join('\n')
+      deployments = await collect(Readable.from([Buffer.from(lines)]), logger)
+    })
+
+    it('should ignore them without logging an error', () => {
+      expect(logger.error).not.toHaveBeenCalled()
+    })
+
+    it('should still yield the valid deployment', () => {
+      expect(deployments).toHaveLength(1)
+    })
+  })
+
+  describe('when the file contains more invalid lines than the log cap allows', () => {
+    beforeEach(async () => {
+      const lines = Array.from({ length: 150 }, (_unused, index) => JSON.stringify({ invalid: index })).join('\n')
+      await collect(Readable.from([Buffer.from(lines)]), logger)
+    })
+
+    it('should cap the per-line errors at 100 plus one suppression notice', () => {
+      expect(logger.error).toHaveBeenCalledTimes(101)
+    })
+
+    it('should log that further line errors are suppressed', () => {
+      expect(logger.error).toHaveBeenCalledWith(
+        'Too many invalid lines in snapshot file, suppressing further line errors',
+        { suppressedAfter: '100' }
+      )
+    })
+  })
+})

--- a/test/processDeploymentsInStream.spec.ts
+++ b/test/processDeploymentsInStream.spec.ts
@@ -311,4 +311,59 @@ describe('processDeploymentsInStream', () => {
       expect(yielded).toEqual(1)
     })
   })
+  describe.each([
+    [
+      'an oversized line and its newline arrive in the same chunk',
+      [Buffer.concat([Buffer.alloc(12 * 1024 * 1024, 0x61), Buffer.from('\ntail\n')])]
+    ],
+    [
+      'an oversized line is followed by a shorter one in the same chunk',
+      [
+        Buffer.concat([
+          Buffer.alloc(12 * 1024 * 1024, 0x61),
+          Buffer.from('\n'),
+          Buffer.alloc(100, 0x62),
+          Buffer.from('\n')
+        ])
+      ]
+    ],
+    [
+      'a line spans chunks and its newline arrives with more data',
+      [Buffer.alloc(6 * 1024 * 1024, 0x61), Buffer.concat([Buffer.alloc(6 * 1024 * 1024, 0x61), Buffer.from('\nshort\n')])]
+    ]
+  ])('when %s', (_label: string, chunks: Buffer[]) => {
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      thrownError = undefined
+      // Each of these hides the oversized line *behind* a newline, which is what an earlier limiter that
+      // only measured bytes after the last newline in a chunk failed to catch.
+      try {
+        await collect(Readable.from(chunks), logger)
+      } catch (error: any) {
+        thrownError = error
+      }
+    })
+
+    it('should still fail the snapshot rather than forwarding the oversized line', () => {
+      expect(thrownError?.message).toEqual('Snapshot line exceeds the maximum allowed length of 10485760 bytes')
+    })
+  })
+
+  describe('when a line is exactly at the maximum allowed length', () => {
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      thrownError = undefined
+      try {
+        await collect(Readable.from([Buffer.concat([Buffer.alloc(10 * 1024 * 1024, 0x61), Buffer.from('\n')])]), logger)
+      } catch (error: any) {
+        thrownError = error
+      }
+    })
+
+    it('should accept it, so the cap is a maximum rather than an exclusive bound', () => {
+      expect(thrownError).toBeUndefined()
+    })
+  })
 })

--- a/test/processDeploymentsInStream.spec.ts
+++ b/test/processDeploymentsInStream.spec.ts
@@ -280,4 +280,35 @@ describe('processDeploymentsInStream', () => {
       expect(loggedLine).toContain('original length')
     })
   })
+  describe('when the underlying stream fails midway through the snapshot', () => {
+    let thrownError: Error | undefined
+    let yielded: number
+
+    beforeEach(async () => {
+      thrownError = undefined
+      yielded = 0
+      // A storage read that dies after one good line. pipe() does not forward a source error to its
+      // destination, so before this was bridged explicitly the error surfaced as an unhandled 'error'
+      // event — a process crash — rather than rejecting the snapshot.
+      const source = new Readable({ read() {} })
+      source.push(Buffer.from(JSON.stringify(validSnapshotLine) + '\n'))
+      setTimeout(() => source.destroy(new Error('storage read failed mid-snapshot')), 20)
+
+      try {
+        for await (const _deployment of processDeploymentsInStream(source, logger)) {
+          yielded++
+        }
+      } catch (error: any) {
+        thrownError = error
+      }
+    })
+
+    it('should reject with the source error rather than crashing or hanging', () => {
+      expect(thrownError?.message).toEqual('storage read failed mid-snapshot')
+    })
+
+    it('should still have yielded the deployments it read before the failure', () => {
+      expect(yielded).toEqual(1)
+    })
+  })
 })

--- a/test/processDeploymentsInStream.spec.ts
+++ b/test/processDeploymentsInStream.spec.ts
@@ -234,4 +234,50 @@ describe('processDeploymentsInStream', () => {
       expect(thrownError?.message).toEqual('Snapshot line exceeds the maximum allowed length of 10485760 bytes')
     })
   })
+  describe.each([
+    ['a far-future instant', Date.now() + 400 * 24 * 60 * 60 * 1000],
+    ['1e308', 1e308],
+    ['an unsafe integer', 9007199254740993],
+    ['a fractional value', 100.5]
+  ])('when a line carries %s as its entityTimestamp', (_label: string, entityTimestamp: number) => {
+    let report: SnapshotStreamReport
+    let deployments: SyncDeployment[]
+
+    beforeEach(async () => {
+      report = { unusableLines: 0 }
+      // All four pass SnapshotSyncDeployment.validate: the schema rejects Infinity and negatives but
+      // bounds nothing above. The entity would otherwise be handed to the deployer carrying this value.
+      const lines = [JSON.stringify({ ...validSnapshotLine, entityTimestamp }), JSON.stringify(validSnapshotLine)].join(
+        '\n'
+      )
+      deployments = await collect(Readable.from([Buffer.from(lines)]), logger, report)
+    })
+
+    it('should not yield it', () => {
+      expect(deployments).toHaveLength(1)
+    })
+
+    it('should count it as unusable, so the snapshot stays unprocessed and is retried', () => {
+      expect(report.unusableLines).toEqual(1)
+    })
+  })
+
+  describe('when an invalid line is very large', () => {
+    let loggedLine: string
+
+    beforeEach(async () => {
+      const hugeLine = `{"entityType":"profile","junk":"${'a'.repeat(200_000)}"}`
+      await collect(Readable.from([Buffer.from(hugeLine)]), logger)
+      const call = (logger.error as jest.Mock).mock.calls[0]
+      loggedLine = String(call[1].deployment ?? call[1].line ?? '')
+    })
+
+    it('should log a truncated preview rather than the whole attacker-controlled payload', () => {
+      expect(loggedLine.length).toBeLessThan(1000)
+    })
+
+    it('should record the original length so the truncation is visible', () => {
+      expect(loggedLine).toContain('original length')
+    })
+  })
 })

--- a/test/processedSnapshotLookupChunking.spec.ts
+++ b/test/processedSnapshotLookupChunking.spec.ts
@@ -87,4 +87,45 @@ describe('filterProcessedSnapshotsInChunks', () => {
       )
     })
   })
+  describe('when the input is a Set rather than an array', () => {
+    it('should consume it directly, so a caller need not copy it first', async () => {
+      processed.add('h2')
+
+      await expect(filterProcessedSnapshotsInChunks(components, new Set(['h1', 'h2']))).resolves.toEqual(
+        new Set(['h2'])
+      )
+    })
+  })
+
+  describe('when the input is a lazy generator', () => {
+    let yielded: number
+    let hashes: () => Generator<string>
+
+    beforeEach(() => {
+      yielded = 0
+      processed.add('h1500')
+      hashes = function* () {
+        for (let index = 0; index < 2500; index++) {
+          yielded++
+          yield `h${index}`
+        }
+      }
+    })
+
+    it('should chunk it without the caller materialising the whole sequence', async () => {
+      await expect(filterProcessedSnapshotsInChunks(components, hashes())).resolves.toEqual(new Set(['h1500']))
+    })
+
+    it('should still bound every batch to one chunk', async () => {
+      await filterProcessedSnapshotsInChunks(components, hashes())
+
+      expect(requestedChunkSizes).toEqual([CHUNK_SIZE, CHUNK_SIZE, 500])
+    })
+
+    it('should have pulled every element exactly once', async () => {
+      await filterProcessedSnapshotsInChunks(components, hashes())
+
+      expect(yielded).toEqual(2500)
+    })
+  })
 })

--- a/test/processedSnapshotLookupChunking.spec.ts
+++ b/test/processedSnapshotLookupChunking.spec.ts
@@ -1,0 +1,90 @@
+import { filterProcessedSnapshotsInChunks } from '../src/deploy-entities'
+import { IProcessedSnapshotStorageComponent } from '../src/types'
+
+describe('filterProcessedSnapshotsInChunks', () => {
+  const CHUNK_SIZE = 1000
+  let processed: Set<string>
+  let requestedChunkSizes: number[]
+  let components: { processedSnapshotStorage: IProcessedSnapshotStorageComponent }
+
+  beforeEach(() => {
+    processed = new Set()
+    requestedChunkSizes = []
+    components = {
+      processedSnapshotStorage: {
+        async filterProcessedSnapshotsFrom(hashes: string[]) {
+          requestedChunkSizes.push(hashes.length)
+          return new Set(hashes.filter((hash) => processed.has(hash)))
+        },
+        async markSnapshotAsProcessed(hash: string) {
+          processed.add(hash)
+        }
+      }
+    }
+  })
+
+  describe('when the list fits in a single chunk', () => {
+    beforeEach(() => {
+      processed.add('h5')
+    })
+
+    it('should issue exactly one lookup', async () => {
+      await filterProcessedSnapshotsInChunks(components, ['h1', 'h5'])
+
+      expect(requestedChunkSizes).toEqual([2])
+    })
+
+    it('should return the hashes the storage reported as processed', async () => {
+      await expect(filterProcessedSnapshotsInChunks(components, ['h1', 'h5'])).resolves.toEqual(new Set(['h5']))
+    })
+  })
+
+  describe('when the list is empty', () => {
+    it('should not touch the storage at all', async () => {
+      await filterProcessedSnapshotsInChunks(components, [])
+
+      expect(requestedChunkSizes).toEqual([])
+    })
+  })
+
+  describe('when the list is exactly one chunk long', () => {
+    it('should not issue a second, empty lookup', async () => {
+      const hashes = Array.from({ length: CHUNK_SIZE }, (_unused, index) => `h${index}`)
+
+      await filterProcessedSnapshotsInChunks(components, hashes)
+
+      expect(requestedChunkSizes).toEqual([CHUNK_SIZE])
+    })
+  })
+
+  describe('when the list is far larger than one chunk', () => {
+    let hashes: string[]
+
+    beforeEach(() => {
+      // Well past the 65,535 bind parameters Postgres accepts in one statement, which is what an
+      // unchunked lookup would hand a consumer's repository as a single `IN` clause.
+      hashes = Array.from({ length: 70_000 }, (_unused, index) => `h${index}`)
+      processed.add('h0')
+      processed.add('h35000')
+      processed.add('h69999')
+    })
+
+    it('should never ask for more than one chunk at a time', async () => {
+      await filterProcessedSnapshotsInChunks(components, hashes)
+
+      expect(Math.max(...requestedChunkSizes)).toEqual(CHUNK_SIZE)
+    })
+
+    it('should cover every hash exactly once across the chunks', async () => {
+      await filterProcessedSnapshotsInChunks(components, hashes)
+
+      expect(requestedChunkSizes.reduce((total, size) => total + size, 0)).toEqual(hashes.length)
+    })
+
+    it('should merge the results from every chunk, including the first and last', async () => {
+      await expect(filterProcessedSnapshotsInChunks(components, hashes)).resolves.toEqual(
+        new Set(['h0', 'h35000', 'h69999'])
+      )
+    })
+  })
+})

--- a/test/publicApi.spec.ts
+++ b/test/publicApi.spec.ts
@@ -1,0 +1,106 @@
+import { createInMemoryStorage } from '@dcl/catalyst-storage'
+import { createTestMetricsComponent } from '@dcl/metrics'
+import { createLogComponent } from '@well-known-components/logger'
+import { createConfigComponent } from '@well-known-components/env-config-provider'
+// Everything below must be reachable from the package root: this is exactly what a consumer can
+// import. A deep import into dist/ would compile here but breaks the published API contract.
+import {
+  createJobQueue,
+  createSynchronizer,
+  decideSnapshotDeploymentFromProcessedSet,
+  downloadEntityAndContentFiles,
+  shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded,
+  getDeployedEntitiesStreamFromPointerChanges,
+  getDeployedEntitiesStreamFromSnapshot,
+  metricsDefinitions,
+  IDeployerComponent,
+  IDownloadQueue,
+  IProcessedSnapshotStorageComponent,
+  ISnapshotStorageComponent,
+  SnapshotsFetcherComponents,
+  SynchronizerComponent,
+  SynchronizerOptions
+} from '../src'
+
+describe('the package root export', () => {
+  describe('when a consumer assembles the components createSynchronizer requires', () => {
+    let components: SnapshotsFetcherComponents & { deployer: IDeployerComponent }
+    let options: SynchronizerOptions
+
+    beforeEach(async () => {
+      const config = createConfigComponent({ LOG_LEVEL: 'ERROR' })
+      const downloadQueue: IDownloadQueue = createJobQueue({ autoStart: true, concurrency: 1 })
+      const processedSnapshotStorage: IProcessedSnapshotStorageComponent = {
+        filterProcessedSnapshotsFrom: jest.fn().mockResolvedValue(new Set<string>()),
+        markSnapshotAsProcessed: jest.fn()
+      }
+      const snapshotStorage: ISnapshotStorageComponent = { has: jest.fn().mockResolvedValue(false) }
+
+      components = {
+        metrics: createTestMetricsComponent(metricsDefinitions),
+        fetcher: { fetch: jest.fn() },
+        downloadQueue,
+        logs: await createLogComponent({ config }),
+        storage: createInMemoryStorage(),
+        processedSnapshotStorage,
+        snapshotStorage,
+        deployer: {
+          scheduleEntityDeployment: jest.fn(),
+          onIdle: jest.fn(),
+          prepareForDeploymentsIn: jest.fn()
+        }
+      }
+
+      options = {
+        bootstrapReconnection: { reconnectTime: 1000 },
+        syncingReconnection: { reconnectTime: 1000 },
+        tmpDownloadFolder: 'downloads',
+        requestMaxRetries: 1,
+        requestRetryWaitTime: 0,
+        pointerChangesWaitTime: 0
+      }
+    })
+
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
+    it('should build a synchronizer without any deep import into dist', async () => {
+      const synchronizer: SynchronizerComponent = await createSynchronizer(components, options)
+
+      await synchronizer.stop!()
+
+      expect(synchronizer.syncWithServers).toBeInstanceOf(Function)
+    })
+
+    it('should expose the entity and stream helpers', () => {
+      expect([
+        downloadEntityAndContentFiles,
+        getDeployedEntitiesStreamFromSnapshot,
+        getDeployedEntitiesStreamFromPointerChanges
+      ]).toEqual([expect.any(Function), expect.any(Function), expect.any(Function)])
+    })
+
+    it('should expose the snapshot-deployment decision helpers', () => {
+      expect([decideSnapshotDeploymentFromProcessedSet, shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded]).toEqual(
+        [expect.any(Function), expect.any(Function)]
+      )
+    })
+
+    describe('and requestMaxRetries is zero', () => {
+      it('should reject up front instead of failing every snapshot request silently', async () => {
+        await expect(createSynchronizer(components, { ...options, requestMaxRetries: 0 })).rejects.toThrow(
+          'options.requestMaxRetries must be an integer >= 1'
+        )
+      })
+    })
+
+    describe('and requestMaxRetries is not an integer', () => {
+      it('should reject up front naming the offending value', async () => {
+        await expect(createSynchronizer(components, { ...options, requestMaxRetries: 1.5 })).rejects.toThrow(
+          'got 1.5'
+        )
+      })
+    })
+  })
+})

--- a/test/publicApi.spec.ts
+++ b/test/publicApi.spec.ts
@@ -21,8 +21,36 @@ import {
   SynchronizerComponent,
   SynchronizerOptions
 } from '../src'
+import * as packageRoot from '../src'
 
 describe('the package root export', () => {
+  describe('when enumerating what the package publishes', () => {
+    // The API guard for this repo. `make build` used to invoke api-extractor, but it was never declared or
+    // installed and no config or report file ever existed, so that step always failed — the check never ran
+    // on any branch, and removing it fixed a broken target rather than dropping a safeguard. Reinstating it
+    // properly is not straightforward either: CI delegates to a shared reusable workflow this repository
+    // cannot add steps to, so the enforceable place for an API check is the suite CI already runs.
+    //
+    // Only value exports appear here — types are erased at runtime, so a type-level surface change still
+    // needs review. Adding or removing a runtime export should be a deliberate edit to this list.
+    const published = [
+      'DEFAULT_TRANSFER_LIMITS',
+      'createJobQueue',
+      'createSynchronizer',
+      'decideSnapshotDeploymentFromProcessedSet',
+      'downloadEntityAndContentFiles',
+      'getDeployedEntitiesStreamFromPointerChanges',
+      'getDeployedEntitiesStreamFromSnapshot',
+      'metricsDefinitions',
+      'resolveTransferLimits',
+      'shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded'
+    ]
+
+    it('should export exactly the documented set of values, no more and no less', () => {
+      expect(Object.keys(packageRoot).sort()).toEqual(published)
+    })
+  })
+
   describe('when a consumer assembles the components createSynchronizer requires', () => {
     let components: SnapshotsFetcherComponents & { deployer: IDeployerComponent }
     let options: SynchronizerOptions

--- a/test/publicApi.spec.ts
+++ b/test/publicApi.spec.ts
@@ -130,5 +130,39 @@ describe('the package root export', () => {
         )
       })
     })
+
+    describe.each([
+      ['bootstrapReconnection', 'reconnectTime', Number.NaN, 'finite number >= 0'],
+      ['bootstrapReconnection', 'reconnectRetryTimeExponent', 0, 'finite number >= 1'],
+      ['bootstrapReconnection', 'maxReconnectionTime', Number.POSITIVE_INFINITY, 'finite number >= 0'],
+      ['syncingReconnection', 'reconnectTime', -1, 'finite number >= 0'],
+      ['syncingReconnection', 'reconnectRetryTimeExponent', Number.NaN, 'finite number >= 1'],
+      ['syncingReconnection', 'maxReconnectionTime', -1, 'finite number >= 0']
+    ])(
+      'and %s.%s is invalid',
+      (group: string, field: string, value: number, expectedRequirement: string) => {
+        let invalidOptions: SynchronizerOptions
+
+        beforeEach(() => {
+          invalidOptions = {
+            ...options,
+            [group]: {
+              ...(options as any)[group],
+              [field]: value
+            }
+          } as SynchronizerOptions
+        })
+
+        afterEach(() => {
+          invalidOptions = undefined as any
+        })
+
+        it('should reject it during construction instead of starting a broken retry job later', async () => {
+          await expect(createSynchronizer(components, invalidOptions)).rejects.toThrow(
+            `options.${group}.${field} must be a ${expectedRequirement}`
+          )
+        })
+      }
+    )
   })
 })

--- a/test/redirectSafeLookupMixedAnswers.spec.ts
+++ b/test/redirectSafeLookupMixedAnswers.spec.ts
@@ -1,0 +1,134 @@
+import { createRedirectSafeLookup } from '../src/utils'
+
+// require, not `import * as`: ts-jest gives an ES namespace object whose properties are getter-only, so
+// the stub below cannot be assigned onto it. The module object from require is the one src/utils reads.
+const dns: any = require('dns')
+
+// The guard's decisions depend on what DNS answers, which is impractical to arrange through a real
+// download — the existing rebinding test uses an IP literal and so never reaches the lookup at all.
+// Driving the returned LookupFunction directly with fabricated answer sets covers it without a socket.
+// Assigned rather than jest.spyOn'd: dns.lookup is writable but not configurable, so defineProperty —
+// which is what spyOn uses — fails with "Cannot redefine property".
+const realLookup = dns.lookup
+
+function withAnswers(answers: Array<Array<{ address: string; family: number }>>) {
+  let call = 0
+  ;(dns as any).lookup = (_hostname: string, _options: any, callback: any) => {
+    const answer = answers[Math.min(call, answers.length - 1)]
+    call++
+    callback(null, answer, answer[0].family)
+  }
+}
+
+function resolveOnce(lookup: ReturnType<typeof createRedirectSafeLookup>, hostname: string): Promise<Error | null> {
+  return new Promise((ok) => {
+    ;(lookup as any)(hostname, { all: true }, (error: Error | null) => ok(error))
+  })
+}
+
+describe('createRedirectSafeLookup', () => {
+  afterEach(() => {
+    ;(dns as any).lookup = realLookup
+  })
+
+  describe('when the allowed host resolves to both a public and a non-public address', () => {
+    let firstLookupError: Error | null
+
+    beforeEach(async () => {
+      withAnswers([
+        [
+          { address: '203.0.113.10', family: 4 },
+          { address: '127.0.0.1', family: 4 }
+        ]
+      ])
+      firstLookupError = await resolveOnce(createRedirectSafeLookup('mixed.example'), 'mixed.example')
+    })
+
+    it('should refuse the ambiguity rather than pick a classification to hold', () => {
+      // Recording "contains a non-public address" was exploitable: the connection may use the public
+      // address while the guard remembers "non-public", after which a same-host redirect resolving to
+      // ONLY loopback matches the recorded value and is allowed through.
+      expect(firstLookupError?.message).toContain('mix of public and non-public addresses')
+    })
+  })
+
+  describe('and the mixed answer set is returned again', () => {
+    let errors: Array<Error | null>
+
+    beforeEach(async () => {
+      withAnswers([
+        [
+          { address: '203.0.113.10', family: 4 },
+          { address: '127.0.0.1', family: 4 }
+        ]
+      ])
+      const lookup = createRedirectSafeLookup('mixed.example')
+      errors = [await resolveOnce(lookup, 'mixed.example'), await resolveOnce(lookup, 'mixed.example')]
+    })
+
+    it('should keep refusing, having recorded no classification from an ambiguous answer', () => {
+      // This is what makes the reported pivot unreachable rather than merely blocked once. The download
+      // aborts on the first refusal, so there is no second request to redirect — and because nothing was
+      // recorded, no later same-host answer has a poisoned value to match against.
+      expect(errors.every((error) => error?.message.includes('mix of public and non-public'))).toBe(true)
+    })
+  })
+
+  describe('when the allowed host resolves only to public addresses throughout', () => {
+    let errors: Array<Error | null>
+
+    beforeEach(async () => {
+      withAnswers([[{ address: '203.0.113.10', family: 4 }], [{ address: '203.0.113.11', family: 4 }]])
+      const lookup = createRedirectSafeLookup('public.example')
+      errors = [await resolveOnce(lookup, 'public.example'), await resolveOnce(lookup, 'public.example')]
+    })
+
+    it('should allow both, so a round-robin CDN handing out a different public IP still works', () => {
+      expect(errors).toEqual([null, null])
+    })
+  })
+
+  describe('when the allowed host resolves only to non-public addresses throughout', () => {
+    let errors: Array<Error | null>
+
+    beforeEach(async () => {
+      withAnswers([[{ address: '127.0.0.1', family: 4 }], [{ address: '127.0.0.1', family: 4 }]])
+      const lookup = createRedirectSafeLookup('local.example')
+      errors = [await resolveOnce(lookup, 'local.example'), await resolveOnce(lookup, 'local.example')]
+    })
+
+    it('should allow both, so a private catalyst and local development keep working', () => {
+      expect(errors).toEqual([null, null])
+    })
+  })
+
+  describe('when the allowed host was public and a same-host redirect resolves to loopback', () => {
+    let redirectError: Error | null
+
+    beforeEach(async () => {
+      withAnswers([[{ address: '203.0.113.10', family: 4 }], [{ address: '127.0.0.1', family: 4 }]])
+      const lookup = createRedirectSafeLookup('rebinding.example')
+      await resolveOnce(lookup, 'rebinding.example')
+      redirectError = await resolveOnce(lookup, 'rebinding.example')
+    })
+
+    it('should refuse it as a classification change', () => {
+      expect(redirectError?.message).toContain('unlike the original request')
+    })
+  })
+
+  describe('when a redirect points at a different host that resolves to a non-public address', () => {
+    let redirectError: Error | null
+
+    beforeEach(async () => {
+      withAnswers([[{ address: '203.0.113.10', family: 4 }], [{ address: '169.254.169.254', family: 4 }]])
+      const lookup = createRedirectSafeLookup('allowed.example')
+      await resolveOnce(lookup, 'allowed.example')
+      redirectError = await resolveOnce(lookup, 'metadata.example')
+    })
+
+    it('should refuse it regardless of the allowed host classification', () => {
+      expect(redirectError?.message).toContain('not a public address')
+    })
+  })
+})

--- a/test/redirectSafeLookupMixedAnswers.spec.ts
+++ b/test/redirectSafeLookupMixedAnswers.spec.ts
@@ -37,7 +37,7 @@ describe('createRedirectSafeLookup', () => {
     beforeEach(async () => {
       withAnswers([
         [
-          { address: '203.0.113.10', family: 4 },
+          { address: '8.8.8.8', family: 4 },
           { address: '127.0.0.1', family: 4 }
         ]
       ])
@@ -58,7 +58,7 @@ describe('createRedirectSafeLookup', () => {
     beforeEach(async () => {
       withAnswers([
         [
-          { address: '203.0.113.10', family: 4 },
+          { address: '8.8.8.8', family: 4 },
           { address: '127.0.0.1', family: 4 }
         ]
       ])
@@ -78,7 +78,7 @@ describe('createRedirectSafeLookup', () => {
     let errors: Array<Error | null>
 
     beforeEach(async () => {
-      withAnswers([[{ address: '203.0.113.10', family: 4 }], [{ address: '203.0.113.11', family: 4 }]])
+      withAnswers([[{ address: '8.8.8.8', family: 4 }], [{ address: '1.1.1.1', family: 4 }]])
       const lookup = createRedirectSafeLookup('public.example')
       errors = [await resolveOnce(lookup, 'public.example'), await resolveOnce(lookup, 'public.example')]
     })
@@ -106,7 +106,7 @@ describe('createRedirectSafeLookup', () => {
     let redirectError: Error | null
 
     beforeEach(async () => {
-      withAnswers([[{ address: '203.0.113.10', family: 4 }], [{ address: '127.0.0.1', family: 4 }]])
+      withAnswers([[{ address: '8.8.8.8', family: 4 }], [{ address: '127.0.0.1', family: 4 }]])
       const lookup = createRedirectSafeLookup('rebinding.example')
       await resolveOnce(lookup, 'rebinding.example')
       redirectError = await resolveOnce(lookup, 'rebinding.example')
@@ -121,7 +121,7 @@ describe('createRedirectSafeLookup', () => {
     let redirectError: Error | null
 
     beforeEach(async () => {
-      withAnswers([[{ address: '203.0.113.10', family: 4 }], [{ address: '169.254.169.254', family: 4 }]])
+      withAnswers([[{ address: '8.8.8.8', family: 4 }], [{ address: '169.254.169.254', family: 4 }]])
       const lookup = createRedirectSafeLookup('allowed.example')
       await resolveOnce(lookup, 'allowed.example')
       redirectError = await resolveOnce(lookup, 'metadata.example')

--- a/test/saveToDisk.spec.ts
+++ b/test/saveToDisk.spec.ts
@@ -118,7 +118,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     )
 
     // check file exists and has correct content
-    const fileContent = await streamToBuffer(await (await components.storage.retrieve('working')).asStream())
+    const fileContent = await streamToBuffer(await (await components.storage.retrieve('working'))!.asStream())
 
     expect(fileContent).toEqual(content)
   })
@@ -137,7 +137,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
       false
     )
 
-    const fileContent = await streamToBuffer(await (await components.storage.retrieve('working')).asStream())
+    const fileContent = await streamToBuffer(await (await components.storage.retrieve('working'))!.asStream())
 
     // check file exists and has correct content
     expect(fileContent).toEqual(content)
@@ -157,7 +157,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
       false
     )
 
-    const fileContent = await streamToBuffer(await (await components.storage.retrieve('working')).asStream())
+    const fileContent = await streamToBuffer(await (await components.storage.retrieve('working'))!.asStream())
 
     // check file exists and has correct content
     expect(fileContent).toEqual(content)

--- a/test/saveToDisk.spec.ts
+++ b/test/saveToDisk.spec.ts
@@ -56,7 +56,9 @@ test('saveToDisk', ({ components, stubComponents }) => {
       }
     })
 
-    components.router.get(`/contents/alwaysFails`, async () => {
+    // ba-prefixed so the hash is verifiable and the download is really attempted: what this test
+    // exercises is the retry ladder converging, not hash validation.
+    components.router.get(`/contents/baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`, async () => {
       return {
         status: 503
       }
@@ -295,7 +297,7 @@ test('saveToDisk', ({ components, stubComponents }) => {
     await expect(async () => {
       await downloadFileWithRetries(
         { metrics, storage: components.storage },
-        'alwaysFails',
+        'baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
         contentFolder,
         [await components.getBaseUrl()],
         new Map(),
@@ -363,4 +365,28 @@ test('saveToDisk', ({ components, stubComponents }) => {
     // check file exists and has correct content
     expect(await checkFileExists(filename)).toEqual(false)
   })
+  it('refuses an unverifiable hash before spending a request on it', async () => {
+    let requests = 0
+    components.router.get('/contents/notacidatall', async () => {
+      requests++
+      return { body: 'anything' }
+    })
+
+    // Alphanumeric, so it passes the path-safety check, but assertHash can only verify Qm/ba shapes —
+    // downloading it could only ever end in "Unknown hashing algorithm" after the bytes had arrived.
+    await expect(
+      downloadFileWithRetries(
+        { metrics, storage: components.storage },
+        'notacidatall',
+        contentFolder,
+        [await components.getBaseUrl()],
+        new Map(),
+        maxRetries,
+        waitTimeBetweenRetries
+      )
+    ).rejects.toThrow('unknown hashing algorithm')
+
+    expect(requests).toEqual(0)
+  })
+
 })

--- a/test/serial-job-runner.spec.ts
+++ b/test/serial-job-runner.spec.ts
@@ -117,4 +117,65 @@ describe('createSerialJobRunner', () => {
       expect(startOrder).toEqual(['a'])
     })
   })
+
+  describe('and jobs are queued behind the running one', () => {
+    let stoppedJobs: string[]
+    let releaseRunningJob: ReturnType<typeof future<void>>
+
+    beforeEach(async () => {
+      stoppedJobs = []
+      releaseRunningJob = future<void>()
+
+      const makeJob = (id: string): IJobWithLifecycle => ({
+        async start() {
+          if (id === 'running') {
+            await releaseRunningJob
+          }
+        },
+        async stop() {
+          stoppedJobs.push(id)
+          releaseRunningJob.resolve()
+        }
+      })
+
+      runner.enqueue(makeJob('running'))
+      runner.enqueue(makeJob('queued-1'))
+      runner.enqueue(makeJob('queued-2'))
+
+      await sleep(20)
+      await runner.stop()
+    })
+
+    it('should stop the queued jobs too, so nothing they handed a caller stays pending', () => {
+      expect(stoppedJobs).toEqual(['running', 'queued-1', 'queued-2'])
+    })
+  })
+
+  describe('when a queued job throws while being stopped', () => {
+    let stoppedJobs: string[]
+
+    beforeEach(async () => {
+      stoppedJobs = []
+
+      runner.enqueue({
+        async start() {},
+        async stop() {
+          throw new Error('failed to stop')
+        }
+      })
+      runner.enqueue({
+        async start() {},
+        async stop() {
+          stoppedJobs.push('second')
+        }
+      })
+
+      await runner.stop()
+    })
+
+    it('should log the failure and still stop the remaining jobs', () => {
+      expect(logger.error).toHaveBeenCalled()
+      expect(stoppedJobs).toEqual(['second'])
+    })
+  })
 })

--- a/test/shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded.spec.ts
+++ b/test/shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded.spec.ts
@@ -1,154 +1,205 @@
 import { shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded } from '../src/deploy-entities'
-import { test } from './components'
+import { IProcessedSnapshotStorageComponent, ISnapshotStorageComponent } from '../src/types'
+import { createProcessedSnapshotStorageComponent } from './test-component'
 
-
+// This function only reads two components, so the storage fakes are built directly instead of going
+// through the `test` runner. Each `test()` block stands up a whole program and HTTP server, which a
+// decision function that never makes a request does not need.
 describe('shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded', () => {
-
-  const processedSnapshotHash = 'someHash'
+  const snapshotHash = 'someHash'
   const h1 = 'h1'
   const h2 = 'h2'
   const h3 = 'h3'
   const genesisTimestamp = 0
 
+  let processedSnapshotStorage: IProcessedSnapshotStorageComponent
+  let snapshotStorage: ISnapshotStorageComponent
+  let markSnapshotAsProcessed: jest.SpyInstance
+  let components: { processedSnapshotStorage: IProcessedSnapshotStorageComponent; snapshotStorage: ISnapshotStorageComponent }
+
   beforeEach(() => {
+    processedSnapshotStorage = createProcessedSnapshotStorageComponent()
+    snapshotStorage = { async has() { return false } }
+    components = { processedSnapshotStorage, snapshotStorage }
+  })
+
+  afterEach(() => {
     jest.restoreAllMocks()
   })
 
-  test('should not process an already processed snapshot', ({ components }) => {
-    it('run test', async () => {
-      components.processedSnapshotStorage.markSnapshotAsProcessed(processedSnapshotHash)
-      const shouldProcess = await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
-        components,
-        genesisTimestamp,
-        processedSnapshotHash,
-        genesisTimestamp + 1,
-        []
-      )
-      expect(shouldProcess).toBeFalsy()
+  describe('when the snapshot has already been processed', () => {
+    beforeEach(async () => {
+      // Awaited, unlike before: the fake happens to mutate its set before its first suspension point, so
+      // the un-awaited calls worked by accident. A storage that actually awaited anything — which the real
+      // DB-backed one does — would have made every one of these tests race its own setup.
+      await processedSnapshotStorage.markSnapshotAsProcessed(snapshotHash)
+      markSnapshotAsProcessed = jest.spyOn(processedSnapshotStorage, 'markSnapshotAsProcessed')
     })
-  })
 
-  test('should not mark as process an already processed snapshot', ({ components }) => {
-    it('run test', async () => {
-      components.processedSnapshotStorage.markSnapshotAsProcessed(processedSnapshotHash)
-      const markSnapshotAsProcessed = jest.spyOn(components.processedSnapshotStorage, 'markSnapshotAsProcessed')
+    it('should not deploy it again', async () => {
+      await expect(
+        shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
+          components,
+          genesisTimestamp,
+          snapshotHash,
+          genesisTimestamp + 1,
+          []
+        )
+      ).resolves.toBe(false)
+    })
+
+    it('should not mark it as processed a second time', async () => {
       await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
         components,
         genesisTimestamp,
-        processedSnapshotHash,
+        snapshotHash,
         genesisTimestamp + 1,
         []
       )
-      expect(markSnapshotAsProcessed).not.toBeCalled()
+
+      expect(markSnapshotAsProcessed).not.toHaveBeenCalled()
     })
   })
 
-  test('should not process snapshot with greatest timestamp smaller or equal than genesis timestamp', ({ components }) => {
-    it('run test', async () => {
-      const shouldProcess = await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(components, genesisTimestamp,
-        processedSnapshotHash,
-        0,
-        []
-      )
-      expect(shouldProcess).toBeFalsy()
+  describe('when the snapshot ends exactly at the genesis timestamp', () => {
+    it('should not deploy it, since genesis is the exclusive lower bound', async () => {
+      await expect(
+        shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
+          components,
+          genesisTimestamp,
+          snapshotHash,
+          genesisTimestamp,
+          []
+        )
+      ).resolves.toBe(false)
     })
   })
 
-  test('should process snapshot with greatest timestamp bigger than genesis timestamp', ({ components }) => {
-    it('run test', async () => {
-      const shouldProcess = await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(components, genesisTimestamp,
-        processedSnapshotHash,
-        1,
-        []
-      )
-      expect(shouldProcess).toBeTruthy()
+  describe('when the snapshot ends after the genesis timestamp', () => {
+    it('should deploy it', async () => {
+      await expect(
+        shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
+          components,
+          genesisTimestamp,
+          snapshotHash,
+          genesisTimestamp + 1,
+          []
+        )
+      ).resolves.toBe(true)
     })
   })
 
-  test('should not process own snapshot', ({ components }) => {
-    it('run test', async () => {
-      jest.spyOn(components.snapshotStorage, 'has').mockImplementation(async (hash) => {
-        return hash === processedSnapshotHash
+  describe('when the snapshot is one this server produced itself', () => {
+    beforeEach(() => {
+      snapshotStorage = {
+        async has(hash: string) {
+          return hash === snapshotHash
+        }
+      }
+      components = { processedSnapshotStorage, snapshotStorage }
+    })
+
+    it('should not deploy its own entities back to itself', async () => {
+      await expect(
+        shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(components, genesisTimestamp, snapshotHash, 1, [])
+      ).resolves.toBe(false)
+    })
+  })
+
+  describe('when every hash in a replaced group has been processed', () => {
+    beforeEach(async () => {
+      await processedSnapshotStorage.markSnapshotAsProcessed(h1)
+      await processedSnapshotStorage.markSnapshotAsProcessed(h2)
+      await processedSnapshotStorage.markSnapshotAsProcessed(h3)
+      markSnapshotAsProcessed = jest.spyOn(processedSnapshotStorage, 'markSnapshotAsProcessed')
+    })
+
+    it('should not deploy the snapshot, its entities having arrived through the replaced ones', async () => {
+      await expect(
+        shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(components, genesisTimestamp, snapshotHash, 1, [
+          [h1, h2, h3]
+        ])
+      ).resolves.toBe(false)
+    })
+
+    it('should mark the snapshot itself as processed, so the conclusion survives a restart', async () => {
+      await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(components, genesisTimestamp, snapshotHash, 1, [
+        [h1, h2, h3]
+      ])
+
+      expect(markSnapshotAsProcessed).toHaveBeenCalledWith(snapshotHash)
+    })
+
+    describe('and a second group is only partly processed', () => {
+      it('should still treat one fully-processed group as sufficient', async () => {
+        await expect(
+          shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(components, genesisTimestamp, snapshotHash, 1, [
+            [h1, h2, h3],
+            ['non-processed']
+          ])
+        ).resolves.toBe(false)
       })
-      const shouldProcess = await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
-        components,
-        genesisTimestamp,
-        processedSnapshotHash,
-        1,
-        []
-      )
-      expect(shouldProcess).toBeFalsy()
+    })
+
+    // Every existing case put the fully-processed group first, so a wrapper that looked up only
+    // `replacedSnapshotHashes[0]` instead of the flattened list passed this spec. Ordering is not
+    // meaningful to the caller, so it must not be meaningful here.
+    describe('and that group is not the first one', () => {
+      it('should find it regardless of its position', async () => {
+        await expect(
+          shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(components, genesisTimestamp, snapshotHash, 1, [
+            ['non-processed'],
+            [h1, h2, h3]
+          ])
+        ).resolves.toBe(false)
+      })
+
+      it('should mark the snapshot as processed just the same', async () => {
+        await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(components, genesisTimestamp, snapshotHash, 1, [
+          ['non-processed'],
+          [h1, h2, h3]
+        ])
+
+        expect(markSnapshotAsProcessed).toHaveBeenCalledWith(snapshotHash)
+      })
     })
   })
 
-  test('should not process snapshot when the replaced hashes of some group were processed', ({ components }) => {
-    it('run test', async () => {
-      components.processedSnapshotStorage.markSnapshotAsProcessed(h1)
-      components.processedSnapshotStorage.markSnapshotAsProcessed(h2)
-      components.processedSnapshotStorage.markSnapshotAsProcessed(h3)
-      const shouldProcess = await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
-        components,
-        genesisTimestamp,
-        processedSnapshotHash,
-        1,
-        [[h1, h2, h3]]
-      )
-      expect(shouldProcess).toBeFalsy()
+  describe('when no replaced group has been fully processed', () => {
+    beforeEach(async () => {
+      await processedSnapshotStorage.markSnapshotAsProcessed(h1)
+      await processedSnapshotStorage.markSnapshotAsProcessed(h2)
+      await processedSnapshotStorage.markSnapshotAsProcessed(h3)
+      markSnapshotAsProcessed = jest.spyOn(processedSnapshotStorage, 'markSnapshotAsProcessed')
     })
-  })
 
-  test('should mark snapshot as processed when the replaced hashes of some group were processed', ({ components }) => {
-    it('run test', async () => {
-      components.processedSnapshotStorage.markSnapshotAsProcessed(h1)
-      components.processedSnapshotStorage.markSnapshotAsProcessed(h2)
-      components.processedSnapshotStorage.markSnapshotAsProcessed(h3)
-      const markAsProcessedSpy = jest.spyOn(components.processedSnapshotStorage, 'markSnapshotAsProcessed')
-      await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
-        components,
-        genesisTimestamp,
-        processedSnapshotHash,
-        1,
-        [[h1, h2, h3]]
-      )
-      expect(markAsProcessedSpy).toBeCalledWith(processedSnapshotHash)
+    it('should deploy the snapshot, since no group covers its entities', async () => {
+      await expect(
+        shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(components, genesisTimestamp, snapshotHash, 1, [
+          [h1, h2, 'non-processed'],
+          [h3, 'non-processed']
+        ])
+      ).resolves.toBe(true)
     })
-  })
 
-  test('should mark snapshot as processed when all the hashes of some replaced-hashes group were processed', ({ components }) => {
-    it('run test', async () => {
-      components.processedSnapshotStorage.markSnapshotAsProcessed(h1)
-      components.processedSnapshotStorage.markSnapshotAsProcessed(h2)
-      components.processedSnapshotStorage.markSnapshotAsProcessed(h3)
-      const markAsProcessedSpy = jest.spyOn(components.processedSnapshotStorage, 'markSnapshotAsProcessed')
-      const shouldProcess = await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
-        components,
-        genesisTimestamp,
-        processedSnapshotHash,
-        1,
-        [[h1, h2, h3], ['non-processed']]
-      )
-      expect(shouldProcess).toBeFalsy()
-      expect(markAsProcessedSpy).toBeCalledWith(processedSnapshotHash)
+    it('should not mark it as processed before its entities have been deployed', async () => {
+      await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(components, genesisTimestamp, snapshotHash, 1, [
+        [h1, h2, 'non-processed'],
+        [h3, 'non-processed']
+      ])
+
+      expect(markSnapshotAsProcessed).not.toHaveBeenCalledWith(snapshotHash)
     })
-  })
 
-  test('should process snapshot when not all the replaced hashes of any group were processed', ({ components }) => {
-    it('run test', async () => {
-      components.processedSnapshotStorage.markSnapshotAsProcessed(h1)
-      components.processedSnapshotStorage.markSnapshotAsProcessed(h2)
-      components.processedSnapshotStorage.markSnapshotAsProcessed(h3)
-      const markAsProcessedSpy = jest.spyOn(components.processedSnapshotStorage, 'markSnapshotAsProcessed')
-      const shouldProcess = await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(
-        components,
-        genesisTimestamp,
-        processedSnapshotHash,
-        1,
-        [[h1, h2, 'non-processed'], [h3, 'non-processed']]
-      )
-      expect(shouldProcess).toBeTruthy()
-      expect(markAsProcessedSpy).not.toBeCalledWith(processedSnapshotHash)
-      const processed = await components.processedSnapshotStorage.filterProcessedSnapshotsFrom([processedSnapshotHash, 'non-processed'])
-      expect(processed.size).toEqual(0)
+    it('should leave the storage with no record of it', async () => {
+      await shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded(components, genesisTimestamp, snapshotHash, 1, [
+        [h1, h2, 'non-processed'],
+        [h3, 'non-processed']
+      ])
+
+      await expect(
+        processedSnapshotStorage.filterProcessedSnapshotsFrom([snapshotHash, 'non-processed'])
+      ).resolves.toEqual(new Set())
     })
   })
 })

--- a/test/shutdownAbandonsRetries.spec.ts
+++ b/test/shutdownAbandonsRetries.spec.ts
@@ -1,0 +1,80 @@
+import { createInMemoryStorage, IContentStorageComponent } from '@dcl/catalyst-storage'
+import { resolve } from 'path'
+import { downloadFileWithRetries } from '../src/downloader'
+
+const contentHash = 'QmazJLZfUmZgNMTdwWSmJRvw4dBfcjS9GuqkwkKGRWb4K6'
+// Nothing listens here, so every attempt fails immediately.
+const deadServer = 'http://127.0.0.1:1'
+
+describe('downloadFileWithRetries', () => {
+  let storage: IContentStorageComponent
+
+  beforeEach(() => {
+    storage = createInMemoryStorage()
+  })
+
+  describe('when the caller is already stopping', () => {
+    it('should reject without attempting the download at all', async () => {
+      await expect(
+        downloadFileWithRetries(
+          { storage },
+          contentHash,
+          resolve('downloads'),
+          [deadServer],
+          new Map(),
+          10,
+          0,
+          () => true
+        )
+      ).rejects.toThrow('the caller asked to stop')
+    })
+  })
+
+  describe('when the caller starts stopping partway through the retry ladder', () => {
+    let attempts: number
+
+    beforeEach(() => {
+      attempts = 0
+    })
+
+    it('should abandon the remaining retries instead of waiting them out', async () => {
+      // Reports "stopping" from the third attempt onwards. Without the stop check the ladder would run
+      // all 10 attempts, which is what makes a shutdown wait out maxRetries x the request timeout.
+      const shouldStop = () => attempts >= 3
+
+      await expect(
+        downloadFileWithRetries(
+          { storage },
+          contentHash,
+          resolve('downloads'),
+          [
+            // Counted through the server picker: every attempt consumes one.
+            deadServer
+          ],
+          new Map(),
+          10,
+          0,
+          () => {
+            const stopping = shouldStop()
+            attempts++
+            return stopping
+          }
+        )
+      ).rejects.toThrow()
+
+      // One check before the first attempt, then one per failure: stopping at the third means we are
+      // far short of the ten attempts the ladder allows.
+      expect(attempts).toBeLessThan(10)
+    })
+  })
+
+  describe('when no stop predicate is supplied', () => {
+    it('should exhaust the configured retries as before', async () => {
+      await expect(
+        downloadFileWithRetries({ storage }, contentHash, resolve('downloads'), [deadServer], new Map(), 2, 0)
+      ).rejects.toThrow()
+
+      expect(await storage.exist(contentHash)).toBe(false)
+    })
+  })
+})

--- a/test/shutdownAwaitsRunningJobs.spec.ts
+++ b/test/shutdownAwaitsRunningJobs.spec.ts
@@ -1,0 +1,126 @@
+import future from 'fp-future'
+import { createJobLifecycleManagerComponent } from '../src/job-lifecycle-manager'
+import { createSerialJobRunner } from '../src/serial-job-runner'
+import { sleep } from '../src/utils'
+import { test } from './components'
+
+// Both helpers only *signal* a job to stop; per IJobWithLifecycle the job ends when start() returns.
+// If stop() resolves before then, a caller that treats it as "everything has wound down" can still
+// have a job mutating state — deploying entities, advancing timestamps — behind its back.
+
+describe('createSerialJobRunner', () => {
+  describe('when stop() is called while a job is still inside its action', () => {
+    let logger: any
+    let runner: ReturnType<typeof createSerialJobRunner>
+    let actionFinished: boolean
+
+    beforeEach(async () => {
+      logger = { log: jest.fn(), debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+      runner = createSerialJobRunner(logger)
+      actionFinished = false
+      const stopSignalled = future<void>()
+
+      runner.enqueue({
+        async start() {
+          await stopSignalled
+          // The action keeps working for a while after being told to stop, as a real one would while
+          // it finishes the request or deployment it is in the middle of.
+          await sleep(40)
+          actionFinished = true
+        },
+        async stop() {
+          stopSignalled.resolve()
+        }
+      })
+
+      await sleep(10)
+      await runner.stop()
+    })
+
+    it('should not resolve until the running action has actually finished', () => {
+      expect(actionFinished).toBe(true)
+    })
+  })
+})
+
+test('createJobLifecycleManagerComponent', ({ components }) => {
+  describe('when stop() is called while a job is still inside its action', () => {
+    let manager: ReturnType<typeof createJobLifecycleManagerComponent>
+    let finishedActions: string[]
+
+    beforeEach(async () => {
+      finishedActions = []
+
+      manager = createJobLifecycleManagerComponent(
+        { logs: components.logs },
+        {
+          jobManagerName: 'shutdown-manager',
+          createJob(name: string) {
+            const stopSignalled = future<void>()
+            return {
+              async start() {
+                await stopSignalled
+                await sleep(40)
+                finishedActions.push(name)
+              },
+              async stop() {
+                stopSignalled.resolve()
+              }
+            }
+          }
+        }
+      )
+
+      manager.setDesiredJobs(new Set(['a', 'b']))
+      await sleep(10)
+      await manager.stop!()
+    })
+
+    it('should not resolve until every running action has actually finished', () => {
+      expect(finishedActions.sort()).toEqual(['a', 'b'])
+    })
+
+    it('should report no running jobs', () => {
+      expect(Array.from(manager.getRunningJobs())).toEqual([])
+    })
+  })
+
+  describe('and a job was dropped from the desired set before the component was stopped', () => {
+    let manager: ReturnType<typeof createJobLifecycleManagerComponent>
+    let finishedActions: string[]
+
+    beforeEach(async () => {
+      finishedActions = []
+
+      manager = createJobLifecycleManagerComponent(
+        { logs: components.logs },
+        {
+          jobManagerName: 'shutdown-manager',
+          createJob(name: string) {
+            const stopSignalled = future<void>()
+            return {
+              async start() {
+                await stopSignalled
+                await sleep(40)
+                finishedActions.push(name)
+              },
+              async stop() {
+                stopSignalled.resolve()
+              }
+            }
+          }
+        }
+      )
+
+      manager.setDesiredJobs(new Set(['a', 'b']))
+      await sleep(10)
+      // 'a' is signalled to stop here but its action keeps running.
+      manager.setDesiredJobs(new Set(['b']))
+      await manager.stop!()
+    })
+
+    it('should wait for the dropped job too, not just the ones still desired', () => {
+      expect(finishedActions.sort()).toEqual(['a', 'b'])
+    })
+  })
+})

--- a/test/shutdownAwaitsRunningJobs.spec.ts
+++ b/test/shutdownAwaitsRunningJobs.spec.ts
@@ -85,6 +85,60 @@ test('createJobLifecycleManagerComponent', ({ components }) => {
     })
   })
 
+  describe('and a replacement job is waiting behind a predecessor when stop() is called', () => {
+    let manager: ReturnType<typeof createJobLifecycleManagerComponent>
+    let startedInstances: string[]
+    let releaseFirst: ReturnType<typeof future<void>>
+
+    beforeEach(async () => {
+      startedInstances = []
+      releaseFirst = future<void>()
+      let instances = 0
+
+      manager = createJobLifecycleManagerComponent(
+        { logs: components.logs },
+        {
+          jobManagerName: 'stop-during-deferred-start',
+          createJob(name: string) {
+            const instance = `${name}-${++instances}`
+            let jobStopped = false
+            return {
+              async start() {
+                startedInstances.push(instance)
+                if (instance === 'a-1') {
+                  await releaseFirst
+                }
+                // Mirrors the real jobs: the action returns promptly once stopped.
+                while (!jobStopped) {
+                  await sleep(5)
+                }
+              },
+              async stop() {
+                jobStopped = true
+              }
+            }
+          }
+        }
+      )
+
+      manager.setDesiredJobs(new Set(['a'])) // a-1 starts and blocks
+      manager.setDesiredJobs(new Set()) // a-1 signalled, its run still pending
+      manager.setDesiredJobs(new Set(['a'])) // a-2 created, deferred behind a-1's run
+      releaseFirst.resolve()
+      await manager.stop!()
+    })
+
+    it('should not leave a job running, and must not hang', () => {
+      expect(Array.from(manager.getRunningJobs())).toEqual([])
+    })
+
+    it('should never start a replacement it has already stopped', () => {
+      // If the name is still in createdJobs while `await job.stop()` yields, the deferred start fires
+      // and launches a job that was just stopped — whose run then never settles, hanging stop().
+      expect(startedInstances).toEqual(['a-1'])
+    })
+  })
+
   describe('and a job was dropped from the desired set before the component was stopped', () => {
     let manager: ReturnType<typeof createJobLifecycleManagerComponent>
     let finishedActions: string[]

--- a/test/streamEntitiesEdgeCases.spec.ts
+++ b/test/streamEntitiesEdgeCases.spec.ts
@@ -1,0 +1,233 @@
+import { AuthLinkType } from '@dcl/schemas'
+import { createReadStream } from 'fs'
+import { resolve } from 'path'
+import {
+  getDeployedEntitiesStreamFromPointerChanges,
+  getDeployedEntitiesStreamFromSnapshot
+} from '../src/stream-entities'
+import { test } from './components'
+
+const snapshotHash = 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu'
+const authChain = [{ type: AuthLinkType.SIGNER, payload: '0x1', signature: '' }]
+
+test('getDeployedEntitiesStreamFromSnapshot', ({ components }) => {
+  const tmpDownloadFolder = resolve('downloads')
+  const streamOptions = {
+    tmpDownloadFolder,
+    requestMaxRetries: 3,
+    requestRetryWaitTime: 0
+  }
+
+  it('prepares the endpoints', () => {
+    components.router.get(`/contents/${snapshotHash}`, async () => ({
+      body: createReadStream(`test/fixtures/${snapshotHash}`)
+    }))
+  })
+
+  describe('when deleting the snapshot after usage fails', () => {
+    let servers: Set<string>
+    let deleteError: Error
+
+    beforeEach(async () => {
+      servers = new Set([await components.getBaseUrl()])
+      deleteError = new Error('storage refused the delete')
+      jest.spyOn(components.storage, 'delete').mockRejectedValue(deleteError)
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should still finish the stream instead of surfacing the cleanup failure', async () => {
+      const streamed: string[] = []
+      for await (const deployment of getDeployedEntitiesStreamFromSnapshot(
+        components,
+        streamOptions,
+        snapshotHash,
+        servers
+      )) {
+        streamed.push(deployment.entityId)
+      }
+
+      expect(streamed.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('when deleteSnapshotAfterUsage is disabled', () => {
+    let servers: Set<string>
+    let deleteSpy: jest.SpyInstance
+
+    beforeEach(async () => {
+      servers = new Set([await components.getBaseUrl()])
+      deleteSpy = jest.spyOn(components.storage, 'delete')
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should keep the snapshot file in storage', async () => {
+      for await (const _deployment of getDeployedEntitiesStreamFromSnapshot(
+        components,
+        { ...streamOptions, deleteSnapshotAfterUsage: false },
+        snapshotHash,
+        servers
+      )) {
+        /* drain */
+      }
+
+      expect(deleteSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when fromTimestamp is newer than every entity in the snapshot', () => {
+    let servers: Set<string>
+
+    beforeEach(async () => {
+      servers = new Set([await components.getBaseUrl()])
+    })
+
+    it('should yield nothing', async () => {
+      const streamed: string[] = []
+      for await (const deployment of getDeployedEntitiesStreamFromSnapshot(
+        components,
+        { ...streamOptions, fromTimestamp: Number.MAX_SAFE_INTEGER, deleteSnapshotAfterUsage: false },
+        snapshotHash,
+        servers
+      )) {
+        streamed.push(deployment.entityId)
+      }
+
+      expect(streamed).toEqual([])
+    })
+  })
+})
+
+function delta(index: number) {
+  return {
+    entityType: 'profile',
+    // 'ba' + 57 chars: the CIDv1 shape the deployment schema requires. Getting the length wrong makes
+    // every delta fail validation and yield nothing, which looks like a hang rather than a failure.
+    entityId: `ba${String(index).padStart(57, '0')}`,
+    entityTimestamp: index,
+    localTimestamp: index,
+    authChain,
+    pointers: ['0x1']
+  }
+}
+
+test('getDeployedEntitiesStreamFromPointerChanges', ({ components }) => {
+  let polls: number
+  // How many deployments each poll returns. fetchPointerChanges always builds the
+  // `${server}/pointer-changes` URL itself, so per-case payloads have to come from here rather than
+  // from a different route.
+  let deltasPerPoll: number
+
+  it('prepares the endpoints', () => {
+    polls = 0
+    deltasPerPoll = 1
+    components.router.get('/pointer-changes', async () => {
+      polls++
+      const startingIndex = (polls - 1) * deltasPerPoll + 1
+      return {
+        body: {
+          deltas: Array.from({ length: deltasPerPoll }, (_unused, offset) => delta(startingIndex + offset)),
+          pagination: {}
+        }
+      }
+    })
+  })
+
+  describe('when shouldStop turns true after the first deployment', () => {
+    let streamed: string[]
+    let pollsWhenDone: number
+
+    beforeEach(async () => {
+      polls = 0
+      streamed = []
+      let seen = 0
+
+      for await (const deployment of getDeployedEntitiesStreamFromPointerChanges(
+        components,
+        { pointerChangesWaitTime: 5 },
+        await components.getBaseUrl(),
+        () => seen >= 1
+      )) {
+        streamed.push(deployment.entityId)
+        seen++
+      }
+      pollsWhenDone = polls
+    })
+
+    it('should stop the stream at the deployment that tripped the predicate', () => {
+      expect(streamed).toHaveLength(1)
+    })
+
+    it('should not keep polling the server', () => {
+      expect(pollsWhenDone).toBe(1)
+    })
+  })
+
+  describe('and shouldStop turns true partway through a single page of deployments', () => {
+    let streamed: string[]
+    let pollsWhenDone: number
+
+    beforeEach(async () => {
+      polls = 0
+      streamed = []
+      // A single poll carrying three deployments, so the predicate has to be honoured mid-page and
+      // not merely between polls.
+      deltasPerPoll = 3
+      let seen = 0
+
+      for await (const deployment of getDeployedEntitiesStreamFromPointerChanges(
+        components,
+        { pointerChangesWaitTime: 5 },
+        await components.getBaseUrl(),
+        () => seen >= 2
+      )) {
+        streamed.push(deployment.entityId)
+        seen++
+      }
+      pollsWhenDone = polls
+    })
+
+    afterEach(() => {
+      deltasPerPoll = 1
+    })
+
+    it('should stop after the deployment that tripped the predicate', () => {
+      expect(streamed).toHaveLength(2)
+    })
+
+    it('should not have needed a second poll to notice', () => {
+      expect(pollsWhenDone).toBe(1)
+    })
+  })
+
+  describe('when shouldStop is already true before the first poll', () => {
+    let streamed: string[]
+
+    beforeEach(async () => {
+      polls = 0
+      streamed = []
+
+      for await (const deployment of getDeployedEntitiesStreamFromPointerChanges(
+        components,
+        { pointerChangesWaitTime: 5 },
+        await components.getBaseUrl(),
+        () => true
+      )) {
+        streamed.push(deployment.entityId)
+      }
+    })
+
+    it('should yield nothing', () => {
+      expect(streamed).toEqual([])
+    })
+
+    it('should never request pointer-changes at all', () => {
+      expect(polls).toBe(0)
+    })
+  })
+})

--- a/test/streamToBuffer.spec.ts
+++ b/test/streamToBuffer.spec.ts
@@ -1,0 +1,72 @@
+import { Readable } from 'stream'
+import { streamToBuffer } from '../src/utils'
+
+describe('streamToBuffer', () => {
+  describe('when no maximum is given', () => {
+    let result: Buffer
+
+    beforeEach(async () => {
+      result = await streamToBuffer(Readable.from([Buffer.from('abc'), Buffer.from('def')]))
+    })
+
+    it('should concatenate every chunk', () => {
+      expect(result.toString()).toEqual('abcdef')
+    })
+  })
+
+  describe('when the stream stays within the maximum', () => {
+    let result: Buffer
+
+    beforeEach(async () => {
+      result = await streamToBuffer(Readable.from([Buffer.alloc(10, 0x61)]), 16)
+    })
+
+    it('should return the buffered content', () => {
+      expect(result.length).toEqual(10)
+    })
+  })
+
+  describe('when the stream exceeds the maximum', () => {
+    let thrownError: Error | undefined
+
+    beforeEach(async () => {
+      thrownError = undefined
+      try {
+        await streamToBuffer(Readable.from([Buffer.alloc(10, 0x61), Buffer.alloc(10, 0x62)]), 16)
+      } catch (error: any) {
+        thrownError = error
+      }
+    })
+
+    it('should reject rather than buffering the whole stream', () => {
+      expect(thrownError?.message).toEqual('Stream exceeds the maximum allowed size of 16 bytes')
+    })
+  })
+
+  describe('and the producer keeps going after the maximum is exceeded', () => {
+    let stream: Readable
+    let chunksProduced: number
+
+    beforeEach(async () => {
+      chunksProduced = 0
+      // Counts what the producer was actually asked for, so the assertion shows the stream was torn
+      // down instead of being drained into a buffer nobody will read.
+      function* chunks() {
+        for (let index = 0; index < 1000; index++) {
+          chunksProduced++
+          yield Buffer.alloc(10, 0x61)
+        }
+      }
+      stream = Readable.from(chunks())
+      await streamToBuffer(stream, 16).catch(() => undefined)
+    })
+
+    it('should destroy the stream', () => {
+      expect(stream.destroyed).toEqual(true)
+    })
+
+    it('should stop pulling chunks from the producer', () => {
+      expect(chunksProduced).toBeLessThan(1000)
+    })
+  })
+})

--- a/test/synchronizer.spec.ts
+++ b/test/synchronizer.spec.ts
@@ -118,7 +118,7 @@ test('synchronizer deploys entities from snapshots and pointer-changes at bootst
       bootstrapFinished.resolve()
     })
     await bootstrapFinished
-    await synchronizer.stop()
+    await synchronizer.stop!()
     const entityIds = [
       // snapshot entities
       'ba000000000000000000000000000000000000000000000000000000001',
@@ -243,7 +243,7 @@ test('synchronizer should not deploy entities from snapshot if it has itdx as ow
       bootstrapFinished.resolve()
     })
     await bootstrapFinished
-    await synchronizer.stop()
+    await synchronizer.stop!()
     expect(deployerMock.scheduleEntityDeployment).not.toBeCalled()
     // expect snapshot is not deleted
     expect(storageDeleteSpy).not.toBeCalled()

--- a/test/synchronizerBootstrapEdgeCases.spec.ts
+++ b/test/synchronizerBootstrapEdgeCases.spec.ts
@@ -52,7 +52,16 @@ test('synchronizer when a server serves snapshots but fails pointer-changes duri
   it('attempts the bootstrap repeatedly', async () => {
     synchronizer = await buildSynchronizer(
       components,
-      { scheduleEntityDeployment: jest.fn(), onIdle: jest.fn(), prepareForDeploymentsIn: jest.fn() },
+      {
+        // Reports each entity as deployed, which is what markAsDeployed is for. A deployer that never
+        // called it would leave the snapshot incomplete, and the server would stay in snapshot
+        // bootstrap instead of reaching the pointer-changes phase this test is about.
+        async scheduleEntityDeployment(entity) {
+          if (entity.markAsDeployed) await entity.markAsDeployed()
+        },
+        onIdle: jest.fn(),
+        prepareForDeploymentsIn: jest.fn()
+      },
       // Short enough that the failed bootstrap retries within the test.
       50
     )

--- a/test/synchronizerBootstrapEdgeCases.spec.ts
+++ b/test/synchronizerBootstrapEdgeCases.spec.ts
@@ -1,0 +1,190 @@
+import future from 'fp-future'
+import { createReadStream } from 'fs'
+import { resolve } from 'path'
+import { createSynchronizer } from '../src/synchronizer'
+import { IDeployerComponent, SnapshotsFetcherComponents, SynchronizerComponent } from '../src/types'
+import { sleep } from '../src/utils'
+import { test } from './components'
+
+const snapshotHash = 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu'
+const replacedHash = 'bafkreico6luxnkk5vxuxvmpsg7hva4upamyz3br2b6ucc7rf3hdlcaehha'
+
+function buildSynchronizer(
+  components: SnapshotsFetcherComponents,
+  deployer: IDeployerComponent,
+  reconnectTime = 60_000
+): Promise<SynchronizerComponent> {
+  const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+  return createSynchronizer(
+    { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage, deployer },
+    {
+      bootstrapReconnection: { reconnectTime },
+      syncingReconnection: { reconnectTime: 60_000 },
+      tmpDownloadFolder: resolve('downloads'),
+      requestMaxRetries: 2,
+      requestRetryWaitTime: 0,
+      pointerChangesWaitTime: 0
+    }
+  )
+}
+
+test('synchronizer when a server serves snapshots but fails pointer-changes during bootstrap', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let snapshotsRequests: number
+  let pointerChangesRequests: number
+
+  it('prepares the endpoints', () => {
+    snapshotsRequests = 0
+    pointerChangesRequests = 0
+    components.router.get('/snapshots', async () => {
+      snapshotsRequests++
+      return { body: [{ hash: snapshotHash, timeRange: { initTimestamp: 0, endTimestamp: 20 * 60_000 + 1 } }] }
+    })
+    components.router.get(`/contents/${snapshotHash}`, async () => ({
+      body: createReadStream(`test/fixtures/${snapshotHash}`)
+    }))
+    components.router.get('/pointer-changes', async () => {
+      pointerChangesRequests++
+      return { status: 503, body: 'pointer-changes is down' }
+    })
+  })
+
+  it('attempts the bootstrap repeatedly', async () => {
+    synchronizer = await buildSynchronizer(
+      components,
+      { scheduleEntityDeployment: jest.fn(), onIdle: jest.fn(), prepareForDeploymentsIn: jest.fn() },
+      // Short enough that the failed bootstrap retries within the test.
+      50
+    )
+
+    const firstAttemptFinished = future<void>()
+    const syncJob = await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    await syncJob.onInitialBootstrapFinished(async () => firstAttemptFinished.resolve())
+    await firstAttemptFinished
+    await sleep(300)
+  })
+
+  it('should keep retrying the pointer-changes bootstrap for the failing server', () => {
+    expect(pointerChangesRequests).toBeGreaterThan(1)
+  })
+
+  it('should not re-fetch the snapshots it already processed on each retry', () => {
+    // The server moved out of the snapshots-bootstrapping set on the first pass, so retries resume at
+    // the pointer-changes phase rather than redoing the whole snapshot download.
+    expect(snapshotsRequests).toBe(1)
+  })
+
+  afterAll(async () => {
+    await synchronizer.stop!()
+  })
+})
+
+test('synchronizer when a snapshot declares replaced snapshot hashes', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let checkedHashes: string[]
+
+  it('prepares the endpoints', () => {
+    checkedHashes = []
+    components.router.get('/snapshots', async () => ({
+      body: [
+        {
+          hash: snapshotHash,
+          timeRange: { initTimestamp: 0, endTimestamp: 20 * 60_000 + 1 },
+          replacedSnapshotHashes: [replacedHash]
+        }
+      ]
+    }))
+    components.router.get(`/contents/${snapshotHash}`, async () => ({
+      body: createReadStream(`test/fixtures/${snapshotHash}`)
+    }))
+    components.router.get('/pointer-changes', async () => ({ body: { deltas: [], pagination: {} } }))
+  })
+
+  it('bootstraps the server', async () => {
+    jest
+      .spyOn(components.processedSnapshotStorage, 'filterProcessedSnapshotsFrom')
+      .mockImplementation(async (hashes: string[]) => {
+        checkedHashes.push(...hashes)
+        return new Set<string>()
+      })
+
+    synchronizer = await buildSynchronizer(components, {
+      async scheduleEntityDeployment(entity) {
+        if (entity.markAsDeployed) await entity.markAsDeployed()
+      },
+      onIdle: jest.fn(),
+      prepareForDeploymentsIn: jest.fn()
+    })
+
+    const bootstrapFinished = future<void>()
+    const syncJob = await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    await syncJob.onInitialBootstrapFinished(async () => bootstrapFinished.resolve())
+    await bootstrapFinished
+  })
+
+  it('should include the replaced hashes in the single processed-snapshots lookup', () => {
+    expect(checkedHashes).toEqual(expect.arrayContaining([snapshotHash, replacedHash]))
+  })
+
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    await synchronizer.stop!()
+  })
+})
+
+test('synchronizer lifecycle guards', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+
+  it('prepares the endpoints', () => {
+    components.router.get('/snapshots', async () => ({ body: [] }))
+    components.router.get('/pointer-changes', async () => ({ body: { deltas: [], pagination: {} } }))
+  })
+
+  describe('when syncWithServers is called after stop', () => {
+    beforeEach(async () => {
+      synchronizer = await buildSynchronizer(components, {
+        scheduleEntityDeployment: jest.fn(),
+        onIdle: jest.fn(),
+        prepareForDeploymentsIn: jest.fn()
+      })
+      await synchronizer.stop!()
+    })
+
+    it('should reject instead of starting new work', async () => {
+      await expect(synchronizer.syncWithServers(new Set(['https://peer.example.com']))).rejects.toThrow(
+        'synchronizer is stopped.'
+      )
+    })
+  })
+
+  describe('when onInitialBootstrapFinished is registered after the first bootstrap already finished', () => {
+    let calledImmediately: boolean
+
+    beforeEach(async () => {
+      calledImmediately = false
+      synchronizer = await buildSynchronizer(components, {
+        scheduleEntityDeployment: jest.fn(),
+        onIdle: jest.fn(),
+        prepareForDeploymentsIn: jest.fn()
+      })
+
+      const firstBootstrap = future<void>()
+      const syncJob = await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+      await syncJob.onInitialBootstrapFinished(async () => firstBootstrap.resolve())
+      await firstBootstrap
+
+      // Registering now must invoke the callback straight away rather than queue it forever.
+      await syncJob.onInitialBootstrapFinished(async () => {
+        calledImmediately = true
+      })
+    })
+
+    afterEach(async () => {
+      await synchronizer.stop!()
+    })
+
+    it('should invoke the callback immediately', () => {
+      expect(calledImmediately).toBe(true)
+    })
+  })
+})

--- a/test/synchronizerConcurrency.spec.ts
+++ b/test/synchronizerConcurrency.spec.ts
@@ -55,7 +55,20 @@ test('createSynchronizer snapshot deployment concurrency', ({ components }) => {
     components.router.get('/pointer-changes', async () => ({ body: { deltas: [], pagination: {} } }))
   })
 
-  async function bootstrapWith(concurrency: SynchronizerOptions['concurrency']) {
+  // Polls until the condition holds instead of assuming a fixed delay was long enough. The previous
+  // fixed 60ms sleep raced the event loop: when no download had started yet the assertion read a peak
+  // of 0, which it did on most runs.
+  async function waitUntil(condition: () => boolean, description: string, timeoutMs = 10_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    while (!condition()) {
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out after ${timeoutMs}ms waiting until ${description}`)
+      }
+      await new Promise((ok) => setTimeout(ok, 5))
+    }
+  }
+
+  async function bootstrapWith(concurrency: SynchronizerOptions['concurrency'], expectedPeak: number) {
     inFlight = 0
     maxInFlight = 0
     releaseDownloads = future<void>()
@@ -85,10 +98,23 @@ test('createSynchronizer snapshot deployment concurrency', ({ components }) => {
     const syncJob = await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
     void syncJob.onInitialBootstrapFinished(async () => bootstrapFinished.resolve())
 
-    // Give every queued snapshot the chance to start before letting them finish.
-    await new Promise((ok) => setTimeout(ok, 60))
-    const observedPeak = maxInFlight
-    releaseDownloads.resolve()
+    let observedPeak: number
+    try {
+      // The downloads are held open, so once this many are in flight the count cannot drop again —
+      // waiting for it is deterministic, unlike sleeping and hoping they started.
+      await waitUntil(
+        () => inFlight >= expectedPeak,
+        `${expectedPeak} snapshot download(s) are in flight (saw ${maxInFlight})`
+      )
+      // Brief settle so a queue that permits MORE than the bound gets the chance to reveal it. This
+      // only guards the upper bound; the lower bound is already established above.
+      await new Promise((ok) => setTimeout(ok, 50))
+      observedPeak = maxInFlight
+    } finally {
+      // Always release, or the held request handlers keep the suite hanging until the jest timeout
+      // instead of reporting why the wait above failed.
+      releaseDownloads.resolve()
+    }
     await bootstrapFinished
     await synchronizer.stop!()
 
@@ -101,7 +127,7 @@ test('createSynchronizer snapshot deployment concurrency', ({ components }) => {
     let observedPeak: number
 
     beforeEach(async () => {
-      observedPeak = await bootstrapWith({ snapshotDeployments: 1 })
+      observedPeak = await bootstrapWith({ snapshotDeployments: 1 }, 1)
     })
 
     it('should download the snapshots one at a time', () => {
@@ -113,7 +139,7 @@ test('createSynchronizer snapshot deployment concurrency', ({ components }) => {
     let observedPeak: number
 
     beforeEach(async () => {
-      observedPeak = await bootstrapWith({ snapshotDeployments: 3 })
+      observedPeak = await bootstrapWith({ snapshotDeployments: 3 }, snapshotHashes.length)
     })
 
     it('should download them in parallel up to the configured bound', () => {

--- a/test/synchronizerConcurrency.spec.ts
+++ b/test/synchronizerConcurrency.spec.ts
@@ -1,0 +1,172 @@
+import future from 'fp-future'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { createSynchronizer } from '../src/synchronizer'
+import { DeployableEntity, SynchronizerComponent, SynchronizerOptions } from '../src/types'
+import { test } from './components'
+
+// Three snapshot hashes deliberately absent from test/fixtures, so each one is really downloaded
+// (rather than short-circuiting on the preloaded in-memory storage) and the download can be held open.
+const snapshotHashes = [
+  'bafkreiconcurrencysnapshotaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  'bafkreiconcurrencysnapshotbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  'bafkreiconcurrencysnapshotccccccccccccccccccccccccccccccccccccc'
+]
+const snapshotBody = readFileSync('test/fixtures/bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu')
+
+function baseOptions(): SynchronizerOptions {
+  return {
+    bootstrapReconnection: { reconnectTime: 60_000 },
+    syncingReconnection: { reconnectTime: 60_000 },
+    tmpDownloadFolder: resolve('downloads'),
+    requestMaxRetries: 1,
+    requestRetryWaitTime: 0,
+    pointerChangesWaitTime: 0
+  }
+}
+
+test('createSynchronizer snapshot deployment concurrency', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let inFlight: number
+  let maxInFlight: number
+  let releaseDownloads: ReturnType<typeof future<void>>
+
+  it('prepares the endpoints', () => {
+    components.router.get('/snapshots', async () => ({
+      body: snapshotHashes.map((hash, index) => ({
+        hash,
+        // Distinct, non-overlapping ranges so none is treated as replacing another.
+        timeRange: { initTimestamp: index * 1000, endTimestamp: (index + 1) * 1000 }
+      }))
+    }))
+
+    for (const hash of snapshotHashes) {
+      components.router.get(`/contents/${hash}`, async () => {
+        inFlight++
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        // Hold every snapshot download open until they have all had a chance to start, so any
+        // overlap the queue permits is observable.
+        await releaseDownloads
+        inFlight--
+        return { body: snapshotBody }
+      })
+    }
+
+    components.router.get('/pointer-changes', async () => ({ body: { deltas: [], pagination: {} } }))
+  })
+
+  async function bootstrapWith(concurrency: SynchronizerOptions['concurrency']) {
+    inFlight = 0
+    maxInFlight = 0
+    releaseDownloads = future<void>()
+
+    const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+    synchronizer = await createSynchronizer(
+      {
+        fetcher,
+        downloadQueue,
+        logs,
+        storage,
+        metrics,
+        processedSnapshotStorage,
+        snapshotStorage,
+        deployer: {
+          async scheduleEntityDeployment(entity: DeployableEntity) {
+            if (entity.markAsDeployed) await entity.markAsDeployed()
+          },
+          onIdle: jest.fn(),
+          prepareForDeploymentsIn: jest.fn()
+        }
+      },
+      { ...baseOptions(), concurrency }
+    )
+
+    const bootstrapFinished = future<void>()
+    const syncJob = await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    void syncJob.onInitialBootstrapFinished(async () => bootstrapFinished.resolve())
+
+    // Give every queued snapshot the chance to start before letting them finish.
+    await new Promise((ok) => setTimeout(ok, 60))
+    const observedPeak = maxInFlight
+    releaseDownloads.resolve()
+    await bootstrapFinished
+    await synchronizer.stop!()
+
+    // Snapshots must be forgotten between cases, or the second run skips them as processed.
+    await storage.delete(snapshotHashes)
+    return observedPeak
+  }
+
+  describe('when snapshotDeployments concurrency is 1', () => {
+    let observedPeak: number
+
+    beforeEach(async () => {
+      observedPeak = await bootstrapWith({ snapshotDeployments: 1 })
+    })
+
+    it('should download the snapshots one at a time', () => {
+      expect(observedPeak).toBe(1)
+    })
+  })
+
+  describe('and snapshotDeployments concurrency allows all of them at once', () => {
+    let observedPeak: number
+
+    beforeEach(async () => {
+      observedPeak = await bootstrapWith({ snapshotDeployments: 3 })
+    })
+
+    it('should download them in parallel up to the configured bound', () => {
+      expect(observedPeak).toBe(snapshotHashes.length)
+    })
+  })
+})
+
+test('createSynchronizer concurrency validation', ({ components }) => {
+  function create(concurrency: SynchronizerOptions['concurrency']) {
+    const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+    return createSynchronizer(
+      {
+        fetcher,
+        downloadQueue,
+        logs,
+        storage,
+        metrics,
+        processedSnapshotStorage,
+        snapshotStorage,
+        deployer: {
+          scheduleEntityDeployment: jest.fn(),
+          onIdle: jest.fn(),
+          prepareForDeploymentsIn: jest.fn()
+        }
+      },
+      { ...baseOptions(), concurrency }
+    )
+  }
+
+  describe('when snapshotDeployments is zero', () => {
+    it('should reject naming the offending option instead of failing inside the queue', async () => {
+      await expect(create({ snapshotDeployments: 0 })).rejects.toThrow(
+        'options.concurrency.snapshotDeployments must be an integer >= 1, got 0'
+      )
+    })
+  })
+
+  describe('when snapshotChecks is not an integer', () => {
+    it('should reject naming the offending option', async () => {
+      await expect(create({ snapshotChecks: 2.5 })).rejects.toThrow(
+        'options.concurrency.snapshotChecks must be an integer >= 1, got 2.5'
+      )
+    })
+  })
+
+  describe('when concurrency is omitted entirely', () => {
+    it('should build the synchronizer with the defaults', async () => {
+      const synchronizer = await create(undefined)
+
+      await synchronizer.stop!()
+
+      expect(synchronizer.syncWithServers).toBeInstanceOf(Function)
+    })
+  })
+})

--- a/test/synchronizerConcurrency.spec.ts
+++ b/test/synchronizerConcurrency.spec.ts
@@ -196,3 +196,54 @@ test('createSynchronizer concurrency validation', ({ components }) => {
     })
   })
 })
+
+test('createSynchronizer transferLimits validation', ({ components }) => {
+  function create(transferLimits: SynchronizerOptions['transferLimits']) {
+    const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+    return createSynchronizer(
+      {
+        fetcher,
+        downloadQueue,
+        logs,
+        storage,
+        metrics,
+        processedSnapshotStorage,
+        snapshotStorage,
+        deployer: {
+          scheduleEntityDeployment: jest.fn(),
+          onIdle: jest.fn(),
+          prepareForDeploymentsIn: jest.fn()
+        }
+      },
+      { ...baseOptions(), transferLimits }
+    )
+  }
+
+  describe('when a transfer limit is below the minimum it accepts', () => {
+    it('should reject at construction rather than on some later download', async () => {
+      await expect(create({ maxDownloadedFileSizeInBytes: 0 })).rejects.toThrow(
+        'transferLimits.maxDownloadedFileSizeInBytes must be an integer >= 1, got 0'
+      )
+    })
+  })
+
+  describe('when a transfer limit is not an integer', () => {
+    it('should reject naming the offending option', async () => {
+      await expect(create({ requestTimeoutInMs: 1.5 })).rejects.toThrow(
+        'transferLimits.requestTimeoutInMs must be an integer >= 1, got 1.5'
+      )
+    })
+  })
+
+  describe('when the rate floor is zero', () => {
+    it('should be accepted, since zero is how the check is disabled', async () => {
+      await expect(create({ minTransferRateInBytesPerSecond: 0 })).resolves.toBeDefined()
+    })
+  })
+
+  describe('when transferLimits is omitted entirely', () => {
+    it('should build the synchronizer with the defaults', async () => {
+      await expect(create(undefined)).resolves.toBeDefined()
+    })
+  })
+})

--- a/test/synchronizerDeployerQuiescence.spec.ts
+++ b/test/synchronizerDeployerQuiescence.spec.ts
@@ -474,7 +474,10 @@ test('synchronizer when a syncing-phase deployment is dropped and the stream the
         tmpDownloadFolder: resolve('downloads'),
         requestMaxRetries: 1,
         requestRetryWaitTime: 0,
-        pointerChangesWaitTime: 0
+        // Non-zero, so the syncing stream is long-lived and keeps polling from its own internal
+        // high-water mark. With 0 it ends after one poll and reconnects regardless, which hides whether
+        // an incomplete poll is what ends the run.
+        pointerChangesWaitTime: 30
       }
     )
 
@@ -488,6 +491,16 @@ test('synchronizer when a syncing-phase deployment is dropped and the stream the
     const resumedPastTheDrop = requestedFrom.filter((from) => Number(from) > droppedLocalTimestamp)
 
     expect(resumedPastTheDrop).toEqual([])
+  })
+
+  it('should reconnect and re-request the window containing it, rather than only pinning the mark', () => {
+    // Holding the durable mark back alone is not enough: the live stream polls from its own internal
+    // high-water mark, so without ending the run nothing re-fetches the dropped entity until the stream
+    // happens to restart — and the periodic snapshot sync that would otherwise catch it runs every 14
+    // days. Repeated polls at the pre-drop `from` are the evidence it is actually being retried.
+    const pollsAtTheDurableMark = requestedFrom.filter((from) => Number(from) <= droppedLocalTimestamp)
+
+    expect(pollsAtTheDurableMark.length).toBeGreaterThanOrEqual(3)
   })
 
   afterAll(async () => {

--- a/test/synchronizerDeployerQuiescence.spec.ts
+++ b/test/synchronizerDeployerQuiescence.spec.ts
@@ -494,3 +494,77 @@ test('synchronizer when a syncing-phase deployment is dropped and the stream the
     await synchronizer.stop!()
   })
 })
+
+test('synchronizer when a deployer acknowledges one delta twice and drops an earlier one', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let requestedFrom: string[]
+  let scheduled: number
+
+  const droppedLocalTimestamp = 50 * 60_000
+  const acknowledgedLocalTimestamp = 100 * 60_000
+
+  function delta(entityId: string, localTimestamp: number, entityTimestamp: number) {
+    return {
+      entityId,
+      entityType: 'profile',
+      pointers: ['0x1'],
+      entityTimestamp,
+      localTimestamp,
+      authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+    }
+  }
+
+  it('prepares the endpoints', () => {
+    requestedFrom = []
+    scheduled = 0
+    components.router.get('/snapshots', async () => ({ body: [] }))
+    components.router.get('/pointer-changes', async (ctx: any) => {
+      requestedFrom.push(new URL(ctx.url.toString()).searchParams.get('from') ?? '')
+      if (requestedFrom.length === 1) {
+        return {
+          body: {
+            deltas: [
+              delta('ba000000000000000000000000000000000000000000000000000000001', droppedLocalTimestamp, 1),
+              delta('ba000000000000000000000000000000000000000000000000000000002', acknowledgedLocalTimestamp, 2)
+            ],
+            pagination: {}
+          }
+        }
+      }
+      return { body: { deltas: [], pagination: {} } }
+    })
+  })
+
+  it('attempts the bootstrap', async () => {
+    synchronizer = await buildSynchronizer(
+      components,
+      {
+        async scheduleEntityDeployment(entity: DeployableEntity) {
+          scheduled++
+          // The first entity is dropped. The second is acknowledged TWICE — enough to make a
+          // call-counting guard see acknowledged === scheduled and believe nothing was missed.
+          if (scheduled === 2 && entity.markAsDeployed) {
+            await entity.markAsDeployed()
+            await entity.markAsDeployed()
+          }
+        },
+        onIdle: jest.fn(),
+        prepareForDeploymentsIn: jest.fn()
+      },
+      50
+    )
+
+    await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    await waitUntil(() => scheduled >= 2 && requestedFrom.length >= 2, 'the bootstrap has been retried')
+  })
+
+  it('should not let the duplicate acknowledgement cover for the dropped delta', () => {
+    const resumedPastTheDrop = requestedFrom.filter((from) => Number(from) > droppedLocalTimestamp)
+
+    expect(resumedPastTheDrop).toEqual([])
+  })
+
+  afterAll(async () => {
+    await synchronizer.stop!()
+  })
+})

--- a/test/synchronizerDeployerQuiescence.spec.ts
+++ b/test/synchronizerDeployerQuiescence.spec.ts
@@ -251,3 +251,85 @@ test('synchronizer when a pointer-changes deployment marks a later timestamp and
     await synchronizer.stop!()
   })
 })
+
+test('synchronizer when a pointer-changes bootstrap deployment is silently dropped', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let requestedFrom: string[]
+  let scheduled: number
+
+  // The earlier delta is dropped by the deployer; the later one is acknowledged. Because the resume point
+  // is a maximum over acknowledged timestamps, the mark would land past the dropped one — and the drain
+  // resolving cleanly cannot tell the difference.
+  const droppedLocalTimestamp = 50 * 60_000
+  const acknowledgedLocalTimestamp = 100 * 60_000
+
+  it('prepares the endpoints', () => {
+    requestedFrom = []
+    scheduled = 0
+    components.router.get('/snapshots', async () => ({ body: [] }))
+    components.router.get('/pointer-changes', async (ctx: any) => {
+      requestedFrom.push(new URL(ctx.url.toString()).searchParams.get('from') ?? '')
+      if (requestedFrom.length > 1) {
+        return { body: { deltas: [], pagination: {} } }
+      }
+      return {
+        body: {
+          deltas: [
+            {
+              entityId: 'ba000000000000000000000000000000000000000000000000000000001',
+              entityType: 'profile',
+              pointers: ['0x1'],
+              entityTimestamp: 1,
+              localTimestamp: droppedLocalTimestamp,
+              authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+            },
+            {
+              entityId: 'ba000000000000000000000000000000000000000000000000000000002',
+              entityType: 'profile',
+              pointers: ['0x2'],
+              entityTimestamp: 2,
+              localTimestamp: acknowledgedLocalTimestamp,
+              authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+            }
+          ],
+          pagination: {}
+        }
+      }
+    })
+  })
+
+  it('attempts the bootstrap', async () => {
+    synchronizer = await buildSynchronizer(
+      components,
+      {
+        async scheduleEntityDeployment(entity: DeployableEntity) {
+          scheduled++
+          // Only the second delta reports back. The first is dropped without an error, which is exactly
+          // what a resolving onIdle() cannot rule out.
+          if (scheduled === 2 && entity.markAsDeployed) {
+            await entity.markAsDeployed()
+          }
+        },
+        // Drains cleanly regardless.
+        onIdle: jest.fn(),
+        prepareForDeploymentsIn: jest.fn()
+      },
+      50
+    )
+
+    await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    await waitUntil(() => scheduled >= 2 && requestedFrom.length >= 2, 'the bootstrap has been retried')
+  })
+
+  it('should not adopt a resume point past the dropped deployment', () => {
+    // The retry must re-request from where the first attempt started, not from the acknowledged mark.
+    // Deliberately the only assertion here: a "was it promoted?" check on the request count would pass
+    // either way, because a promoted server's syncing job polls this endpoint too. The `from` value is
+    // what actually distinguishes the two outcomes.
+    expect(requestedFrom[1]).toEqual(requestedFrom[0])
+  })
+
+  afterAll(async () => {
+    await synchronizer.stop!()
+  })
+})

--- a/test/synchronizerDeployerQuiescence.spec.ts
+++ b/test/synchronizerDeployerQuiescence.spec.ts
@@ -180,3 +180,74 @@ test('synchronizer when the deployer drains without marking every entity deploye
     await synchronizer.stop!()
   })
 })
+
+test('synchronizer when a pointer-changes deployment marks a later timestamp and the drain then fails', ({
+  components
+}) => {
+  let synchronizer: SynchronizerComponent
+  let requestedFrom: string[]
+  let drainAlreadyFailed: boolean
+
+  // Well past the 20-minute bootstrap shift, so a prematurely committed mark cannot be masked by it.
+  const lateLocalTimestamp = 100 * 60_000
+
+  it('prepares the endpoints', () => {
+    requestedFrom = []
+    drainAlreadyFailed = false
+    components.router.get('/snapshots', async () => ({ body: [] }))
+    components.router.get('/pointer-changes', async (ctx: any) => {
+      requestedFrom.push(new URL(ctx.url.toString()).searchParams.get('from') ?? '')
+      // Only the first poll carries the deployment, so the retry cannot re-advance the mark by itself.
+      if (requestedFrom.length > 1) {
+        return { body: { deltas: [], pagination: {} } }
+      }
+      return {
+        body: {
+          deltas: [
+            {
+              entityId: 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu',
+              entityType: 'profile',
+              pointers: ['0x1'],
+              entityTimestamp: 1,
+              localTimestamp: lateLocalTimestamp,
+              authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+            }
+          ],
+          pagination: {}
+        }
+      }
+    })
+  })
+
+  it('retries the bootstrap after the failed drain', async () => {
+    synchronizer = await buildSynchronizer(
+      components,
+      {
+        // Reports the entity as deployed, which is what advances the high-water mark.
+        async scheduleEntityDeployment(entity: DeployableEntity) {
+          if (entity.markAsDeployed) await entity.markAsDeployed()
+        },
+        // ...and then the drain fails, because some OTHER queued deployment did not make it.
+        async onIdle() {
+          if (requestedFrom.length >= 1 && !drainAlreadyFailed) {
+            drainAlreadyFailed = true
+            throw new Error('deployer failed to drain')
+          }
+        },
+        prepareForDeploymentsIn: jest.fn()
+      },
+      50
+    )
+
+    await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    await waitUntil(() => drainAlreadyFailed && requestedFrom.length >= 2, 'the bootstrap has been retried')
+  })
+
+  it('should resume the retry from the timestamp it started at, not the uncommitted one', () => {
+    expect(requestedFrom[1]).toEqual(requestedFrom[0])
+  })
+
+  afterAll(async () => {
+    await synchronizer.stop!()
+  })
+})

--- a/test/synchronizerDeployerQuiescence.spec.ts
+++ b/test/synchronizerDeployerQuiescence.spec.ts
@@ -333,3 +333,68 @@ test('synchronizer when a pointer-changes bootstrap deployment is silently dropp
     await synchronizer.stop!()
   })
 })
+
+test('synchronizer when a server is dropped midway through its pointer-changes bootstrap', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let pagesServed: number
+  const totalPages = 6
+
+  function pageDelta(index: number) {
+    return {
+      entityId: `ba00000000000000000000000000000000000000000000000000000000${index}`,
+      entityType: 'profile',
+      pointers: ['0x1'],
+      entityTimestamp: index,
+      localTimestamp: index,
+      authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+    }
+  }
+
+  it('prepares the endpoints', () => {
+    pagesServed = 0
+    components.router.get('/snapshots', async () => ({ body: [] }))
+    // A long paginated backlog, so the bootstrap pass takes several round trips to work through.
+    components.router.get('/pointer-changes', async () => {
+      pagesServed++
+      const isLast = pagesServed >= totalPages
+      return {
+        body: {
+          deltas: [pageDelta(pagesServed)],
+          pagination: isLast ? {} : { next: `?from=0&page=${pagesServed + 1}` }
+        }
+      }
+    })
+  })
+
+  it('drops the server while the backlog is still streaming', async () => {
+    synchronizer = await buildSynchronizer(
+      components,
+      {
+        async scheduleEntityDeployment(entity: DeployableEntity) {
+          if (entity.markAsDeployed) await entity.markAsDeployed()
+          // Remove the server the moment its bootstrap is underway, the way a DAO refresh would.
+          if (pagesServed === 2) {
+            await synchronizer.syncWithServers(new Set())
+          }
+        },
+        onIdle: jest.fn(),
+        prepareForDeploymentsIn: jest.fn()
+      },
+      60_000
+    )
+
+    await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    await waitUntil(() => pagesServed >= 2, 'the bootstrap has started streaming the backlog')
+    await new Promise((ok) => setTimeout(ok, 300))
+  })
+
+  it('should stop streaming rather than working through the rest of the backlog', () => {
+    // Without a desired-server check in the stream predicate the pass runs to the last page, deploying
+    // entities for a server the caller had already removed.
+    expect(pagesServed).toBeLessThan(totalPages)
+  })
+
+  afterAll(async () => {
+    await synchronizer.stop!()
+  })
+})

--- a/test/synchronizerDeployerQuiescence.spec.ts
+++ b/test/synchronizerDeployerQuiescence.spec.ts
@@ -1,0 +1,182 @@
+import { hashV1 } from '@dcl/hashing'
+import { resolve } from 'path'
+import { createSynchronizer } from '../src/synchronizer'
+import {
+  DeployableEntity,
+  IDeployerComponent,
+  SnapshotsFetcherComponents,
+  SynchronizerComponent
+} from '../src/types'
+import { test } from './components'
+
+function deployment(entityId: string, entityTimestamp: number) {
+  return JSON.stringify({
+    entityId,
+    entityType: 'profile',
+    pointers: ['0x1'],
+    entityTimestamp,
+    authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+  })
+}
+
+function buildSynchronizer(
+  components: SnapshotsFetcherComponents,
+  deployer: IDeployerComponent,
+  reconnectTime: number
+): Promise<SynchronizerComponent> {
+  const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+  return createSynchronizer(
+    { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage, deployer },
+    {
+      bootstrapReconnection: { reconnectTime },
+      syncingReconnection: { reconnectTime: 60_000 },
+      tmpDownloadFolder: resolve('downloads'),
+      requestMaxRetries: 1,
+      requestRetryWaitTime: 0,
+      pointerChangesWaitTime: 0
+    }
+  )
+}
+
+async function waitUntil(condition: () => boolean, description: string, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (!condition()) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out after ${timeoutMs}ms waiting until ${description}`)
+    }
+    await new Promise((ok) => setTimeout(ok, 10))
+  }
+}
+
+test('synchronizer when the deployer fails to drain during pointer-changes bootstrap', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let pointerChangesRequested: number
+  let drainAlreadyFailed: boolean
+
+  it('prepares the endpoints', () => {
+    pointerChangesRequested = 0
+    drainAlreadyFailed = false
+    // No snapshots, so bootstrap goes straight to the pointer-changes phase.
+    components.router.get('/snapshots', async () => ({ body: [] }))
+    components.router.get('/pointer-changes', async () => {
+      pointerChangesRequested++
+      return { body: { deltas: [], pagination: {} } }
+    })
+  })
+
+  it('retries the bootstrap after the failed drain', async () => {
+    synchronizer = await buildSynchronizer(
+      components,
+      {
+        scheduleEntityDeployment: jest.fn(),
+        // Reject the drain that follows the first pointer-changes bootstrap, then behave normally. This
+        // is how an asynchronous deployer reports that a queued deployment failed.
+        async onIdle() {
+          if (pointerChangesRequested >= 1 && !drainAlreadyFailed) {
+            drainAlreadyFailed = true
+            throw new Error('deployer failed to drain')
+          }
+        },
+        prepareForDeploymentsIn: jest.fn()
+      },
+      50
+    )
+
+    await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    // With the server stranded in neither state, the retry finds nothing to bootstrap and never polls
+    // again, so a second request is the evidence it was retained in pointer-changes bootstrap.
+    await waitUntil(
+      () => drainAlreadyFailed && pointerChangesRequested >= 2,
+      'the bootstrap has been retried after the failed drain'
+    )
+  })
+
+  it('should keep the server in pointer-changes bootstrap rather than losing it', () => {
+    expect(pointerChangesRequested).toBeGreaterThanOrEqual(2)
+  })
+
+  afterAll(async () => {
+    await synchronizer.stop!()
+  })
+})
+
+test('synchronizer when the deployer drains without marking every entity deployed', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let pointerChangesRequested: number
+  let markedAsProcessed: string[]
+  let snapshotHash: string
+  let contentsRequested: number
+
+  // Two valid deployments. The deployer will report only the first as deployed, so the snapshot can
+  // never be marked processed even though the deployer's queue drains cleanly.
+  const snapshotBody = Buffer.from(
+    [
+      '### Decentraland json snapshot',
+      deployment('bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu', 1),
+      deployment('ba' + 'b'.repeat(57), 2)
+    ].join('\n')
+  )
+
+  it('prepares the endpoints', async () => {
+    pointerChangesRequested = 0
+    contentsRequested = 0
+    markedAsProcessed = []
+    snapshotHash = await hashV1(snapshotBody)
+
+    components.router.get('/snapshots', async () => ({
+      body: [{ hash: snapshotHash, timeRange: { initTimestamp: 0, endTimestamp: 20 * 60_000 + 5000 } }]
+    }))
+    components.router.get(`/contents/${snapshotHash}`, async () => {
+      contentsRequested++
+      return { body: snapshotBody.toString() }
+    })
+    components.router.get('/pointer-changes', async () => {
+      pointerChangesRequested++
+      return { body: { deltas: [], pagination: {} } }
+    })
+  })
+
+  it('attempts the bootstrap', async () => {
+    jest
+      .spyOn(components.processedSnapshotStorage, 'markSnapshotAsProcessed')
+      .mockImplementation(async (hash: string) => {
+        markedAsProcessed.push(hash)
+      })
+
+    let scheduled = 0
+    synchronizer = await buildSynchronizer(
+      components,
+      {
+        async scheduleEntityDeployment(entity: DeployableEntity) {
+          scheduled++
+          // Only the first entity reports back. The second is silently dropped, which is exactly what
+          // onIdle() resolving cannot rule out.
+          if (scheduled === 1 && entity.markAsDeployed) {
+            await entity.markAsDeployed()
+          }
+        },
+        onIdle: jest.fn(),
+        prepareForDeploymentsIn: jest.fn()
+      },
+      60_000
+    )
+
+    await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    await waitUntil(() => contentsRequested > 0, 'the snapshot has been fetched and streamed')
+    // Let the bootstrap get as far as it is going to get.
+    await new Promise((ok) => setTimeout(ok, 300))
+  })
+
+  it('should not mark the snapshot as processed', () => {
+    expect(markedAsProcessed).not.toContain(snapshotHash)
+  })
+
+  it('should not promote the server past entities that never deployed', () => {
+    expect(pointerChangesRequested).toBe(0)
+  })
+
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    await synchronizer.stop!()
+  })
+})

--- a/test/synchronizerDeployerQuiescence.spec.ts
+++ b/test/synchronizerDeployerQuiescence.spec.ts
@@ -398,3 +398,99 @@ test('synchronizer when a server is dropped midway through its pointer-changes b
     await synchronizer.stop!()
   })
 })
+
+test('synchronizer when a syncing-phase deployment is dropped and the stream then reconnects', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let requestedFrom: string[]
+  let scheduled: number
+
+  // Well past the 20-minute bootstrap shift, so nothing masks a mark that moved too far.
+  const droppedLocalTimestamp = 50 * 60_000
+  const acknowledgedLocalTimestamp = 100 * 60_000
+
+  function delta(entityId: string, localTimestamp: number, entityTimestamp: number) {
+    return {
+      entityId,
+      entityType: 'profile',
+      pointers: ['0x1'],
+      entityTimestamp,
+      localTimestamp,
+      authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+    }
+  }
+
+  it('prepares the endpoints', () => {
+    requestedFrom = []
+    scheduled = 0
+    components.router.get('/snapshots', async () => ({ body: [] }))
+    components.router.get('/pointer-changes', async (ctx: any) => {
+      requestedFrom.push(new URL(ctx.url.toString()).searchParams.get('from') ?? '')
+      // The first poll is the bootstrap's, and it must come back empty so the bootstrap completes and the
+      // server is promoted — otherwise the bootstrap guard, not the syncing path, is what is under test.
+      // The second poll is the first syncing one, and it carries the pair.
+      if (requestedFrom.length === 2) {
+        return {
+          body: {
+            deltas: [
+              delta('ba000000000000000000000000000000000000000000000000000000001', droppedLocalTimestamp, 1),
+              delta('ba000000000000000000000000000000000000000000000000000000002', acknowledgedLocalTimestamp, 2)
+            ],
+            pagination: {}
+          }
+        }
+      }
+      return { body: { deltas: [], pagination: {} } }
+    })
+  })
+
+  it('bootstraps, then drops a syncing deployment and lets the stream reconnect', async () => {
+    const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+    synchronizer = await createSynchronizer(
+      {
+        fetcher,
+        downloadQueue,
+        logs,
+        storage,
+        metrics,
+        processedSnapshotStorage,
+        snapshotStorage,
+        deployer: {
+          async scheduleEntityDeployment(entity: DeployableEntity) {
+            scheduled++
+            // The earlier entity is dropped, the later one confirmed. A max over acknowledged timestamps
+            // would carry the durable resume point past the dropped one.
+            if (scheduled !== 1 && entity.markAsDeployed) {
+              await entity.markAsDeployed()
+            }
+          },
+          onIdle: jest.fn(),
+          prepareForDeploymentsIn: jest.fn()
+        }
+      },
+      {
+        bootstrapReconnection: { reconnectTime: 60_000 },
+        // Short, so the syncing stream reconnects inside the test and records its resume point.
+        syncingReconnection: { reconnectTime: 50 },
+        tmpDownloadFolder: resolve('downloads'),
+        requestMaxRetries: 1,
+        requestRetryWaitTime: 0,
+        pointerChangesWaitTime: 0
+      }
+    )
+
+    await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    // Poll 1 bootstrap, poll 2 the syncing poll carrying the pair, poll 3+ the reconnects whose `from`
+    // is the durable resume point being asserted.
+    await waitUntil(() => requestedFrom.length >= 4, 'the syncing stream has reconnected after the drop')
+  })
+
+  it('should never resume past the dropped deployment', () => {
+    const resumedPastTheDrop = requestedFrom.filter((from) => Number(from) > droppedLocalTimestamp)
+
+    expect(resumedPastTheDrop).toEqual([])
+  })
+
+  afterAll(async () => {
+    await synchronizer.stop!()
+  })
+})

--- a/test/synchronizerFailedSnapshot.spec.ts
+++ b/test/synchronizerFailedSnapshot.spec.ts
@@ -1,0 +1,88 @@
+import future from 'fp-future'
+import { resolve } from 'path'
+import { createSynchronizer } from '../src/synchronizer'
+import { SynchronizerComponent } from '../src/types'
+import { test } from './components'
+
+test('synchronizer when a snapshot advertised by a server cannot be deployed', ({ components }) => {
+  const contentFolder = resolve('downloads')
+  // A hash that is deliberately absent from test/fixtures, so it is not preloaded in the in-memory
+  // storage and the download is actually attempted (and fails) instead of short-circuiting.
+  const undownloadableSnapshot = 'bafkreisnapshotthatisnevergoingtobeserved0000000000000000000000'
+  const snapshotEndTimestamp = 20 * 60_000 + 1
+
+  let synchronizer: SynchronizerComponent
+  let pointerChangesRequests: string[]
+
+  it('prepares the endpoints', () => {
+    pointerChangesRequests = []
+
+    components.router.get('/snapshots', async () => ({
+      body: [
+        {
+          hash: undownloadableSnapshot,
+          timeRange: { initTimestamp: 0, endTimestamp: snapshotEndTimestamp },
+          replacedSnapshotHashes: []
+        }
+      ]
+    }))
+
+    // The snapshot file is never served, so deployEntitiesFromSnapshot fails for this server.
+    components.router.get(`/contents/${undownloadableSnapshot}`, async () => ({
+      status: 500,
+      body: 'the snapshot file is unavailable'
+    }))
+
+    components.router.get('/pointer-changes', async (ctx) => {
+      pointerChangesRequests.push(ctx.url.searchParams.get('from') ?? '')
+      return { body: { deltas: [], pagination: {} } }
+    })
+  })
+
+  it('attempts the bootstrap', async () => {
+    const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+    synchronizer = await createSynchronizer(
+      {
+        fetcher,
+        downloadQueue,
+        logs,
+        storage,
+        processedSnapshotStorage,
+        snapshotStorage,
+        metrics,
+        deployer: {
+          scheduleEntityDeployment: jest.fn(),
+          onIdle: jest.fn(),
+          prepareForDeploymentsIn: jest.fn()
+        }
+      },
+      {
+        // High enough that the failed bootstrap is not retried within the test.
+        bootstrapReconnection: { reconnectTime: 60_000 },
+        syncingReconnection: { reconnectTime: 60_000 },
+        tmpDownloadFolder: contentFolder,
+        requestMaxRetries: 1,
+        requestRetryWaitTime: 0,
+        pointerChangesWaitTime: 0
+      }
+    )
+
+    const bootstrapTryFinished = future<void>()
+    const syncJob = await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    await syncJob.onInitialBootstrapFinished(async () => {
+      bootstrapTryFinished.resolve()
+    })
+    await bootstrapTryFinished
+    await synchronizer.stop!()
+  })
+
+  it('should not start the pointer-changes stream for the server that failed', () => {
+    expect(pointerChangesRequests).toEqual([])
+  })
+
+  it('should leave the snapshot unmarked so a later bootstrap retries it', async () => {
+    const processed = await components.processedSnapshotStorage.filterProcessedSnapshotsFrom([undownloadableSnapshot])
+
+    expect(processed.has(undownloadableSnapshot)).toBe(false)
+  })
+})

--- a/test/synchronizerJobCoalescing.spec.ts
+++ b/test/synchronizerJobCoalescing.spec.ts
@@ -1,0 +1,97 @@
+import { resolve } from 'path'
+import { createSynchronizer } from '../src/synchronizer'
+import { SynchronizerComponent, SyncJob } from '../src/types'
+import { test } from './components'
+
+test('synchronizer when syncWithServers is called repeatedly while a job is running', ({ components }) => {
+  const contentFolder = resolve('downloads')
+
+  async function createStoppableSynchronizer(): Promise<SynchronizerComponent> {
+    const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+    return createSynchronizer(
+      {
+        fetcher,
+        downloadQueue,
+        logs,
+        storage,
+        processedSnapshotStorage,
+        snapshotStorage,
+        metrics,
+        deployer: {
+          scheduleEntityDeployment: jest.fn(),
+          onIdle: jest.fn(),
+          prepareForDeploymentsIn: jest.fn()
+        }
+      },
+      {
+        bootstrapReconnection: { reconnectTime: 60_000 },
+        syncingReconnection: { reconnectTime: 60_000 },
+        tmpDownloadFolder: contentFolder,
+        requestMaxRetries: 1,
+        requestRetryWaitTime: 0,
+        pointerChangesWaitTime: 0
+      }
+    )
+  }
+
+  it('prepares the endpoints', () => {
+    // A server that never serves its snapshots keeps the first job bootstrapping, so everything after
+    // it stays queued — the situation a periodic DAO refresh used to pile jobs up in.
+    components.router.get('/snapshots', async () => ({ status: 500, body: 'no snapshots for you' }))
+  })
+
+  describe('when a job is already running and several more calls arrive', () => {
+    let synchronizer: SynchronizerComponent
+    let runningJob: SyncJob
+    let firstQueuedJob: SyncJob
+    let laterJobs: SyncJob[]
+
+    beforeEach(async () => {
+      synchronizer = await createStoppableSynchronizer()
+      const baseUrl = await components.getBaseUrl()
+      // The runner starts this one immediately, so it is the running job, not a queued one.
+      runningJob = await synchronizer.syncWithServers(new Set([baseUrl]))
+      firstQueuedJob = await synchronizer.syncWithServers(new Set([baseUrl]))
+      laterJobs = []
+      for (let call = 0; call < 5; call++) {
+        laterJobs.push(await synchronizer.syncWithServers(new Set([baseUrl])))
+      }
+    })
+
+    afterEach(async () => {
+      await synchronizer.stop!()
+    })
+
+    it('should queue a job behind the running one rather than reusing the running job', () => {
+      expect(firstQueuedJob).not.toBe(runningJob)
+    })
+
+    it('should hand every later caller the already-queued job instead of stacking more', () => {
+      expect(laterJobs.every((job) => job === firstQueuedJob)).toEqual(true)
+    })
+  })
+
+  describe('and the desired server set changes on a call that coalesces', () => {
+    let synchronizer: SynchronizerComponent
+    let firstQueuedJob: SyncJob
+    let coalescedJob: SyncJob
+
+    beforeEach(async () => {
+      synchronizer = await createStoppableSynchronizer()
+      const baseUrl = await components.getBaseUrl()
+      await synchronizer.syncWithServers(new Set([baseUrl]))
+      firstQueuedJob = await synchronizer.syncWithServers(new Set([baseUrl]))
+      // The queued job reads the live desired-server state when it starts, so a changed set does not
+      // need a job of its own.
+      coalescedJob = await synchronizer.syncWithServers(new Set([baseUrl, 'http://another-server.com']))
+    })
+
+    afterEach(async () => {
+      await synchronizer.stop!()
+    })
+
+    it('should still reuse the queued job', () => {
+      expect(coalescedJob).toBe(firstQueuedJob)
+    })
+  })
+})

--- a/test/synchronizerLookupChunking.spec.ts
+++ b/test/synchronizerLookupChunking.spec.ts
@@ -1,0 +1,124 @@
+import { hashV1 } from '@dcl/hashing'
+import { resolve } from 'path'
+import { createSynchronizer } from '../src/synchronizer'
+import { IDeployerComponent, SnapshotsFetcherComponents, SynchronizerComponent } from '../src/types'
+import { test } from './components'
+
+const snapshotBody = Buffer.from(
+  [
+    '### Decentraland json snapshot',
+    JSON.stringify({
+      entityId: 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu',
+      entityType: 'profile',
+      pointers: ['0x1'],
+      entityTimestamp: 1,
+      authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+    })
+  ].join('\n')
+)
+
+function buildSynchronizer(
+  components: SnapshotsFetcherComponents,
+  deployer: IDeployerComponent
+): Promise<SynchronizerComponent> {
+  const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+  return createSynchronizer(
+    { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage, deployer },
+    {
+      bootstrapReconnection: { reconnectTime: 60_000 },
+      syncingReconnection: { reconnectTime: 60_000 },
+      tmpDownloadFolder: resolve('downloads'),
+      requestMaxRetries: 1,
+      requestRetryWaitTime: 0,
+      pointerChangesWaitTime: 0
+    }
+  )
+}
+
+test('synchronizer when a server advertises far more replaced hashes than one query should carry', ({ components }) => {
+  const CHUNK_SIZE = 1000
+  let synchronizer: SynchronizerComponent
+  let lookupSizes: number[]
+  let contentsRequested: number
+  let validHash: string
+  let realFilter: (hashes: string[]) => Promise<Set<string>>
+
+  it('prepares the endpoints', async () => {
+    lookupSizes = []
+    contentsRequested = 0
+    validHash = await hashV1(snapshotBody)
+
+    // Ten entries at the per-entry cap of 1000. Each is individually legal, which is the point: the
+    // aggregate the synchronizer batches is bounded by nothing but the response size limit.
+    const snapshots = Array.from({ length: 10 }, (_unused, entry) => ({
+      hash: `ba${String(entry).padStart(57, '0')}`,
+      timeRange: { initTimestamp: entry * 60_000, endTimestamp: (entry + 1) * 60_000 },
+      replacedSnapshotHashes: Array.from({ length: CHUNK_SIZE }, (_ignored, index) => `ba${entry}${String(index).padStart(56, '0')}`)
+    }))
+
+    components.router.get('/snapshots', async () => ({
+      body: [
+        ...snapshots,
+        { hash: validHash, timeRange: { initTimestamp: 20 * 60_000, endTimestamp: 40 * 60_000 } }
+      ]
+    }))
+    components.router.get(`/contents/${validHash}`, async () => {
+      contentsRequested++
+      return { body: snapshotBody.toString() }
+    })
+    components.router.get('/contents/:file', async () => ({ body: snapshotBody.toString() }))
+    components.router.get('/pointer-changes', async () => ({ body: { deltas: [], pagination: {} } }))
+
+    // Records what each lookup is actually asked for. Chunking that exists in a helper but is bypassed at
+    // the call site would leave this holding one 10,001-hash entry.
+    //
+    // A plain wrapper rather than jest.spyOn: the test runner calls jest.resetAllMocks() before every step
+    // and jest.restoreAllMocks() after, so a spy installed in this step is gone by the time the next one
+    // runs the bootstrap. That silently produced an empty recording and an assertion that passed on
+    // Math.max() of nothing.
+    realFilter = components.processedSnapshotStorage.filterProcessedSnapshotsFrom.bind(
+      components.processedSnapshotStorage
+    )
+    components.processedSnapshotStorage.filterProcessedSnapshotsFrom = async (hashes: string[]) => {
+      lookupSizes.push(hashes.length)
+      return realFilter(hashes)
+    }
+  })
+
+  it('bootstraps the server', async () => {
+    synchronizer = await buildSynchronizer(components, {
+      async scheduleEntityDeployment(entity) {
+        if (entity.markAsDeployed) await entity.markAsDeployed()
+      },
+      onIdle: jest.fn(),
+      prepareForDeploymentsIn: jest.fn()
+    })
+
+    await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+
+    const deadline = Date.now() + 20_000
+    while (contentsRequested === 0) {
+      if (Date.now() > deadline) {
+        throw new Error('the snapshot was never downloaded')
+      }
+      await new Promise((ok) => setTimeout(ok, 20))
+    }
+  })
+
+  it('should have looked up more than 10,000 hashes in total', () => {
+    // Guards the test itself: if the fixture stopped producing a large aggregate, the assertion below
+    // would pass trivially.
+    expect(lookupSizes.reduce((total, size) => total + size, 0)).toBeGreaterThan(10_000)
+  })
+
+  it('should never have asked the storage for more than one chunk at a time', () => {
+    expect(Math.max(...lookupSizes)).toBeLessThanOrEqual(CHUNK_SIZE)
+  })
+
+  afterAll(async () => {
+    components.processedSnapshotStorage.filterProcessedSnapshotsFrom = realFilter
+    if (synchronizer?.stop) {
+      await synchronizer.stop()
+    }
+  })
+})

--- a/test/synchronizerPartialSnapshotList.spec.ts
+++ b/test/synchronizerPartialSnapshotList.spec.ts
@@ -1,0 +1,99 @@
+import { hashV1 } from '@dcl/hashing'
+import { resolve } from 'path'
+import { createSynchronizer } from '../src/synchronizer'
+import { IDeployerComponent, SnapshotsFetcherComponents, SynchronizerComponent } from '../src/types'
+import { test } from './components'
+
+const snapshotBody = Buffer.from(
+  [
+    '### Decentraland json snapshot',
+    JSON.stringify({
+      entityId: 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu',
+      entityType: 'profile',
+      pointers: ['0x1'],
+      entityTimestamp: 1,
+      authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+    })
+  ].join('\n')
+)
+
+function buildSynchronizer(
+  components: SnapshotsFetcherComponents,
+  deployer: IDeployerComponent
+): Promise<SynchronizerComponent> {
+  const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+  return createSynchronizer(
+    { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage, deployer },
+    {
+      bootstrapReconnection: { reconnectTime: 60_000 },
+      syncingReconnection: { reconnectTime: 60_000 },
+      tmpDownloadFolder: resolve('downloads'),
+      requestMaxRetries: 1,
+      requestRetryWaitTime: 0,
+      pointerChangesWaitTime: 0
+    }
+  )
+}
+
+test('synchronizer when a server serves one unreadable snapshot entry alongside a valid one', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let pointerChangesRequested: number
+  let contentsRequested: number
+  let validHash: string
+
+  it('prepares the endpoints', async () => {
+    pointerChangesRequested = 0
+    contentsRequested = 0
+    validHash = await hashV1(snapshotBody)
+
+    components.router.get('/snapshots', async () => ({
+      body: [
+        // Newer, and perfectly readable: on its own this would advance the server to its endTimestamp.
+        { hash: validHash, timeRange: { initTimestamp: 20 * 60_000, endTimestamp: 40 * 60_000 } },
+        // Older, and unreadable — a time range nothing in the surviving list covers.
+        { hash: '../../etc/passwd', timeRange: { initTimestamp: 0, endTimestamp: 20 * 60_000 } }
+      ]
+    }))
+    components.router.get(`/contents/${validHash}`, async () => {
+      contentsRequested++
+      return { body: snapshotBody.toString() }
+    })
+    components.router.get('/pointer-changes', async () => {
+      pointerChangesRequested++
+      return { body: { deltas: [], pagination: {} } }
+    })
+  })
+
+  it('attempts the bootstrap', async () => {
+    synchronizer = await buildSynchronizer(components, {
+      async scheduleEntityDeployment(entity) {
+        if (entity.markAsDeployed) await entity.markAsDeployed()
+      },
+      onIdle: jest.fn(),
+      prepareForDeploymentsIn: jest.fn()
+    })
+
+    await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+
+    const deadline = Date.now() + 10_000
+    while (contentsRequested === 0) {
+      if (Date.now() > deadline) {
+        throw new Error('Timed out waiting for the readable snapshot to be deployed; the path under test never ran')
+      }
+      await new Promise((ok) => setTimeout(ok, 10))
+    }
+    await new Promise((ok) => setTimeout(ok, 300))
+  })
+
+  it('should still deploy the snapshot it could read', () => {
+    expect(contentsRequested).toBeGreaterThan(0)
+  })
+
+  it('should not promote the server past the range it could not read', () => {
+    expect(pointerChangesRequested).toBe(0)
+  })
+
+  afterAll(async () => {
+    await synchronizer.stop!()
+  })
+})

--- a/test/synchronizerReplacementChain.spec.ts
+++ b/test/synchronizerReplacementChain.spec.ts
@@ -1,0 +1,103 @@
+import future from 'fp-future'
+import { resolve } from 'path'
+import { createSynchronizer } from '../src/synchronizer'
+import { IDeployerComponent, SnapshotsFetcherComponents, SynchronizerComponent } from '../src/types'
+import { test } from './components'
+
+// Deliberately absent from test/fixtures, so nothing is preloaded into storage and a decision to deploy
+// really does show up as a request for the snapshot's contents.
+const alreadyProcessedHash = 'bafkreichainoldestaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const middleHash = 'bafkreichainmiddlebbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+const newestHash = 'bafkreichainnewestccccccccccccccccccccccccccccccccccccccccccccc'
+
+function buildSynchronizer(
+  components: SnapshotsFetcherComponents,
+  deployer: IDeployerComponent
+): Promise<SynchronizerComponent> {
+  const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+  return createSynchronizer(
+    { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage, deployer },
+    {
+      bootstrapReconnection: { reconnectTime: 60_000 },
+      syncingReconnection: { reconnectTime: 60_000 },
+      tmpDownloadFolder: resolve('downloads'),
+      requestMaxRetries: 1,
+      requestRetryWaitTime: 0,
+      pointerChangesWaitTime: 0
+    }
+  )
+}
+
+test('synchronizer when snapshots form a replacement chain', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let contentsRequested: string[]
+  let markedAsProcessed: string[]
+
+  it('prepares the endpoints', () => {
+    contentsRequested = []
+    markedAsProcessed = []
+
+    // newest replaces middle, middle replaces the one already processed. Resolving the chain needs the
+    // decision for `middle` to be visible to the decision for `newest`, which happens in the same pass.
+    components.router.get('/snapshots', async () => ({
+      body: [
+        {
+          hash: middleHash,
+          timeRange: { initTimestamp: 0, endTimestamp: 20 * 60_000 + 1 },
+          replacedSnapshotHashes: [alreadyProcessedHash]
+        },
+        {
+          hash: newestHash,
+          timeRange: { initTimestamp: 0, endTimestamp: 20 * 60_000 + 2 },
+          replacedSnapshotHashes: [middleHash]
+        }
+      ]
+    }))
+
+    for (const hash of [middleHash, newestHash]) {
+      components.router.get(`/contents/${hash}`, async () => {
+        contentsRequested.push(hash)
+        return { body: '' }
+      })
+    }
+
+    components.router.get('/pointer-changes', async () => ({ body: { deltas: [], pagination: {} } }))
+  })
+
+  it('bootstraps the server', async () => {
+    jest
+      .spyOn(components.processedSnapshotStorage, 'filterProcessedSnapshotsFrom')
+      .mockImplementation(async () => new Set<string>([alreadyProcessedHash]))
+    jest
+      .spyOn(components.processedSnapshotStorage, 'markSnapshotAsProcessed')
+      .mockImplementation(async (hash: string) => {
+        markedAsProcessed.push(hash)
+      })
+
+    synchronizer = await buildSynchronizer(components, {
+      async scheduleEntityDeployment(entity) {
+        if (entity.markAsDeployed) await entity.markAsDeployed()
+      },
+      onIdle: jest.fn(),
+      prepareForDeploymentsIn: jest.fn()
+    })
+
+    const bootstrapFinished = future<void>()
+    const syncJob = await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    await syncJob.onInitialBootstrapFinished(async () => bootstrapFinished.resolve())
+    await bootstrapFinished
+  })
+
+  it('should mark the whole chain as processed', () => {
+    expect(markedAsProcessed).toEqual(expect.arrayContaining([middleHash, newestHash]))
+  })
+
+  it('should not download any snapshot in the chain, since all of them are already covered', () => {
+    expect(contentsRequested).toEqual([])
+  })
+
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    await synchronizer.stop!()
+  })
+})

--- a/test/synchronizerShutdown.spec.ts
+++ b/test/synchronizerShutdown.spec.ts
@@ -1,0 +1,75 @@
+import { resolve } from 'path'
+import { createSynchronizer } from '../src/synchronizer'
+import { SynchronizerComponent, SyncJob } from '../src/types'
+import { test } from './components'
+
+test('synchronizer when it is stopped before the bootstrap could finish', ({ components }) => {
+  const contentFolder = resolve('downloads')
+
+  async function createStoppableSynchronizer(): Promise<SynchronizerComponent> {
+    const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+    return createSynchronizer(
+      {
+        fetcher,
+        downloadQueue,
+        logs,
+        storage,
+        processedSnapshotStorage,
+        snapshotStorage,
+        metrics,
+        deployer: {
+          scheduleEntityDeployment: jest.fn(),
+          onIdle: jest.fn(),
+          prepareForDeploymentsIn: jest.fn()
+        }
+      },
+      {
+        bootstrapReconnection: { reconnectTime: 60_000 },
+        syncingReconnection: { reconnectTime: 60_000 },
+        tmpDownloadFolder: contentFolder,
+        requestMaxRetries: 1,
+        requestRetryWaitTime: 0,
+        pointerChangesWaitTime: 0
+      }
+    )
+  }
+
+  it('prepares the endpoints', () => {
+    // A server that never serves its snapshots keeps the job in the bootstrapping state, so the
+    // sync-finished future stays pending until the synchronizer is stopped.
+    components.router.get('/snapshots', async () => ({ status: 500, body: 'no snapshots for you' }))
+  })
+
+  describe('when the sync job is the one currently running', () => {
+    let synchronizer: SynchronizerComponent
+    let syncJob: SyncJob
+
+    beforeEach(async () => {
+      synchronizer = await createStoppableSynchronizer()
+      syncJob = await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+      await synchronizer.stop!()
+    })
+
+    it('should reject onSyncFinished() instead of leaving the caller waiting forever', async () => {
+      await expect(syncJob.onSyncFinished()).rejects.toThrow('stopped before it finished')
+    })
+  })
+
+  describe('and another sync job is still queued behind it', () => {
+    let synchronizer: SynchronizerComponent
+    let queuedSyncJob: SyncJob
+
+    beforeEach(async () => {
+      synchronizer = await createStoppableSynchronizer()
+      const baseUrl = await components.getBaseUrl()
+      await synchronizer.syncWithServers(new Set([baseUrl]))
+      // The serial runner keeps this second job queued while the first one is still bootstrapping.
+      queuedSyncJob = await synchronizer.syncWithServers(new Set([baseUrl]))
+      await synchronizer.stop!()
+    })
+
+    it('should reject onSyncFinished() for the queued job that never started', async () => {
+      await expect(queuedSyncJob.onSyncFinished()).rejects.toThrow('stopped before it finished')
+    })
+  })
+})

--- a/test/synchronizerSnapshotStopSymmetry.spec.ts
+++ b/test/synchronizerSnapshotStopSymmetry.spec.ts
@@ -1,0 +1,93 @@
+import { hashV1 } from '@dcl/hashing'
+import { resolve } from 'path'
+import { createSynchronizer } from '../src/synchronizer'
+import { IDeployerComponent, SnapshotsFetcherComponents, SynchronizerComponent } from '../src/types'
+import { sleep } from '../src/utils'
+import { test } from './components'
+
+// Ten entities, so the stream is still feeding the deployer when the server is dropped mid-phase.
+const snapshotBody = Buffer.from(
+  [
+    '### Decentraland json snapshot',
+    ...Array.from({ length: 10 }, (_unused, index) =>
+      JSON.stringify({
+        entityId: `ba${String(index).padStart(57, '0')}`,
+        entityType: 'profile',
+        pointers: ['0x1'],
+        entityTimestamp: index + 1,
+        authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+      })
+    )
+  ].join('\n')
+)
+
+test('synchronizer when a server is dropped while its snapshot is still deploying', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let scheduled: number
+  let snapshotHash: string
+  let baseUrl: string
+
+  it('prepares the endpoints', async () => {
+    scheduled = 0
+    snapshotHash = await hashV1(snapshotBody)
+    baseUrl = await components.getBaseUrl()
+
+    components.router.get('/snapshots', async () => ({
+      body: [{ hash: snapshotHash, timeRange: { initTimestamp: 0, endTimestamp: 60_000 } }]
+    }))
+    components.router.get('/contents/:file', async () => ({ body: snapshotBody.toString() }))
+    components.router.get('/pointer-changes', async () => ({ body: { deltas: [], pagination: {} } }))
+  })
+
+  it('drops the server midway through the snapshot phase', async () => {
+    synchronizer = await buildSynchronizer(components, {
+      async scheduleEntityDeployment(entity) {
+        scheduled++
+        // Slow enough that the phase is still running when syncWithServers narrows the desired set.
+        await sleep(60)
+        if (entity.markAsDeployed) await entity.markAsDeployed()
+      },
+      onIdle: jest.fn(),
+      prepareForDeploymentsIn: jest.fn()
+    })
+
+    await synchronizer.syncWithServers(new Set([baseUrl]))
+    while (scheduled === 0) {
+      await sleep(10)
+    }
+
+    // The server is no longer wanted. Its snapshot work should stop rather than run the phase out.
+    await synchronizer.syncWithServers(new Set())
+    const scheduledWhenDropped = scheduled
+    await sleep(400)
+
+    // A couple more may land: the stop signal is consulted between entities, not mid-entity.
+    expect(scheduled).toBeLessThan(scheduledWhenDropped + 4)
+  })
+
+  it('should not have deployed all ten entities of a snapshot nobody wants any more', () => {
+    expect(scheduled).toBeLessThan(10)
+  })
+
+  afterAll(async () => {
+    if (synchronizer?.stop) await synchronizer.stop()
+  })
+})
+
+function buildSynchronizer(
+  components: SnapshotsFetcherComponents,
+  deployer: IDeployerComponent
+): Promise<SynchronizerComponent> {
+  const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+  return createSynchronizer(
+    { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage, deployer },
+    {
+      bootstrapReconnection: { reconnectTime: 60_000 },
+      syncingReconnection: { reconnectTime: 60_000 },
+      tmpDownloadFolder: resolve('downloads'),
+      requestMaxRetries: 1,
+      requestRetryWaitTime: 0,
+      pointerChangesWaitTime: 0
+    }
+  )
+}

--- a/test/synchronizerSyncingJobs.spec.ts
+++ b/test/synchronizerSyncingJobs.spec.ts
@@ -1,0 +1,177 @@
+import { AuthLinkType } from '@dcl/schemas'
+import future from 'fp-future'
+import { resolve } from 'path'
+import { createSynchronizer } from '../src/synchronizer'
+import { DeployableEntity, SynchronizerComponent } from '../src/types'
+import { sleep } from '../src/utils'
+import { test } from './components'
+
+const authChain = [{ type: AuthLinkType.SIGNER, payload: '0x3b21028719a4aca7ebee35b0157a6f1b0cf0d0c5', signature: '' }]
+const snapshotHash = 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu'
+const snapshotEndTimestamp = 20 * 60_000 + 1
+
+function pointerChangesDelta(entityId: string, localTimestamp: number) {
+  return {
+    entityType: 'profile',
+    entityId,
+    entityTimestamp: localTimestamp,
+    localTimestamp,
+    authChain,
+    pointers: ['0x1']
+  }
+}
+
+test('synchronizer when a syncing server is dropped from the desired set', ({ components }) => {
+  const contentFolder = resolve('downloads')
+  let synchronizer: SynchronizerComponent
+  let pointerChangesRequests: string[]
+  let requestsWhenDropped: number
+
+  it('prepares the endpoints', () => {
+    pointerChangesRequests = []
+
+    components.router.get('/snapshots', async () => ({
+      body: [{ hash: snapshotHash, timeRange: { initTimestamp: 0, endTimestamp: snapshotEndTimestamp } }]
+    }))
+    components.router.get('/pointer-changes', async (ctx) => {
+      pointerChangesRequests.push(ctx.url.searchParams.get('from') ?? '')
+      return { body: { deltas: [], pagination: {} } }
+    })
+  })
+
+  it('bootstraps the server into the syncing state and then drops it', async () => {
+    const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+    synchronizer = await createSynchronizer(
+      {
+        fetcher,
+        downloadQueue,
+        logs,
+        storage,
+        processedSnapshotStorage,
+        snapshotStorage,
+        metrics,
+        deployer: {
+          async scheduleEntityDeployment(entity: DeployableEntity) {
+            if (entity.markAsDeployed) await entity.markAsDeployed()
+          },
+          onIdle: jest.fn(),
+          prepareForDeploymentsIn: jest.fn()
+        }
+      },
+      {
+        bootstrapReconnection: { reconnectTime: 60_000 },
+        syncingReconnection: { reconnectTime: 60_000 },
+        tmpDownloadFolder: contentFolder,
+        requestMaxRetries: 3,
+        requestRetryWaitTime: 0,
+        // Poll quickly so the running stream is clearly observable.
+        pointerChangesWaitTime: 20
+      }
+    )
+
+    const bootstrapFinished = future<void>()
+    const serverUrl = await components.getBaseUrl()
+    const syncJob = await synchronizer.syncWithServers(new Set([serverUrl]))
+    await syncJob.onInitialBootstrapFinished(async () => bootstrapFinished.resolve())
+    await bootstrapFinished
+
+    // Let the syncing (post-bootstrap) pointer-changes job poll a few times.
+    await sleep(150)
+    expect(pointerChangesRequests.length).toBeGreaterThan(1)
+
+    // Drop the server: syncWithServers removes it from every state set, and the new sync job calls
+    // setDesiredJobs with the reduced set, which stops the per-server pointer-changes job.
+    await synchronizer.syncWithServers(new Set())
+    await sleep(100)
+    requestsWhenDropped = pointerChangesRequests.length
+  })
+
+  it('should stop polling the dropped server instead of streaming it until shutdown', async () => {
+    await sleep(300)
+
+    expect(pointerChangesRequests.length).toBe(requestsWhenDropped)
+  })
+
+  afterAll(async () => {
+    await synchronizer.stop!()
+  })
+})
+
+test('synchronizer when a syncing stream fails and reconnects', ({ components }) => {
+  const contentFolder = resolve('downloads')
+  let synchronizer: SynchronizerComponent
+  let pointerChangesRequests: string[]
+
+  it('prepares the endpoints', () => {
+    pointerChangesRequests = []
+    let call = 0
+
+    components.router.get('/snapshots', async () => ({
+      body: [{ hash: snapshotHash, timeRange: { initTimestamp: 0, endTimestamp: snapshotEndTimestamp } }]
+    }))
+    components.router.get('/pointer-changes', async (ctx) => {
+      const from = ctx.url.searchParams.get('from') ?? ''
+      pointerChangesRequests.push(from)
+      call++
+      // 1st call: the bootstrap pass. 2nd: the syncing job's first poll, which advances the
+      // last-entity timestamp well past the bootstrap value. 3rd: fail, forcing a reconnect.
+      if (call === 2) {
+        return { body: { deltas: [pointerChangesDelta('ba00000000000000000000000000000000000000000000000000000dead', 9_000_000)], pagination: {} } }
+      }
+      if (call === 3) {
+        return { status: 503, body: 'synthetic stream failure' }
+      }
+      return { body: { deltas: [], pagination: {} } }
+    })
+  })
+
+  it('bootstraps, deploys a newer entity, then lets the stream fail', async () => {
+    const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+    synchronizer = await createSynchronizer(
+      {
+        fetcher,
+        downloadQueue,
+        logs,
+        storage,
+        processedSnapshotStorage,
+        snapshotStorage,
+        metrics,
+        deployer: {
+          async scheduleEntityDeployment(entity: DeployableEntity) {
+            if (entity.markAsDeployed) await entity.markAsDeployed()
+          },
+          onIdle: jest.fn(),
+          prepareForDeploymentsIn: jest.fn()
+        }
+      },
+      {
+        bootstrapReconnection: { reconnectTime: 60_000 },
+        // Reconnect quickly after the synthetic failure.
+        syncingReconnection: { reconnectTime: 30 },
+        tmpDownloadFolder: contentFolder,
+        requestMaxRetries: 3,
+        requestRetryWaitTime: 0,
+        pointerChangesWaitTime: 20
+      }
+    )
+
+    const bootstrapFinished = future<void>()
+    const syncJob = await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    await syncJob.onInitialBootstrapFinished(async () => bootstrapFinished.resolve())
+    await bootstrapFinished
+    await sleep(400)
+  })
+
+  it('should resume from the latest processed timestamp rather than rewinding to bootstrap', () => {
+    // The bootstrap pass starts at snapshotEndTimestamp - 20min = 1. After the entity at 9_000_000 is
+    // deployed, every later request must start from there; a request back at '1' means the reconnect
+    // rewound and is re-streaming everything since bootstrap.
+    const requestsAfterTheDeployedEntity = pointerChangesRequests.slice(2)
+
+    expect(requestsAfterTheDeployedEntity.every((from) => Number(from) >= 9_000_000)).toBe(true)
+  })
+
+  afterAll(async () => {
+    await synchronizer.stop!()
+  })
+})

--- a/test/synchronizerSyncingJobs.spec.ts
+++ b/test/synchronizerSyncingJobs.spec.ts
@@ -97,6 +97,84 @@ test('synchronizer when a syncing server is dropped from the desired set', ({ co
   })
 })
 
+test('synchronizer when a server is removed while its pointer-changes bootstrap is in flight', ({ components }) => {
+  const contentFolder = resolve('downloads')
+  let synchronizer: SynchronizerComponent
+  let pointerChangesRequests: number
+  let releaseBootstrapPoll: ReturnType<typeof future<void>>
+
+  it('prepares the endpoints', () => {
+    pointerChangesRequests = 0
+    releaseBootstrapPoll = future<void>()
+
+    components.router.get('/snapshots', async () => ({
+      body: [{ hash: snapshotHash, timeRange: { initTimestamp: 0, endTimestamp: snapshotEndTimestamp } }]
+    }))
+    components.router.get('/pointer-changes', async () => {
+      pointerChangesRequests++
+      // Hold the bootstrap poll open so the server can be dropped while it is still running.
+      if (pointerChangesRequests === 1) {
+        await releaseBootstrapPoll
+      }
+      return { body: { deltas: [], pagination: {} } }
+    })
+  })
+
+  it('drops the server midway through its bootstrap', async () => {
+    const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+    synchronizer = await createSynchronizer(
+      {
+        fetcher,
+        downloadQueue,
+        logs,
+        storage,
+        processedSnapshotStorage,
+        snapshotStorage,
+        metrics,
+        deployer: {
+          async scheduleEntityDeployment(entity: DeployableEntity) {
+            if (entity.markAsDeployed) await entity.markAsDeployed()
+          },
+          onIdle: jest.fn(),
+          prepareForDeploymentsIn: jest.fn()
+        }
+      },
+      {
+        bootstrapReconnection: { reconnectTime: 60_000 },
+        syncingReconnection: { reconnectTime: 60_000 },
+        tmpDownloadFolder: contentFolder,
+        requestMaxRetries: 3,
+        requestRetryWaitTime: 0,
+        pointerChangesWaitTime: 20
+      }
+    )
+
+    const serverUrl = await components.getBaseUrl()
+    const syncJob = await synchronizer.syncWithServers(new Set([serverUrl]))
+    const bootstrapFinished = future<void>()
+    void syncJob.onInitialBootstrapFinished(async () => bootstrapFinished.resolve())
+
+    // Wait until the bootstrap poll is actually in flight, then remove the server.
+    await sleep(120)
+    await synchronizer.syncWithServers(new Set())
+
+    releaseBootstrapPoll.resolve()
+    await Promise.race([bootstrapFinished, sleep(500)])
+    await sleep(250)
+  })
+
+  it('should not resurrect the removed server into a long-lived syncing job', () => {
+    // The in-flight bootstrap used to add the server to syncingServers unconditionally when it
+    // finished, and the following setDesiredJobs then started a permanent pointer-changes job for a
+    // server the caller had explicitly removed. Only the held bootstrap poll should ever have run.
+    expect(pointerChangesRequests).toBe(1)
+  })
+
+  afterAll(async () => {
+    await synchronizer.stop!()
+  })
+})
+
 test('synchronizer when a syncing stream fails and reconnects', ({ components }) => {
   const contentFolder = resolve('downloads')
   let synchronizer: SynchronizerComponent

--- a/test/synchronizerUnusableSnapshot.spec.ts
+++ b/test/synchronizerUnusableSnapshot.spec.ts
@@ -1,0 +1,104 @@
+import { hashV1 } from '@dcl/hashing'
+import future from 'fp-future'
+import { resolve } from 'path'
+import { createSynchronizer } from '../src/synchronizer'
+import { IDeployerComponent, SnapshotsFetcherComponents, SynchronizerComponent } from '../src/types'
+import { test } from './components'
+
+const snapshotEndTimestamp = 20 * 60_000 + 5000
+
+// One valid deployment, then a truncated line. The valid entity deploys; the truncated line is an entity
+// that never will, which is what must stop the server advancing past this snapshot's time range.
+const partlyUnusableSnapshot = Buffer.from(
+  [
+    '### Decentraland json snapshot',
+    JSON.stringify({
+      entityId: 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu',
+      entityType: 'profile',
+      pointers: ['0x1'],
+      entityTimestamp: 1,
+      authChain: [{ type: 'SIGNER', payload: '0x1', signature: '' }]
+    }),
+    '{"entityType":"pro'
+  ].join('\n')
+)
+
+function buildSynchronizer(
+  components: SnapshotsFetcherComponents,
+  deployer: IDeployerComponent
+): Promise<SynchronizerComponent> {
+  const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+  return createSynchronizer(
+    { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage, deployer },
+    {
+      bootstrapReconnection: { reconnectTime: 60_000 },
+      syncingReconnection: { reconnectTime: 60_000 },
+      tmpDownloadFolder: resolve('downloads'),
+      requestMaxRetries: 1,
+      requestRetryWaitTime: 0,
+      pointerChangesWaitTime: 0
+    }
+  )
+}
+
+test('synchronizer when a server serves a snapshot with unreadable lines', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let pointerChangesRequested: number
+  let markedAsProcessed: string[]
+  let unusableSnapshotHash: string
+
+  it('prepares the endpoints', async () => {
+    pointerChangesRequested = 0
+    markedAsProcessed = []
+    // The real content hash, so the download passes verification and the snapshot actually reaches the
+    // parser. A fabricated hash would fail hash verification first and mask what is under test.
+    unusableSnapshotHash = await hashV1(partlyUnusableSnapshot)
+
+    components.router.get('/snapshots', async () => ({
+      body: [{ hash: unusableSnapshotHash, timeRange: { initTimestamp: 0, endTimestamp: snapshotEndTimestamp } }]
+    }))
+    components.router.get(`/contents/${unusableSnapshotHash}`, async () => ({
+      body: partlyUnusableSnapshot.toString()
+    }))
+    components.router.get('/pointer-changes', async () => {
+      pointerChangesRequested++
+      return { body: { deltas: [], pagination: {} } }
+    })
+  })
+
+  it('attempts the bootstrap', async () => {
+    jest
+      .spyOn(components.processedSnapshotStorage, 'markSnapshotAsProcessed')
+      .mockImplementation(async (hash: string) => {
+        markedAsProcessed.push(hash)
+      })
+
+    synchronizer = await buildSynchronizer(components, {
+      async scheduleEntityDeployment(entity) {
+        if (entity.markAsDeployed) await entity.markAsDeployed()
+      },
+      onIdle: jest.fn(),
+      prepareForDeploymentsIn: jest.fn()
+    })
+
+    const syncJob = await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    // The bootstrap cannot finish: the server stays in snapshot bootstrap and the sync job keeps
+    // retrying, so wait for the first attempt to have been made rather than for completion.
+    const firstAttemptSettled = future<void>()
+    void syncJob.onInitialBootstrapFinished(async () => firstAttemptSettled.resolve())
+    await Promise.race([firstAttemptSettled, new Promise((ok) => setTimeout(ok, 1500))])
+  })
+
+  it('should not mark the unusable snapshot as processed', () => {
+    expect(markedAsProcessed).not.toContain(unusableSnapshotHash)
+  })
+
+  it('should not promote the server to pointer-changes, which would skip the undeployed entities', () => {
+    expect(pointerChangesRequested).toBe(0)
+  })
+
+  afterAll(async () => {
+    jest.restoreAllMocks()
+    await synchronizer.stop!()
+  })
+})

--- a/test/synchronizerUnusableSnapshot.spec.ts
+++ b/test/synchronizerUnusableSnapshot.spec.ts
@@ -1,5 +1,4 @@
 import { hashV1 } from '@dcl/hashing'
-import future from 'fp-future'
 import { resolve } from 'path'
 import { createSynchronizer } from '../src/synchronizer'
 import { IDeployerComponent, SnapshotsFetcherComponents, SynchronizerComponent } from '../src/types'
@@ -46,10 +45,12 @@ test('synchronizer when a server serves a snapshot with unreadable lines', ({ co
   let pointerChangesRequested: number
   let markedAsProcessed: string[]
   let unusableSnapshotHash: string
+  let contentsRequested: number
 
   it('prepares the endpoints', async () => {
     pointerChangesRequested = 0
     markedAsProcessed = []
+    contentsRequested = 0
     // The real content hash, so the download passes verification and the snapshot actually reaches the
     // parser. A fabricated hash would fail hash verification first and mask what is under test.
     unusableSnapshotHash = await hashV1(partlyUnusableSnapshot)
@@ -57,9 +58,10 @@ test('synchronizer when a server serves a snapshot with unreadable lines', ({ co
     components.router.get('/snapshots', async () => ({
       body: [{ hash: unusableSnapshotHash, timeRange: { initTimestamp: 0, endTimestamp: snapshotEndTimestamp } }]
     }))
-    components.router.get(`/contents/${unusableSnapshotHash}`, async () => ({
-      body: partlyUnusableSnapshot.toString()
-    }))
+    components.router.get(`/contents/${unusableSnapshotHash}`, async () => {
+      contentsRequested++
+      return { body: partlyUnusableSnapshot.toString() }
+    })
     components.router.get('/pointer-changes', async () => {
       pointerChangesRequested++
       return { body: { deltas: [], pagination: {} } }
@@ -81,12 +83,19 @@ test('synchronizer when a server serves a snapshot with unreadable lines', ({ co
       prepareForDeploymentsIn: jest.fn()
     })
 
-    const syncJob = await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
-    // The bootstrap cannot finish: the server stays in snapshot bootstrap and the sync job keeps
-    // retrying, so wait for the first attempt to have been made rather than for completion.
-    const firstAttemptSettled = future<void>()
-    void syncJob.onInitialBootstrapFinished(async () => firstAttemptSettled.resolve())
-    await Promise.race([firstAttemptSettled, new Promise((ok) => setTimeout(ok, 1500))])
+    await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+
+    // The bootstrap cannot finish — the server stays in snapshot bootstrap and the job keeps retrying —
+    // so completion is not the signal to wait for. Wait for the snapshot to have actually been fetched
+    // and parsed, and fail if that never happens: a race against a timeout that ignores which side won
+    // would let the assertions below pass vacuously if this code path were never reached.
+    const deadline = Date.now() + 10_000
+    while (contentsRequested === 0) {
+      if (Date.now() > deadline) {
+        throw new Error('Timed out waiting for the unusable snapshot to be requested; the path under test never ran')
+      }
+      await new Promise((ok) => setTimeout(ok, 10))
+    }
   })
 
   it('should not mark the unusable snapshot as processed', () => {

--- a/test/transferLimitsConfig.spec.ts
+++ b/test/transferLimitsConfig.spec.ts
@@ -1,0 +1,171 @@
+import { Readable } from 'stream'
+import { IFetchComponent } from '@dcl/core-commons'
+import { hashV1 } from '@dcl/hashing'
+import { downloadEntityAndContentFiles } from '../src'
+import { DEFAULT_TRANSFER_LIMITS, fetchJson, resolveTransferLimits, tooSlowToContinue } from '../src/utils'
+import { test } from './components'
+
+describe('resolveTransferLimits', () => {
+  describe('when nothing is supplied', () => {
+    it('should return the values this package used before they were configurable', () => {
+      expect(resolveTransferLimits()).toEqual({
+        requestTimeoutInMs: 15_000,
+        maxDownloadedFileSizeInBytes: 1024 * 1024 * 1024,
+        minTransferRateInBytesPerSecond: 4096,
+        transferRateGracePeriodInMs: 60_000
+      })
+    })
+  })
+
+  describe('when only one field is supplied', () => {
+    it('should keep the defaults for every other field', () => {
+      expect(resolveTransferLimits({ minTransferRateInBytesPerSecond: 512 })).toEqual({
+        ...DEFAULT_TRANSFER_LIMITS,
+        minTransferRateInBytesPerSecond: 512
+      })
+    })
+  })
+
+  describe.each([
+    ['requestTimeoutInMs', 0, 1],
+    ['requestTimeoutInMs', -1, 1],
+    ['maxDownloadedFileSizeInBytes', 0, 1],
+    ['minTransferRateInBytesPerSecond', -1, 0],
+    ['transferRateGracePeriodInMs', -1, 0]
+  ])('when %s is given %s', (field: string, value: number, minimum: number) => {
+    it('should throw naming the field and the minimum it accepts', () => {
+      expect(() => resolveTransferLimits({ [field]: value } as any)).toThrow(
+        `transferLimits.${field} must be an integer >= ${minimum}, got ${value}`
+      )
+    })
+  })
+
+  describe.each([
+    ['a fraction', 1.5],
+    ['not a number', Number.NaN],
+    ['infinite', Number.POSITIVE_INFINITY]
+  ])('when a limit is %s', (_label: string, value: number) => {
+    it('should throw rather than coerce it into a bound that cannot hold', () => {
+      expect(() => resolveTransferLimits({ requestTimeoutInMs: value })).toThrow('must be an integer')
+    })
+  })
+
+  describe('when the rate floor is set to zero', () => {
+    it('should disable the check, so an arbitrarily slow transfer continues', () => {
+      const limits = resolveTransferLimits({ minTransferRateInBytesPerSecond: 0 })
+      const realNow = Date.now()
+      const spy = jest.spyOn(Date, 'now').mockReturnValue(realNow + 86_400_000)
+
+      try {
+        // A full day elapsed with one byte transferred: refused at any non-zero floor.
+        expect(tooSlowToContinue(1, realNow, limits)).toBeUndefined()
+      } finally {
+        spy.mockRestore()
+      }
+    })
+  })
+})
+
+describe('fetchJson', () => {
+  function fetcherReturning(payload: string): IFetchComponent {
+    return {
+      fetch: async () =>
+        new Response(Readable.toWeb(Readable.from([Buffer.from(payload)])) as ReadableStream, { status: 200 })
+    } as any
+  }
+
+  describe('when a caller raises the rate floor above what the peer delivers', () => {
+    let clockSpy: jest.SpyInstance
+    let error: Error | undefined
+
+    beforeEach(async () => {
+      const realNow = Date.now()
+      let calls = 0
+      clockSpy = jest.spyOn(Date, 'now').mockImplementation(() => realNow + calls++ * 2_000)
+
+      error = undefined
+      try {
+        // A 1s grace period and a 1 MiB/s floor: this small body could never satisfy it, which is only
+        // observable if the supplied limits actually reach the body reader.
+        await fetchJson('http://localhost/unused', fetcherReturning('{"ok":true}'), {
+          transferLimits: { minTransferRateInBytesPerSecond: 1024 * 1024, transferRateGracePeriodInMs: 1_000 }
+        })
+      } catch (thrown: any) {
+        error = thrown
+      }
+    })
+
+    afterEach(() => {
+      clockSpy.mockRestore()
+    })
+
+    it('should reject using the supplied floor rather than the default', () => {
+      expect(error?.message).toContain(`below the minimum of ${1024 * 1024} bytes/s`)
+    })
+  })
+
+  describe('when the default floor would have rejected but the caller disabled it', () => {
+    let clockSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      const realNow = Date.now()
+      let calls = 0
+      clockSpy = jest.spyOn(Date, 'now').mockImplementation(() => realNow + calls++ * 70_000)
+    })
+
+    afterEach(() => {
+      clockSpy.mockRestore()
+    })
+
+    it('should parse the body instead', async () => {
+      await expect(
+        fetchJson('http://localhost/unused', fetcherReturning('{"ok":true}'), {
+          transferLimits: { minTransferRateInBytesPerSecond: 0 }
+        })
+      ).resolves.toEqual({ ok: true })
+    })
+  })
+})
+
+test('downloadEntityAndContentFiles when the caller tightens the download size cap', ({ components }) => {
+  let entityId: string
+
+  beforeEach(async () => {
+    const entity = { type: 'profile', metadata: { avatars: [] }, content: [] }
+    const bytes = Buffer.from(JSON.stringify(entity))
+    entityId = await hashV1(bytes)
+    // Serves the real entity bytes, so the download passes hash verification and the only thing that can
+    // fail it is a transfer bound. Junk bytes would fail on the hash instead and prove nothing.
+    components.router.get('/contents/:file', async () => ({ body: bytes.toString() }))
+  })
+
+  // The point of this one is the plumbing, not the policy: the cap has to survive five levels of call
+  // chain (downloadEntityAndContentFiles -> downloadFileWithRetries -> downloadJob ->
+  // saveContentFileToDisk -> downloadFile) to reach the stream, and every parameter along the way is
+  // optional — so a wiring that type-checks can still silently fall back to the default at any hop.
+  it('should enforce the configured cap rather than the 1 GiB default', async () => {
+    await components.storage.delete([entityId])
+
+    await expect(
+      downloadEntityAndContentFiles(
+        components,
+        entityId,
+        [await components.getBaseUrl()],
+        new Map(),
+        'downloads',
+        1,
+        0,
+        1,
+        { maxDownloadedFileSizeInBytes: 8 }
+      )
+    ).rejects.toThrow('exceeds the maximum allowed size of 8 bytes')
+  })
+
+  it('should use the 1 GiB default when no limits are supplied', async () => {
+    await components.storage.delete([entityId])
+
+    await expect(
+      downloadEntityAndContentFiles(components, entityId, [await components.getBaseUrl()], new Map(), 'downloads', 1, 0)
+    ).resolves.toBeDefined()
+  })
+})

--- a/test/transferLimitsConfig.spec.ts
+++ b/test/transferLimitsConfig.spec.ts
@@ -89,6 +89,22 @@ describe('resolveTransferLimits', () => {
     })
   })
 
+  describe('when a limit name is misspelled', () => {
+    // The failure mode this closes is specifically undetectable: the caller asked for a stricter bound,
+    // silently got the permissive default, and nothing in the logs or the result said so.
+    it('should reject rather than silently use the default for the limit they meant', () => {
+      expect(() => resolveTransferLimits({ minTransferRateInBytesPerSec: 512 } as any)).toThrow(
+        'transferLimits.minTransferRateInBytesPerSec is not a known limit'
+      )
+    })
+
+    it('should list the names it does accept', () => {
+      expect(() => resolveTransferLimits({ nonsense: 1 } as any)).toThrow(
+        'Valid names: downloadInactivityTimeoutInMs, maxDownloadedFileSizeInBytes, maxPagesPerPaginatedCall, minTransferRateInBytesPerSecond, requestTimeoutInMs, transferRateGracePeriodInMs'
+      )
+    })
+  })
+
   describe('when the rate floor is set to zero', () => {
     it('should disable the check, so an arbitrarily slow transfer continues', () => {
       const limits = resolveTransferLimits({ minTransferRateInBytesPerSecond: 0 })

--- a/test/transferLimitsConfig.spec.ts
+++ b/test/transferLimitsConfig.spec.ts
@@ -165,14 +165,19 @@ describe('fetchJson', () => {
 
 test('downloadEntityAndContentFiles when the caller tightens the download size cap', ({ components }) => {
   let entityId: string
+  // Held at suite scope, not declared inside the beforeEach: the router accumulates handlers across
+  // beforeEach runs and the first one registered wins, so a handler closing over a per-run binding would
+  // serve the first test's bytes to every later test. Reading a suite-scoped binding keeps every
+  // registration equivalent.
+  let entityBytes: Buffer
 
   beforeEach(async () => {
     const entity = { type: 'profile', metadata: { avatars: [] }, content: [] }
-    const bytes = Buffer.from(JSON.stringify(entity))
-    entityId = await hashV1(bytes)
+    entityBytes = Buffer.from(JSON.stringify(entity))
+    entityId = await hashV1(entityBytes)
     // Serves the real entity bytes, so the download passes hash verification and the only thing that can
     // fail it is a transfer bound. Junk bytes would fail on the hash instead and prove nothing.
-    components.router.get('/contents/:file', async () => ({ body: bytes.toString() }))
+    components.router.get('/contents/:file', async () => ({ body: entityBytes.toString() }))
   })
 
   // The point of this one is the plumbing, not the policy: the cap has to survive five levels of call
@@ -197,7 +202,7 @@ test('downloadEntityAndContentFiles when the caller tightens the download size c
     ).rejects.toThrow('exceeds the maximum allowed size of 8 bytes')
   })
 
-  it('should use the 1 GiB default when no limits are supplied', async () => {
+  it('should fall back to the 1 GiB default with no limits supplied', async () => {
     await components.storage.delete([entityId])
 
     await expect(

--- a/test/transferLimitsConfig.spec.ts
+++ b/test/transferLimitsConfig.spec.ts
@@ -2,7 +2,13 @@ import { Readable } from 'stream'
 import { IFetchComponent } from '@dcl/core-commons'
 import { hashV1 } from '@dcl/hashing'
 import { downloadEntityAndContentFiles } from '../src'
-import { DEFAULT_TRANSFER_LIMITS, fetchJson, resolveTransferLimits, tooSlowToContinue } from '../src/utils'
+import {
+  DEFAULT_TRANSFER_LIMITS,
+  fetchJson,
+  resolveTransferLimits,
+  saveContentFileToDisk,
+  tooSlowToContinue
+} from '../src/utils'
 import { test } from './components'
 
 describe('resolveTransferLimits', () => {
@@ -10,6 +16,7 @@ describe('resolveTransferLimits', () => {
     it('should return the values this package used before they were configurable', () => {
       expect(resolveTransferLimits()).toEqual({
         requestTimeoutInMs: 15_000,
+        downloadInactivityTimeoutInMs: 30_000,
         maxDownloadedFileSizeInBytes: 1024 * 1024 * 1024,
         minTransferRateInBytesPerSecond: 4096,
         transferRateGracePeriodInMs: 60_000
@@ -47,6 +54,35 @@ describe('resolveTransferLimits', () => {
   ])('when a limit is %s', (_label: string, value: number) => {
     it('should throw rather than coerce it into a bound that cannot hold', () => {
       expect(() => resolveTransferLimits({ requestTimeoutInMs: value })).toThrow('must be an integer')
+    })
+  })
+
+  describe('when a field is present but explicitly undefined', () => {
+    // Config assembled from env vars or optional options carries explicit undefined for an absent value
+    // far more often than it omits the key, and a plain spread would overwrite the default with it and
+    // then fail validation.
+    it('should treat it as omitted rather than as an invalid value', () => {
+      expect(resolveTransferLimits({ requestTimeoutInMs: undefined })).toEqual(DEFAULT_TRANSFER_LIMITS)
+    })
+
+    it('should still apply the other fields supplied alongside it', () => {
+      expect(
+        resolveTransferLimits({ requestTimeoutInMs: undefined, minTransferRateInBytesPerSecond: 512 })
+      ).toEqual({ ...DEFAULT_TRANSFER_LIMITS, minTransferRateInBytesPerSecond: 512 })
+    })
+  })
+
+  describe('when every field is explicitly undefined', () => {
+    it('should return the defaults untouched', () => {
+      expect(
+        resolveTransferLimits({
+          requestTimeoutInMs: undefined,
+          downloadInactivityTimeoutInMs: undefined,
+          maxDownloadedFileSizeInBytes: undefined,
+          minTransferRateInBytesPerSecond: undefined,
+          transferRateGracePeriodInMs: undefined
+        })
+      ).toEqual(DEFAULT_TRANSFER_LIMITS)
     })
   })
 
@@ -168,4 +204,33 @@ test('downloadEntityAndContentFiles when the caller tightens the download size c
       downloadEntityAndContentFiles(components, entityId, [await components.getBaseUrl()], new Map(), 'downloads', 1, 0)
     ).resolves.toBeDefined()
   })
+})
+
+test('saveContentFileToDisk when a peer accepts the connection and then goes silent', ({ components }) => {
+  let baseUrl: string
+
+  beforeEach(async () => {
+    baseUrl = await components.getBaseUrl()
+    // Headers never sent, body never written: the socket simply idles. Only the inactivity deadline can
+    // end this, so the wait is a direct measure of the configured value being used.
+    components.router.get('/silent/:file', async () => new Promise(() => {}) as any)
+  })
+
+  it('should abort after the configured deadline rather than the hardcoded 30s', async () => {
+    const startedAt = Date.now()
+
+    await expect(
+      saveContentFileToDisk(
+        components,
+        `${baseUrl}/silent/QmTestHash`,
+        'downloads/QmTestHash',
+        'QmTestHash',
+        false,
+        { downloadInactivityTimeoutInMs: 250 }
+      )
+    ).rejects.toThrow('Timeout while downloading')
+
+    // Comfortably under the 30s default, so this cannot pass while the option is ignored.
+    expect(Date.now() - startedAt).toBeLessThan(5_000)
+  }, 40_000)
 })

--- a/test/transferLimitsConfig.spec.ts
+++ b/test/transferLimitsConfig.spec.ts
@@ -19,7 +19,8 @@ describe('resolveTransferLimits', () => {
         downloadInactivityTimeoutInMs: 30_000,
         maxDownloadedFileSizeInBytes: 1024 * 1024 * 1024,
         minTransferRateInBytesPerSecond: 4096,
-        transferRateGracePeriodInMs: 60_000
+        transferRateGracePeriodInMs: 60_000,
+        maxPagesPerPaginatedCall: 10_000
       })
     })
   })
@@ -38,7 +39,8 @@ describe('resolveTransferLimits', () => {
     ['requestTimeoutInMs', -1, 1],
     ['maxDownloadedFileSizeInBytes', 0, 1],
     ['minTransferRateInBytesPerSecond', -1, 0],
-    ['transferRateGracePeriodInMs', -1, 0]
+    ['transferRateGracePeriodInMs', -1, 0],
+    ['maxPagesPerPaginatedCall', 0, 1]
   ])('when %s is given %s', (field: string, value: number, minimum: number) => {
     it('should throw naming the field and the minimum it accepts', () => {
       expect(() => resolveTransferLimits({ [field]: value } as any)).toThrow(
@@ -80,7 +82,8 @@ describe('resolveTransferLimits', () => {
           downloadInactivityTimeoutInMs: undefined,
           maxDownloadedFileSizeInBytes: undefined,
           minTransferRateInBytesPerSecond: undefined,
-          transferRateGracePeriodInMs: undefined
+          transferRateGracePeriodInMs: undefined,
+          maxPagesPerPaginatedCall: undefined
         })
       ).toEqual(DEFAULT_TRANSFER_LIMITS)
     })

--- a/test/transferRateGuard.spec.ts
+++ b/test/transferRateGuard.spec.ts
@@ -1,0 +1,141 @@
+import { Readable } from 'stream'
+import { pipeline as streamPipeline } from 'stream/promises'
+import { createTransferLimiter, tooSlowToContinue } from '../src/utils'
+
+// The guard measures against Date.now(), and the grace period is a minute — far longer than a test
+// should take. Advancing a stubbed clock is what lets the real code paths be exercised in milliseconds.
+function withClock(): { advanceBy(ms: number): void; restore(): void } {
+  const realNow = Date.now()
+  let offset = 0
+  const spy = jest.spyOn(Date, 'now').mockImplementation(() => realNow + offset)
+  return {
+    advanceBy(ms: number) {
+      offset += ms
+    },
+    restore() {
+      spy.mockRestore()
+    }
+  }
+}
+
+describe('tooSlowToContinue', () => {
+  let clock: ReturnType<typeof withClock>
+  let startedAt: number
+
+  beforeEach(() => {
+    clock = withClock()
+    startedAt = Date.now()
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
+  describe('when the transfer is still inside the grace period', () => {
+    beforeEach(() => {
+      clock.advanceBy(59_000)
+    })
+
+    it('should allow a transfer that has sent almost nothing, since setup dominates early samples', () => {
+      expect(tooSlowToContinue(1, startedAt)).toBeUndefined()
+    })
+  })
+
+  describe('when a peer has trickled one byte per inactivity window past the grace period', () => {
+    let error: Error | undefined
+
+    beforeEach(() => {
+      // Three windows of 30s: every one refreshes the inactivity deadline, so this peer looks alive to
+      // every check that existed before the rate floor.
+      clock.advanceBy(90_000)
+      error = tooSlowToContinue(3, startedAt)
+    })
+
+    it('should refuse to continue', () => {
+      expect(error).toBeDefined()
+    })
+
+    it('should report the bytes, the measured rate and the floor it fell below', () => {
+      expect(error!.message).toEqual(
+        'Transfer of 3 bytes averaged 0.03 bytes/s over 90s, below the minimum of 4096 bytes/s'
+      )
+    })
+  })
+
+  describe('when a slow but genuine transfer is making steady progress past the grace period', () => {
+    beforeEach(() => {
+      clock.advanceBy(120_000)
+    })
+
+    it('should allow a rate above the floor', () => {
+      // 120s at ~8 KiB/s: half the speed of a dial-up modem is still allowed through.
+      expect(tooSlowToContinue(8 * 1024 * 120, startedAt)).toBeUndefined()
+    })
+
+    it('should allow a rate sitting exactly on the floor', () => {
+      expect(tooSlowToContinue(4 * 1024 * 120, startedAt)).toBeUndefined()
+    })
+  })
+})
+
+describe('createTransferLimiter', () => {
+  let clock: ReturnType<typeof withClock>
+
+  beforeEach(() => {
+    clock = withClock()
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
+  describe('when the source trickles bytes slowly enough to stay under the floor', () => {
+    it('should destroy the pipeline rather than let it hold its slot indefinitely', async () => {
+      const limiter = createTransferLimiter(1024 * 1024)
+      // Each chunk arrives well within the 30s inactivity deadline, so only the rate floor can stop it.
+      const trickle = Readable.from(
+        (async function* () {
+          for (let chunk = 0; chunk < 5; chunk++) {
+            clock.advanceBy(25_000)
+            yield Buffer.from('x')
+          }
+        })()
+      )
+
+      await expect(streamPipeline(trickle, limiter, async function* () {})).rejects.toThrow(
+        'below the minimum of 4096 bytes/s'
+      )
+    })
+  })
+
+  describe('when the source delivers a normal payload promptly', () => {
+    let received: number
+
+    beforeEach(() => {
+      received = 0
+    })
+
+    it('should pass every byte through untouched', async () => {
+      const limiter = createTransferLimiter(1024 * 1024)
+      const payload = Buffer.alloc(64 * 1024, 7)
+
+      await streamPipeline(Readable.from([payload]), limiter, async function (source) {
+        for await (const chunk of source) {
+          received += chunk.length
+        }
+      })
+
+      expect(received).toEqual(payload.length)
+    })
+  })
+
+  describe('when the payload exceeds the size ceiling', () => {
+    it('should still report the size failure rather than the rate one', async () => {
+      const limiter = createTransferLimiter(10)
+
+      await expect(
+        streamPipeline(Readable.from([Buffer.alloc(64)]), limiter, async function* () {})
+      ).rejects.toThrow('exceeds the maximum allowed size of 10 bytes')
+    })
+  })
+})

--- a/test/transferRateGuard.spec.ts
+++ b/test/transferRateGuard.spec.ts
@@ -1,7 +1,14 @@
+import * as zlib from 'zlib'
 import { Readable } from 'stream'
 import { pipeline as streamPipeline } from 'stream/promises'
-import { DEFAULT_TRANSFER_LIMITS, createTransferLimiter, resolveTransferLimits } from '../src/utils'
-import { tooSlowToContinue } from '../src/utils'
+import {
+  DEFAULT_TRANSFER_LIMITS,
+  createSizeCap,
+  createDownloadTransforms,
+  createTransferRateGuard,
+  resolveTransferLimits,
+  tooSlowToContinue
+} from '../src/utils'
 
 // The guard measures against Date.now(), and the grace period is a minute — far longer than a test
 // should take. Advancing a stubbed clock is what lets the real code paths be exercised in milliseconds.
@@ -79,7 +86,7 @@ describe('tooSlowToContinue', () => {
   })
 })
 
-describe('createTransferLimiter', () => {
+describe('createDownloadTransforms', () => {
   let clock: ReturnType<typeof withClock>
 
   beforeEach(() => {
@@ -92,7 +99,7 @@ describe('createTransferLimiter', () => {
 
   describe('when the source trickles bytes slowly enough to stay under the floor', () => {
     it('should destroy the pipeline rather than let it hold its slot indefinitely', async () => {
-      const limiter = createTransferLimiter(resolveTransferLimits({ maxDownloadedFileSizeInBytes: 1024 * 1024 }))
+      const limiter = createTransferRateGuard(resolveTransferLimits({ maxDownloadedFileSizeInBytes: 1024 * 1024 }))
       // Each chunk arrives well within the 30s inactivity deadline, so only the rate floor can stop it.
       const trickle = Readable.from(
         (async function* () {
@@ -117,7 +124,7 @@ describe('createTransferLimiter', () => {
     })
 
     it('should pass every byte through untouched', async () => {
-      const limiter = createTransferLimiter(resolveTransferLimits({ maxDownloadedFileSizeInBytes: 1024 * 1024 }))
+      const limiter = createTransferRateGuard(resolveTransferLimits({ maxDownloadedFileSizeInBytes: 1024 * 1024 }))
       const payload = Buffer.alloc(64 * 1024, 7)
 
       await streamPipeline(Readable.from([payload]), limiter, async function (source) {
@@ -132,11 +139,124 @@ describe('createTransferLimiter', () => {
 
   describe('when the payload exceeds the size ceiling', () => {
     it('should still report the size failure rather than the rate one', async () => {
-      const limiter = createTransferLimiter(resolveTransferLimits({ maxDownloadedFileSizeInBytes: 10 }))
+      const limiter = createSizeCap(10, 'Downloaded file')
 
       await expect(
         streamPipeline(Readable.from([Buffer.alloc(64)]), limiter, async function* () {})
       ).rejects.toThrow('exceeds the maximum allowed size of 10 bytes')
+    })
+  })
+})
+
+describe('createDownloadTransforms when the response is gzip encoded', () => {
+  let clock: ReturnType<typeof withClock>
+
+  beforeEach(() => {
+    clock = withClock()
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
+  describe('and the peer trickles compressed bytes that decompress to nothing', () => {
+    let error: Error | undefined
+
+    beforeEach(async () => {
+      // Concatenated empty gzip members: every one is valid, gunzip accepts multi-member streams, and the
+      // whole thing decompresses to zero bytes. A rate check placed after gunzip is never invoked even
+      // once, because a Transform only runs when a chunk reaches it — so the guard did not merely allow
+      // this, it never ran, while the raw socket traffic kept the inactivity deadline refreshed.
+      const emptyMember = zlib.gzipSync(Buffer.alloc(0))
+      const trickle = Readable.from(
+        (async function* () {
+          for (let member = 0; member < 200; member++) {
+            clock.advanceBy(1_000)
+            yield emptyMember
+          }
+        })()
+      )
+
+      error = undefined
+      try {
+        await streamPipeline([
+          trickle,
+          ...createDownloadTransforms(true, DEFAULT_TRANSFER_LIMITS),
+          async function* () {}
+        ] as any)
+      } catch (thrown: any) {
+        error = thrown
+      }
+    })
+
+    it('should refuse the transfer instead of holding the slot indefinitely', () => {
+      expect(error).toBeDefined()
+    })
+
+    it('should fail on the rate floor, measured against the raw compressed bytes', () => {
+      expect(error!.message).toContain('below the minimum of 4096 bytes/s')
+    })
+  })
+
+  describe('and the peer sends a real payload promptly', () => {
+    let received: number
+
+    beforeEach(() => {
+      received = 0
+    })
+
+    it('should decompress it and pass every byte through', async () => {
+      const payload = Buffer.alloc(64 * 1024, 7)
+
+      await streamPipeline([
+        Readable.from([zlib.gzipSync(payload)]),
+        ...createDownloadTransforms(true, DEFAULT_TRANSFER_LIMITS),
+        async function (source: AsyncIterable<Buffer>) {
+          for await (const chunk of source) {
+            received += chunk.length
+          }
+        }
+      ] as any)
+
+      expect(received).toEqual(payload.length)
+    })
+  })
+
+  describe('and the compressed stream alone exceeds the size cap', () => {
+    it('should refuse it on the compressed side, naming which side tripped', async () => {
+      // Stays above the rate floor throughout, so only a bound on the compressed bytes can stop it. Without
+      // one, a peer can stream valid gzip forever and never produce a decompressed byte to measure.
+      const emptyMember = zlib.gzipSync(Buffer.alloc(0))
+      const flood = Readable.from(
+        (function* () {
+          for (let member = 0; member < 5000; member++) {
+            yield emptyMember
+          }
+        })()
+      )
+
+      await expect(
+        streamPipeline([
+          flood,
+          ...createDownloadTransforms(true, resolveTransferLimits({ maxDownloadedFileSizeInBytes: 1024 })),
+          async function* () {}
+        ] as any)
+      ).rejects.toThrow('Compressed response exceeds the maximum allowed size of 1024 bytes')
+    })
+  })
+
+  describe('and the decompressed payload exceeds the size cap', () => {
+    it('should still refuse it on the decompressed side, so gzip bombs stay bounded', async () => {
+      // 1 MiB of zeroes compresses to about a kilobyte: the compressed cap below would not catch it.
+      const bomb = zlib.gzipSync(Buffer.alloc(1024 * 1024))
+
+      await expect(
+        streamPipeline([
+          Readable.from([bomb]),
+          ...createDownloadTransforms(true, resolveTransferLimits({ maxDownloadedFileSizeInBytes: 4096 })),
+          async function* () {}
+        ] as any)
+      ).rejects.toThrow('Downloaded file exceeds the maximum allowed size of 4096 bytes')
     })
   })
 })

--- a/test/transferRateGuard.spec.ts
+++ b/test/transferRateGuard.spec.ts
@@ -1,6 +1,7 @@
 import { Readable } from 'stream'
 import { pipeline as streamPipeline } from 'stream/promises'
-import { createTransferLimiter, tooSlowToContinue } from '../src/utils'
+import { DEFAULT_TRANSFER_LIMITS, createTransferLimiter, resolveTransferLimits } from '../src/utils'
+import { tooSlowToContinue } from '../src/utils'
 
 // The guard measures against Date.now(), and the grace period is a minute — far longer than a test
 // should take. Advancing a stubbed clock is what lets the real code paths be exercised in milliseconds.
@@ -37,7 +38,7 @@ describe('tooSlowToContinue', () => {
     })
 
     it('should allow a transfer that has sent almost nothing, since setup dominates early samples', () => {
-      expect(tooSlowToContinue(1, startedAt)).toBeUndefined()
+      expect(tooSlowToContinue(1, startedAt, DEFAULT_TRANSFER_LIMITS)).toBeUndefined()
     })
   })
 
@@ -48,7 +49,7 @@ describe('tooSlowToContinue', () => {
       // Three windows of 30s: every one refreshes the inactivity deadline, so this peer looks alive to
       // every check that existed before the rate floor.
       clock.advanceBy(90_000)
-      error = tooSlowToContinue(3, startedAt)
+      error = tooSlowToContinue(3, startedAt, DEFAULT_TRANSFER_LIMITS)
     })
 
     it('should refuse to continue', () => {
@@ -69,11 +70,11 @@ describe('tooSlowToContinue', () => {
 
     it('should allow a rate above the floor', () => {
       // 120s at ~8 KiB/s: half the speed of a dial-up modem is still allowed through.
-      expect(tooSlowToContinue(8 * 1024 * 120, startedAt)).toBeUndefined()
+      expect(tooSlowToContinue(8 * 1024 * 120, startedAt, DEFAULT_TRANSFER_LIMITS)).toBeUndefined()
     })
 
     it('should allow a rate sitting exactly on the floor', () => {
-      expect(tooSlowToContinue(4 * 1024 * 120, startedAt)).toBeUndefined()
+      expect(tooSlowToContinue(4 * 1024 * 120, startedAt, DEFAULT_TRANSFER_LIMITS)).toBeUndefined()
     })
   })
 })
@@ -91,7 +92,7 @@ describe('createTransferLimiter', () => {
 
   describe('when the source trickles bytes slowly enough to stay under the floor', () => {
     it('should destroy the pipeline rather than let it hold its slot indefinitely', async () => {
-      const limiter = createTransferLimiter(1024 * 1024)
+      const limiter = createTransferLimiter(resolveTransferLimits({ maxDownloadedFileSizeInBytes: 1024 * 1024 }))
       // Each chunk arrives well within the 30s inactivity deadline, so only the rate floor can stop it.
       const trickle = Readable.from(
         (async function* () {
@@ -116,7 +117,7 @@ describe('createTransferLimiter', () => {
     })
 
     it('should pass every byte through untouched', async () => {
-      const limiter = createTransferLimiter(1024 * 1024)
+      const limiter = createTransferLimiter(resolveTransferLimits({ maxDownloadedFileSizeInBytes: 1024 * 1024 }))
       const payload = Buffer.alloc(64 * 1024, 7)
 
       await streamPipeline(Readable.from([payload]), limiter, async function (source) {
@@ -131,7 +132,7 @@ describe('createTransferLimiter', () => {
 
   describe('when the payload exceeds the size ceiling', () => {
     it('should still report the size failure rather than the rate one', async () => {
-      const limiter = createTransferLimiter(10)
+      const limiter = createTransferLimiter(resolveTransferLimits({ maxDownloadedFileSizeInBytes: 10 }))
 
       await expect(
         streamPipeline(Readable.from([Buffer.alloc(64)]), limiter, async function* () {})

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -9,6 +9,7 @@
       "node",
       "jest"
     ],
+    "strict": true, /* Match the strictness src is compiled with, so tests cannot rely on looser types. */
     "resolveJsonModule": true,
     "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     "skipLibCheck": true, /* Skip type checking of declaration files. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true, /* Generates corresponding '.d.ts' file. */
     "declarationMap": true, /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true, /* Generates corresponding '.map' file. */
+    "stripInternal": true, /* Omits declarations tagged @internal from the published type surface. */
     "types": [
       "node"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,9 +2490,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
+  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
 
 fastq@^1.6.0:
   version "1.20.1"
@@ -3568,9 +3568,9 @@ js-yaml@^3.13.1:
     esprima "^4.0.0"
 
 js-yaml@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,237 @@
 # yarn lockfile v1
 
 
+"@aws-sdk/checksums@^3.1000.21":
+  version "3.1000.21"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/checksums/-/checksums-3.1000.21.tgz#2be054036892f93c25c84d6ec70bb58127aa2161"
+  integrity sha512-AcYTunavv8dqm9u2pbq/gIlFERUo+jQDKKLZpYOgMLLytoAJ/qoyuhWj97FB7UzpMFVJNzMEUylzKK/s/05org==
+  dependencies:
+    "@aws-sdk/core" "^3.977.1"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.29.8"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/client-s3@^3.1095.0":
+  version "3.1096.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.1096.0.tgz#0f66e5f6bf5a4d1f8a2837d13847e3f9de4f308a"
+  integrity sha512-sEx7KAEtkp1UqOoWQv2baM1rreClZG7o9YE8EfPvYpPBvGad1fQRG3sMHrOPMkIdZ9VjGRl25GiaG1MSeie2Mw==
+  dependencies:
+    "@aws-sdk/checksums" "^3.1000.21"
+    "@aws-sdk/core" "^3.977.1"
+    "@aws-sdk/credential-provider-node" "^3.972.73"
+    "@aws-sdk/middleware-sdk-s3" "^3.972.67"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.42"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.29.8"
+    "@smithy/fetch-http-handler" "^5.6.10"
+    "@smithy/node-http-handler" "^4.9.10"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/core@^3.977.1":
+  version "3.977.1"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.977.1.tgz#2831daa053f3a50ad426898e6920f08f807b97ff"
+  integrity sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==
+  dependencies:
+    "@aws-sdk/types" "^3.974.2"
+    "@aws-sdk/xml-builder" "^3.972.37"
+    "@aws/lambda-invoke-store" "^0.3.0"
+    "@smithy/core" "^3.29.8"
+    "@smithy/signature-v4" "^5.6.9"
+    "@smithy/types" "^4.16.1"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-env@^3.972.62":
+  version "3.972.62"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.62.tgz#24f6f62ff31df013963a700ab111c6e6d059944e"
+  integrity sha512-BkDrk2cNjed31IKin/Oksb2ziF+gfuyRskFVuT4EU9Mep7M8Y/d8DJG4+anHme4Vuse7CwaEscwEfGyR6mzBhQ==
+  dependencies:
+    "@aws-sdk/core" "^3.977.1"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.29.8"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@^3.972.64":
+  version "3.972.64"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.64.tgz#55b5a410542ad091e08a4eb492d4a7c564606d22"
+  integrity sha512-Wj1FGK2IxY5EccQCvH+niTYhIvDoDujJf2CpRRgS3NpYNEgiFNVItNbJYQjINRlu7fG7jSsXkKV0UWKriEplrw==
+  dependencies:
+    "@aws-sdk/core" "^3.977.1"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.29.8"
+    "@smithy/fetch-http-handler" "^5.6.10"
+    "@smithy/node-http-handler" "^4.9.10"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-ini@^3.973.7":
+  version "3.973.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.7.tgz#12f8319cdb3814dde93ae9d9ee760ae48fdfe5db"
+  integrity sha512-2CefB8cCxDu52P24B8Ay93/cTT199bcSvNHQ8e2f4BjSCF83yErBnTIZEBo0VeIgCfmw+PJKFUXnlQWxm2dkug==
+  dependencies:
+    "@aws-sdk/core" "^3.977.1"
+    "@aws-sdk/credential-provider-env" "^3.972.62"
+    "@aws-sdk/credential-provider-http" "^3.972.64"
+    "@aws-sdk/credential-provider-login" "^3.972.69"
+    "@aws-sdk/credential-provider-process" "^3.972.62"
+    "@aws-sdk/credential-provider-sso" "^3.973.6"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.68"
+    "@aws-sdk/nested-clients" "^3.997.36"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.29.8"
+    "@smithy/credential-provider-imds" "^4.4.13"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-login@^3.972.69":
+  version "3.972.69"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.69.tgz#943ea85a247063511ec8b3d324e880b7162ca2db"
+  integrity sha512-gM3j0Ie9+FoLNTYODY+QWbg3vCRBc7mR9cRdntxTMkFYIrwfRmuucfavP6HNBlYSuaYww54TNJGej4GFgoPZAg==
+  dependencies:
+    "@aws-sdk/core" "^3.977.1"
+    "@aws-sdk/nested-clients" "^3.997.36"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.29.8"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-node@^3.972.73":
+  version "3.972.73"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.73.tgz#b0184a78073b6b3a0946f8e22c9aa1a877a0f2ac"
+  integrity sha512-VTzdbf8Ukjdb9yUubZzRI678CWZvKovhE8Nv3qihwhC187sRMGls+r9N8Wuht5q1xjKx2nmpS48ar8ppupjkCA==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^3.972.62"
+    "@aws-sdk/credential-provider-http" "^3.972.64"
+    "@aws-sdk/credential-provider-ini" "^3.973.7"
+    "@aws-sdk/credential-provider-process" "^3.972.62"
+    "@aws-sdk/credential-provider-sso" "^3.973.6"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.68"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.29.8"
+    "@smithy/credential-provider-imds" "^4.4.13"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@^3.972.62":
+  version "3.972.62"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.62.tgz#09d61aa0f0ef20a1ed5c6f729ea89ee3c9758ed9"
+  integrity sha512-zXYU9UWNL66gtMgNLhmxlrvEokuI7r6G2q7FRGu41Bya4iS30JLelUipJX9SV4zhyCPWJhI9Li54R1d9H8Tq6A==
+  dependencies:
+    "@aws-sdk/core" "^3.977.1"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.29.8"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-sso@^3.973.6":
+  version "3.973.6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.6.tgz#f395a91ae737a0ad3a8c276f1bfa01b2a241ab3e"
+  integrity sha512-DobZggy3K49xdCpjeyMou0FQhkoYbluVGNydL6D+lcxF8GoAsttFX0xnH5GmiQ89We5dB6TRpW+CD/VowBH6HQ==
+  dependencies:
+    "@aws-sdk/core" "^3.977.1"
+    "@aws-sdk/nested-clients" "^3.997.36"
+    "@aws-sdk/token-providers" "3.1096.0"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.29.8"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@^3.972.68":
+  version "3.972.68"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.68.tgz#8860040273d92b2d5f48b94ac26a1c6a48c056c2"
+  integrity sha512-bq+yTt+uWJx60VVp/OIAX5xqUAu/K2Uc3eknWnWl+KtfcU2CQe0uNw6lySrn2t5GKHq7jsV0Z63HiBGVtzr/lg==
+  dependencies:
+    "@aws-sdk/core" "^3.977.1"
+    "@aws-sdk/nested-clients" "^3.997.36"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.29.8"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/lib-storage@^3.1095.0":
+  version "3.1096.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/lib-storage/-/lib-storage-3.1096.0.tgz#1791ff3f758c634b4a6fe710f2bf456b181cd992"
+  integrity sha512-A9ZoQFUawEO2l7jVoBRtDbIJ3hPBnxMRy3oIGQREOsMfwQFvoiyyV0f1Fl5CuIfoovv508TuW+Pe6WZIfh7NOg==
+  dependencies:
+    "@smithy/core" "^3.29.8"
+    "@smithy/types" "^4.16.1"
+    buffer "5.6.0"
+    events "3.3.0"
+    stream-browserify "3.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-sdk-s3@^3.972.67":
+  version "3.972.67"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.67.tgz#b40e10b111663bfda81563c4980116029fe07cdf"
+  integrity sha512-aB1ahF9z4J5r8YK1QodwNX/P8XSKBFtnjf7h72XCs0BP3rtThOiXeA3Lm+Z+8tiN9Iwl5otsGeHaXmQoQ5MVfA==
+  dependencies:
+    "@aws-sdk/core" "^3.977.1"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.42"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.29.8"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/nested-clients@^3.997.36":
+  version "3.997.36"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.997.36.tgz#1e0f641d1e1190117496cf2dd584e1e3bb48d20f"
+  integrity sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg==
+  dependencies:
+    "@aws-sdk/core" "^3.977.1"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.42"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.29.8"
+    "@smithy/fetch-http-handler" "^5.6.10"
+    "@smithy/node-http-handler" "^4.9.10"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/signature-v4-multi-region@^3.996.42":
+  version "3.996.42"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz#855bbea16f0ddbbafd99106793f43bf1001b4e71"
+  integrity sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==
+  dependencies:
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/signature-v4" "^5.6.9"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/token-providers@3.1096.0":
+  version "3.1096.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.1096.0.tgz#0aa251af60554fd58796ec98a69c7bcc48eeccc3"
+  integrity sha512-hdUS2hDppy3vkWeFl5y86RLNU6OWH2mQB09yOSsRefwhhGTSFPkaZvfLDD/9vFcvMzlr8QFQFw3fw2FtrurVQA==
+  dependencies:
+    "@aws-sdk/core" "^3.977.1"
+    "@aws-sdk/nested-clients" "^3.997.36"
+    "@aws-sdk/types" "^3.974.2"
+    "@smithy/core" "^3.29.8"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@^3.974.2":
+  version "3.974.2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.974.2.tgz#05e7ccac417735e0786d430d2d5cc139047a08da"
+  integrity sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==
+  dependencies:
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/xml-builder@^3.972.37":
+  version "3.972.37"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz#669363721702d46a500c6ea485a44591e511f280"
+  integrity sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==
+  dependencies:
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@aws/lambda-invoke-store@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz#708802d987f8e17bdf4af4de1031660ce1cdd65f"
+  integrity sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
@@ -282,16 +513,15 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@dcl/catalyst-storage@^4.5.1":
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/@dcl/catalyst-storage/-/catalyst-storage-4.6.1.tgz#0f169d8d85f6b4c2f5f716399cf6c624b388a7ad"
-  integrity sha512-bz0djW6xhj45DBCRB8RaYphrJSgwJpknOcM/3UPcpba2Wj8pYzsSQEG/mzzKskRWaph4TV1pBS3NSAfcc8Iw0Q==
+"@dcl/catalyst-storage@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@dcl/catalyst-storage/-/catalyst-storage-5.0.0.tgz#7cae2f7bab474f6dc352b32a839f792cab0fe9e6"
+  integrity sha512-62FXes2crUzuMvHl9I4eRnTmaSYJXknI9oWm0P+WNnjvybfy75DGx1/rcWUEMtxSJ0lq+ZmRqNi804hpMm5X5A==
   dependencies:
-    "@well-known-components/interfaces" "^1.1.1"
-    aws-sdk "^2.1426.0"
-    aws-sdk-client-mock "^3.0.0"
-    destroy "^1.2.0"
-    file-type "^21.1.1"
+    "@aws-sdk/client-s3" "^3.1095.0"
+    "@aws-sdk/lib-storage" "^3.1095.0"
+    "@well-known-components/interfaces" "^1.5.2"
+    file-type "^22.0.1"
 
 "@dcl/core-commons@0.10.1", "@dcl/core-commons@^0.10.0", "@dcl/core-commons@^0.10.1":
   version "0.10.1"
@@ -797,39 +1027,70 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.10.tgz#beefe675f1853f73676aecc915b2bd2ac98c4fc6"
   integrity sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==
 
-"@sinonjs/commons@^3.0.0", "@sinonjs/commons@^3.0.1":
+"@sinonjs/commons@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
   integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^10.0.2", "@sinonjs/fake-timers@^10.3.0":
+"@sinonjs/fake-timers@^10.0.2":
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz#55fdff1ecab9f354019129daf4df0dd4d923ea66"
   integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@sinonjs/fake-timers@^11.2.2":
-  version "11.3.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz#51d6e8d83ca261ff02c0ab0e68e9db23d5cd5999"
-  integrity sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==
+"@smithy/core@^3.29.8", "@smithy/core@^3.31.0":
+  version "3.31.0"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.31.0.tgz#b35b5992ddeaa8044267cbb76e290181b4943160"
+  integrity sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw==
   dependencies:
-    "@sinonjs/commons" "^3.0.1"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
 
-"@sinonjs/samsam@^8.0.0":
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-8.0.3.tgz#eb6ffaef421e1e27783cc9b52567de20cb28072d"
-  integrity sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==
+"@smithy/credential-provider-imds@^4.4.13":
+  version "4.4.15"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.15.tgz#405202db182c4a06a6cc9bfc0f281d059544e450"
+  integrity sha512-xYVGrisQqTJWhOnScUhbx8s9H63TMtoxzuUoxG6mP8J+B/YbX3vZxVsgV0xDf43abJnJP0fjP7BkQh7OESwuRA==
   dependencies:
-    "@sinonjs/commons" "^3.0.1"
-    type-detect "^4.1.0"
+    "@smithy/core" "^3.31.0"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
 
-"@sinonjs/text-encoding@^0.7.2":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz#282046f03e886e352b2d5f5da5eb755e01457f3f"
-  integrity sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==
+"@smithy/fetch-http-handler@^5.6.10":
+  version "5.6.12"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.12.tgz#cedde1c9c3b01e0d2089480908c9ef952d273ebb"
+  integrity sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q==
+  dependencies:
+    "@smithy/core" "^3.31.0"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@smithy/node-http-handler@^4.9.10":
+  version "4.9.12"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.9.12.tgz#da7ede54a652f47aa3ac771d178fc6424ad3ca77"
+  integrity sha512-dWW5KRt4mnEvjNzbGqGeCuAvgum85Y9ZoyuMQqcTEfapndyVJ1k9BEHK7kdXJZ32enyRmmwcFjMwlB/KgLKI3Q==
+  dependencies:
+    "@smithy/core" "^3.31.0"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@smithy/signature-v4@^5.6.9":
+  version "5.6.11"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.6.11.tgz#1e71be9713615c603ebe25471ad75febaa9a12d7"
+  integrity sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw==
+  dependencies:
+    "@smithy/core" "^3.31.0"
+    "@smithy/types" "^4.16.1"
+    tslib "^2.6.2"
+
+"@smithy/types@^4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.16.1.tgz#19e199c234829a51c085caf63f0bb17bb80187e4"
+  integrity sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==
+  dependencies:
+    tslib "^2.6.2"
 
 "@tokenizer/inflate@^0.4.1":
   version "0.4.1"
@@ -965,29 +1226,17 @@
   dependencies:
     undici-types "~6.21.0"
 
-"@types/node@^22.10.0":
-  version "22.20.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.20.1.tgz#84e7cdf63cdaa20c134aa317ccc901aa21e16f0e"
-  integrity sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==
+"@types/node@^24.0.0":
+  version "24.13.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.13.3.tgz#49f18bd3c647866dcda51a0756c145e14590ce16"
+  integrity sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==
   dependencies:
-    undici-types "~6.21.0"
+    undici-types "~7.18.0"
 
 "@types/semver@^7.3.12":
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.1.tgz#3ce3af1a5524ef327d2da9e4fd8b6d95c8d70528"
   integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
-
-"@types/sinon@^10.0.10":
-  version "10.0.20"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.20.tgz#f1585debf4c0d99f9938f4111e5479fb74865146"
-  integrity sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==
-  dependencies:
-    "@types/sinonjs__fake-timers" "*"
-
-"@types/sinonjs__fake-timers@*":
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz#49f731d9453f52d64dd79f5a5626c1cf1b81bea4"
-  integrity sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
@@ -1216,7 +1465,7 @@
   dependencies:
     dotenv "^16.0.1"
 
-"@well-known-components/interfaces@^1.1.1", "@well-known-components/interfaces@^1.5.1", "@well-known-components/interfaces@^1.5.2":
+"@well-known-components/interfaces@^1.5.1", "@well-known-components/interfaces@^1.5.2":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@well-known-components/interfaces/-/interfaces-1.5.2.tgz#ef7001a19d410459e65b216dd948d15be19e4efa"
   integrity sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==
@@ -1381,31 +1630,6 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-sdk-client-mock@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk-client-mock/-/aws-sdk-client-mock-3.1.0.tgz#5fa55e654e256c132cd2fce24645621e5486590a"
-  integrity sha512-3Mx5R8DDka2TB8qtr5jDbSVJsUM6uoX5tZSReBsJS8HunVtL9PHhb+RU7b+I3/53B2fJAyoEp7dJNXndBI+6MA==
-  dependencies:
-    "@types/sinon" "^10.0.10"
-    sinon "^16.1.3"
-    tslib "^2.1.0"
-
-aws-sdk@^2.1426.0:
-  version "2.1693.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1693.0.tgz#fda38671af3dc5fa8117e9aa09cf6ce37e34010e"
-  integrity sha512-cJmb8xEnVLT+R6fBS5sn/EFJiX7tUnDaPtOPZ1vFbOJtd0fnZn/Ky2XGgsvvoeliWeH7mL3TWSX5zXXGSQV6gQ==
-  dependencies:
-    buffer "4.9.2"
-    events "1.1.1"
-    ieee754 "1.1.13"
-    jmespath "0.16.0"
-    querystring "0.2.0"
-    sax "1.2.1"
-    url "0.10.3"
-    util "^0.12.4"
-    uuid "8.0.0"
-    xml2js "0.6.2"
-
 babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
@@ -1500,6 +1724,11 @@ bintrees@1.0.2:
   resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
   integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
 
+bowser@^2.11.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.14.1.tgz#4ea39bf31e305184522d7ad7bfd91389e4f0cb79"
+  integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
+
 brace-expansion@^1.1.7:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
@@ -1552,14 +1781,13 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-buffer@4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
-  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
+buffer@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
-    isarray "^1.0.0"
 
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -1808,11 +2036,6 @@ diff@^4.0.1:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.4.tgz#7a6dbfda325f25f07517e9b518f897c08332e07d"
   integrity sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==
-
-diff@^5.1.0:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.2.tgz#0a4742797281d09cfa699b79ea32d27723623bad"
-  integrity sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2199,10 +2422,10 @@ eventemitter3@^4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
-  integrity sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==
+events@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 execa@^5.0.0:
   version "5.1.1"
@@ -2297,15 +2520,15 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-file-type@^21.1.1:
-  version "21.3.4"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-21.3.4.tgz#e3f902faee8ec4aa152909fc902a7a77f9c06725"
-  integrity sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==
+file-type@^22.0.1:
+  version "22.0.1"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-22.0.1.tgz#0184dbd6b6353bb25eb21a0c413a23885b6d1818"
+  integrity sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==
   dependencies:
     "@tokenizer/inflate" "^0.4.1"
-    strtok3 "^10.3.4"
-    token-types "^6.1.1"
-    uint8array-extras "^1.4.0"
+    strtok3 "^10.3.5"
+    token-types "^6.1.2"
+    uint8array-extras "^1.5.0"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -2635,11 +2858,6 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-ieee754@1.1.13:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
-
 ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
@@ -2692,14 +2910,6 @@ internal-slot@^1.1.0:
     es-errors "^1.3.0"
     hasown "^2.0.2"
     side-channel "^1.1.0"
-
-is-arguments@^1.0.4:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.2.0.tgz#ad58c6aecf563b78ef2bf04df540da8f5d7d8e1b"
-  integrity sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==
-  dependencies:
-    call-bound "^1.0.2"
-    has-tostringtag "^1.0.2"
 
 is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
   version "3.0.5"
@@ -2806,7 +3016,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-generator-function@^1.0.10, is-generator-function@^1.0.7:
+is-generator-function@^1.0.10:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.1.2.tgz#ae3b61e3d5ea4e4839b90bad22b02335051a17d5"
   integrity sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==
@@ -2896,7 +3106,7 @@ is-symbol@^1.0.4, is-symbol@^1.1.1:
     has-symbols "^1.1.0"
     safe-regex-test "^1.1.0"
 
-is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15, is-typed-array@^1.1.3:
+is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.15.tgz#4bfb4a45b61cee83a5a46fba778e4e8d59c0ce0b"
   integrity sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==
@@ -2922,11 +3132,6 @@ is-weakset@^2.0.3:
   dependencies:
     call-bound "^1.0.3"
     get-intrinsic "^1.2.6"
-
-isarray@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -3349,11 +3554,6 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
-jmespath@0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
-  integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -3408,11 +3608,6 @@ json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
-
-just-extend@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-6.2.0.tgz#b816abfb3d67ee860482e7401564672558163947"
-  integrity sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==
 
 keyv@^4.5.3:
   version "4.5.4"
@@ -3610,17 +3805,6 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-nise@^5.1.4:
-  version "5.1.9"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.9.tgz#0cb73b5e4499d738231a473cd89bd8afbb618139"
-  integrity sha512-qOnoujW4SV6e40dYxJOb3uvuoPHtmLzIk4TFo+j0jPJoC+5Z9xja5qH5JZobEPsa8+YYphMrOSwnrshEhG2qww==
-  dependencies:
-    "@sinonjs/commons" "^3.0.0"
-    "@sinonjs/fake-timers" "^11.2.2"
-    "@sinonjs/text-encoding" "^0.7.2"
-    just-extend "^6.2.0"
-    path-to-regexp "^6.2.1"
 
 node-exports-info@^1.6.0:
   version "1.6.0"
@@ -3838,7 +4022,7 @@ path-scurry@^1.6.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@^6.2.1, path-to-regexp@^6.3.0:
+path-to-regexp@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
   integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
@@ -3929,11 +4113,6 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-  integrity sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
-
 punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
@@ -3944,11 +4123,6 @@ pure-rand@^6.0.0:
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
   integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
 
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==
-
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -3958,6 +4132,15 @@ react-is@^18.0.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+readable-stream@^3.5.0:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 reflect-metadata@^0.2.2:
   version "0.2.2"
@@ -4084,6 +4267,11 @@ safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-push-apply@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/safe-push-apply/-/safe-push-apply-1.0.0.tgz#01850e981c1602d398c85081f360e4e6d03d27f5"
@@ -4100,16 +4288,6 @@ safe-regex-test@^1.1.0:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-regex "^1.2.1"
-
-sax@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
-  integrity sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==
-
-sax@>=0.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.6.0.tgz#da59637629307b97e7c4cb28e080a7bc38560d5b"
-  integrity sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==
 
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
@@ -4219,18 +4397,6 @@ signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-sinon@^16.1.3:
-  version "16.1.3"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-16.1.3.tgz#b760ddafe785356e2847502657b4a0da5501fba8"
-  integrity sha512-mjnWWeyxcAf9nC0bXcPmiDut+oE8HYridTNzBbF98AYVLmWwGRp2ISEpyhYflG1ifILT+eNn3BmKUJPxjXUPlA==
-  dependencies:
-    "@sinonjs/commons" "^3.0.0"
-    "@sinonjs/fake-timers" "^10.3.0"
-    "@sinonjs/samsam" "^8.0.0"
-    diff "^5.1.0"
-    nise "^5.1.4"
-    supports-color "^7.2.0"
-
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -4283,6 +4449,14 @@ stop-iteration-iterator@^1.1.0:
   dependencies:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
+
+stream-browserify@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
+  integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
+  dependencies:
+    inherits "~2.0.4"
+    readable-stream "^3.5.0"
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -4339,6 +4513,13 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -4361,14 +4542,14 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-strtok3@^10.3.4:
+strtok3@^10.3.5:
   version "10.3.5"
   resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-10.3.5.tgz#7213285da0dc3dec0fc8ce5df4b8b7a733f14360"
   integrity sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==
   dependencies:
     "@tokenizer/token" "^0.3.0"
 
-supports-color@^7.1.0, supports-color@^7.2.0:
+supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -4433,7 +4614,7 @@ toidentifier@~1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-token-types@^6.1.1:
+token-types@^6.1.1, token-types@^6.1.2:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/token-types/-/token-types-6.1.2.tgz#18d0fd59b996d421f9f83914d6101c201bd08129"
   integrity sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==
@@ -4481,7 +4662,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0, tslib@^2.4.0:
+tslib@^2.4.0, tslib@^2.6.2:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -4504,11 +4685,6 @@ type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
-
-type-detect@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.1.0.tgz#deb2453e8f08dcae7ae98c626b13dddb0155906c"
-  integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
 
 type-fest@^0.20.2:
   version "0.20.2"
@@ -4585,7 +4761,7 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
   integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
 
-uint8array-extras@^1.4.0:
+uint8array-extras@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/uint8array-extras/-/uint8array-extras-1.5.0.tgz#10d2a85213de3ada304fea1c454f635c73839e86"
   integrity sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==
@@ -4609,6 +4785,11 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici-types@~7.18.0:
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
+  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 unrs-resolver@^1.6.2:
   version "1.12.2"
@@ -4655,29 +4836,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-url@0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
-  integrity sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
-
-util@^0.12.4:
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
-  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
-  dependencies:
-    inherits "^2.0.3"
-    is-arguments "^1.0.4"
-    is-generator-function "^1.0.7"
-    is-typed-array "^1.1.3"
-    which-typed-array "^1.1.2"
-
-uuid@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
-  integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
@@ -4740,7 +4902,7 @@ which-collection@^1.0.2:
     is-weakmap "^2.0.2"
     is-weakset "^2.0.3"
 
-which-typed-array@^1.1.16, which-typed-array@^1.1.19, which-typed-array@^1.1.2:
+which-typed-array@^1.1.16, which-typed-array@^1.1.19:
   version "1.1.22"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.22.tgz#8f3cc78aefb40b437346dd40a1dbfa5d1da43fe9"
   integrity sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==
@@ -4791,19 +4953,6 @@ write-file-atomic@^4.0.2:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
-
-xml2js@0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.2.tgz#dd0b630083aa09c161e25a4d0901e2b2a929b499"
-  integrity sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~11.0.0"
-
-xmlbuilder@~11.0.0:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
-  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -958,17 +958,17 @@
   dependencies:
     undici-types ">=7.24.0 <7.24.7"
 
-"@types/node@^18.15.11":
-  version "18.19.130"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.130.tgz#da4c6324793a79defb7a62cba3947ec5add00d59"
-  integrity sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==
-  dependencies:
-    undici-types "~5.26.4"
-
 "@types/node@^20.3.1":
   version "20.19.43"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.43.tgz#fcecf580ba42a0db55cf404c372c97973c376c97"
   integrity sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==
+  dependencies:
+    undici-types "~6.21.0"
+
+"@types/node@^22.10.0":
+  version "22.20.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.20.1.tgz#84e7cdf63cdaa20c134aa317ccc901aa21e16f0e"
+  integrity sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==
   dependencies:
     undici-types "~6.21.0"
 
@@ -4575,10 +4575,10 @@ typed-url-params@^1.0.1:
   resolved "https://registry.yarnpkg.com/typed-url-params/-/typed-url-params-1.0.1.tgz#59aeb01881a6ac6cc1cbd6e9f949f306ddb5a6e7"
   integrity sha512-762imXO+myoSDHD9+YxUfSmfT0yGH1j+3s9UJ6uqKkOYIwHH6/gsFo67ZoST0Ey/RSoaps1zGu1N+eiuuCxfeg==
 
-typescript@^4.5.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.7.2:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 uglify-js@^3.1.4:
   version "3.19.3"
@@ -4604,11 +4604,6 @@ unbox-primitive@^1.1.0:
   version "7.24.6"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
-
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 undici-types@~6.21.0:
   version "6.21.0"


### PR DESCRIPTION
## Why this exists

`@dcl/snapshots-fetcher` could not be imported at all when installed from the registry. Chasing that opened a wider question: if the entry point had been broken this long without anyone noticing, what else was only working by luck?

The answer, across several review rounds, was a recurring pattern rather than a list of unrelated bugs:

> **Partial work was reported as complete.** A snapshot whose lines wouldn't parse, a deployment the deployer never confirmed, a snapshot list we could only half-read — each ended with the server's high-water mark moved forward and the server marked as synced. The entities behind them were skipped silently, and nothing retried because everything looked successful.

Most of this PR is that one pattern, found in six different places, plus the input validation and lifecycle work needed to make "incomplete" something the code can actually detect.

---

## How the problems were found and fixed

### 1. The published package was unimportable

`src/synchronizer.ts` imports `fp-future`, which was never declared. It resolved locally only because the `@dcl/http-server` **devDependency** hoisted it, and `dist/index.js` re-exports `./synchronizer`, so `require('@dcl/snapshots-fetcher')` threw `MODULE_NOT_FOUND` on *every* entry point.

**How it was confirmed:** built the package, linked only the declared production dependencies into a clean project, and required it — `MODULE_NOT_FOUND` before, all 10 exports after. That same harness now guards every dependency change in the branch.

The mirror error is fixed too: `@dcl/fetch-component` was a production dependency used only by tests.

### 2. Sync advanced past entities it never deployed

Six variants of the same failure. In each case the fix is to make incompleteness *representable*, then refuse to advance on it:

| What was incomplete | How it looked successful | How it's fixed |
|---|---|---|
| Snapshot lines that wouldn't parse | Stream ended normally; `0 >= 0` marked it processed | Lines are counted; a non-zero count fails the snapshot |
| A snapshot that failed to deploy | Only *thrown* jobs were recorded as failed | The unusable-line path now throws too |
| Deployments the deployer never confirmed | `onIdle()` proves the queue drained, not that `markAsDeployed` ran | The processed marker is re-read after the drain |
| A snapshot list we could only half-read | The surviving subset looked like the full history | `getSnapshots` returns a discarded count; the server stays bootstrapping |
| Timestamps committed before the drain | A later success pushed the mark past an earlier failure | Bootstrap marks are held until `onIdle()` succeeds |
| A replacement chain resolved one link per pass | Chain tail re-deployed needlessly | The decision phase runs to a fixed point |

**How each was verified:** every fix has a regression test that was **run against the old code and confirmed to fail** — not just added alongside. Two examples of what that caught: the stranded-server test times out waiting for a retry that never comes, and the partial-snapshot-list test sees `pointerChangesRequested: 2` where it should be `0`.

That discipline also caught two of my own tests that proved nothing — one raced a `setTimeout` and ignored which side won, another used a fabricated hash so the download failed verification before reaching the code under test. Both are fixed.

### 3. Remote input could crash, hang, or permanently poison sync state

Everything from a content server is untrusted, and several fields were used as arithmetic or as control flow with no bounds.

**Crashes and hangs:** a malformed `Location` header crashed the *process* (`new URL()` throwing inside an HTTP response callback is an `uncaughtException`, not a rejection). A repeated `pagination.next` looped forever. `/pointer-changes` carried no request timeout while `/snapshots` did, so a server that accepted a connection and went silent stalled that server's sync permanently — a pending promise never reaches the reconnection logic.

**Poisoned state — the subtle one.** Timestamps become a server's high-water mark, and it only ever moves forward, so a single bad value is permanent for the life of the process: the server then polls from an instant nothing can reach and silently stops syncing. Guarding finiteness was not enough:

- JSON can't carry `NaN` (`{"a":NaN}` is a syntax error) but it *can* carry `Infinity`, because the number grammar has no range limit and `1e999` parses to it.
- `1e308` is finite, non-negative, and just as unusable.

**How it's fixed:** one shared "is this a plausible instant" policy — safe integer, non-negative, within a day of our clock — applied on all three paths that carry remote timestamps. Getting there took three passes, because each round found the same class behind a different endpoint; the policy now lives in one place precisely so it can't drift again.

**Bounded allocation:** entity files, snapshot lines, buffered bodies, `content[]`, avatar snapshots and `replacedSnapshotHashes` all have explicit ceilings. Where a limit means dropping data (`content[]`) it **rejects rather than truncates**, since silently fetching part of an entity and reporting success is the failure mode this PR exists to remove.

### 4. Stopping didn't stop anything

`stop()` set a flag checked only *between* retry iterations, while the pointer-changes stream is an infinite loop whose only exit was a synchronizer-wide flag. Measured: `stop()` returned in 0 ms reporting `isStopped() === true` while polling continued (5 → 18 polls).

**How it's fixed:** a per-job stop signal threaded into the stream itself (checking it only in the consumer's loop can never end a stream whose poll returned nothing), interruptible sleeps, and `stop()` now awaits in-flight work — including `deployer.onIdle()`, so an asynchronous deployer is drained before shutdown returns.

Related: the job manager could run two jobs for one server, removed servers kept polling until the next bootstrap pass, and queued sync jobs stacked without bound under a DAO refresh loop.

### 5. The corrupt-file root cause

The previous two PRs (#203, #204) added eviction and re-verification for corrupt local entity files. Those were downstream mitigations. The cause was in `@dcl/catalyst-storage` 4, which wrote content-addressed files **straight to their final path**:

```
SIGKILL mid-write, then restart:
  4.6.1: leaves <root>/7cca/QmTestHash   -> exist() = true   (skipped forever)
  5.0.0: leaves <root>/.tmp-writes/96a7… -> exist() = false  (re-downloaded)
```

Version 5 stages writes and commits by `rename`, so a crash publishes nothing. **This is why the PR requires Node 24** — catalyst-storage 5 declares that floor, and this package cannot honestly claim `>=22` while depending on it.

### 6. Security advisories

Three high-severity alerts cleared by a lockfile-only bump (both declaring ranges already admitted the patched versions — the resolutions were just stale): `fast-uri` 3.1.2 → 3.1.4 (two host-confusion advisories, production-reachable via `@dcl/schemas > ajv`) and `js-yaml` 4.2.0 → 4.3.0 (quadratic CPU, dev-only). Two further alerts — `uuid` and `aws-sdk` v2 end-of-support — were cleared by the catalyst-storage 5 upgrade moving to AWS SDK v3.

---

**Steady-state pointer-changes now drains per poll.** The scalar max watermark had the same hazard the bootstrap fix closed — an entity deployed at `t=200` advancing the mark past one that failed at `t=100` — but the stream never ends, so there was no checkpoint to hold marks until. Each poll now awaits the deployer and commits its timestamps only if every scheduled deployment was acknowledged, reconnecting from the last confirmed timestamp otherwise. Measured cost: 0.5% at the default 5s poll interval, 2.4% at 1s, up to 18.5% only when poll and deploy latency are evenly matched back-to-back. The drain is per *poll*, so it waits on the residual queue rather than on each deployment.

---

## ⚠️ Breaking changes — `2.0.0` → `3.0.0`

Each is a deliberate choice, not a side effect.

**Requires Node ≥ 24** (was ≥ 22). Forced by catalyst-storage 5. With `engineStrict: true` an install on Node 22 now fails rather than warns.

**`markAsDeployed()` is load-bearing.** It was always documented as the signal that an entity truly deployed, but nothing depended on it. Now the snapshot's processed marker is re-read after the deployer drains, so **a deployer that never calls `markAsDeployed()` will never finish bootstrapping** — where previously it advanced anyway and skipped those entities. The real catalyst deployer calls it. Retries also make deployments need to be idempotent.

**`fetchJson` refuses all redirects**, not just cross-origin ones. Same-origin isn't safe either: an origin is a hostname, not an address, so a host can answer the first request from a public IP and rebind before the redirect is fetched. `IFetchComponent` exposes no way to pin the request's own DNS resolution, so any check here would resolve separately from the request it guards. No known catalyst JSON endpoint redirects.

**`stop()` blocks until work finishes**, including the deployer's queue. Bounded by roughly one in-flight request, but no longer near-instant — check it against your SIGTERM grace period.

**`createJobQueue().stop()` is terminal.** After it is called the queue refuses new work (`scheduleJob` and friends throw) and a retry ladder in flight stops re-enqueueing itself; a stopped queue cannot be restarted. Previously `stop()` only waited for quiescence and left the queue accepting jobs, so a consumer could still have work start after shutting it down. A queue built with `autoStart: false` is now started by `stop()` so its queued work can drain — otherwise shutdown waited on jobs that could never begin, and the type offers no way to start them.

**Transfer bounds are configurable via `transferLimits`.** Six fields — the JSON request timeout (15s), the download inactivity deadline (30s), the downloaded-file ceiling (1 GiB), the rate floor (4 KiB/s) and its 60s grace period, and the pagination page cap (10,000) — depend on the link a node runs on rather than on correctness, so they are options rather than constants — on the stream options, defaulting to the previous values. Not on the components bag, which is where I tried first: reading an optional config field off `components` fails against a strict container (this repo's harness proxies it and throws on unknown members), so it would have broken consumers building components that way. `createSynchronizer` validates them at construction. See the README section.

**Transfers must average at least 4 KiB/s.** Both body-reading paths bounded total bytes and socket inactivity, but neither bounded time: the inactivity deadlines refresh per chunk, so a peer trickling one byte per 30s window looked healthy forever while holding a queue slot, bounded only by the size cap (1 GiB at that rate is geological). The floor is enforced on the **raw** response, before decompression — placed after gunzip it never ran at all, since gunzip can consume unbounded input while emitting nothing (concatenated empty gzip members: measured 1 MB in, 0 bytes out). `maxDownloadedFileSizeInBytes` now applies to the compressed stream as well as the decompressed one, for the same reason. The rate is judged only after a 60s grace period, so small responses never see it, and it sits far below any usable link — but a genuinely slow transfer that cannot beat it now fails its attempt instead of continuing. Downloads retry, so this costs an attempt rather than the entity. Tunable, and `minTransferRateInBytesPerSecond: 0` disables it — the floor was picked by reasoning about modem speeds, not from catalyst data.

**The processed-snapshots lookup is chunked.** Per-entry caps did not bound the aggregate: the synchronizer batches every entry from every server into one lookup, bounded only by the 50 MiB response limit (~845,000 hashes). Postgres refuses a statement with over 65,535 bind parameters, and the decision pass is shared across servers, so one server advertising enough hashes could make the lookup throw for the whole pass and stall syncing from every well-behaved server in it. Now serial batches of 1000 — serial deliberately, since issuing every chunk at once keeps the peak storage load the chunking exists to remove.

**Discarded response bodies are destroyed, not drained.** A download that rejects on its status code or on an unsupported `Content-Encoding` now destroys the response instead of `resume()`-ing it. Draining reads the body to completion outside every transfer bound — the size caps and rate floor live in the download pipeline, which these paths never reach — so a server could pair an error status with an endless body and keep the socket and bandwidth after the caller had already moved on. The cost is that these paths no longer return their socket to the keep-alive pool, which does not matter on a path that is about to retry elsewhere.

**`Content-Encoding` is matched case-insensitively**, with `x-gzip` accepted as the legacy alias. Comparing against the exact string `gzip` meant a correct `Content-Encoding: GZip` response was written to disk still compressed, failed hash verification, and burned the whole retry ladder against a well-behaved server. Any other coding — `br`, `deflate`, or several layered — is now refused up front naming it, instead of surfacing as a hash mismatch after the retries were spent. No response that used to succeed stops succeeding.

**URLs in errors and logs are sanitized.** After a redirect, or in a pagination `next`, the URL is the server's text: unbounded in length, and able to carry `user:password@`. Every message in the download, JSON and pagination paths now truncates it and strips userinfo, so error text a consumer forwards to logs cannot leak credentials or blow up log cardinality. If you match on error strings, the URL portion may now be shortened.

**Snapshot bootstrap stops when its servers are dropped**, matching pointer-changes. Checked across every server that advertised the snapshot, since its entities serve all of them.

**Pointer-changes de-duplication only suppresses what an earlier poll delivered.** `from` is inclusive, so each poll re-returns the rows at the high-water timestamp; the suppression set used to grow during a poll, which collapsed two legitimate deltas for the same entity at the same `localTimestamp` inside one response. It is now a **count per row fingerprint** — entityType, entityId, entityTimestamp, localTimestamp, sorted pointers and each auth link — read frozen per poll. `entityId` is the hash of the entity file and does not cover the authChain, so two rows can share an id and be distinct deployments, and nothing guarantees a server replays rows in the order it first sent them. Keyed by id, a new row arriving before the replay of a delivered one spent that id's allowance and was suppressed while the replay was yielded in its place. Fingerprinting removes the guesswork; counts stay because rows identical in every field are genuinely indistinguishable. Boundary state is capped at 10,000 tracked rows per timestamp; the 10,001st distinct row now fails the poll before it is yielded, so the confirmed high-water mark cannot advance and the row is retried rather than lost. Fingerprinting hashes fields incrementally into SHA-256 after enforcing local structural limits (10,000 pointers, 100 auth links, 256 KiB per string, and 1 MiB of aggregate fingerprint material), avoiding attacker-sized canonical JSON; internal fingerprint helpers are stripped from generated declarations. I had previously argued the collapse was safe because `entityId` is content-addressed — that may hold, but it is an invariant about a remote server this package cannot check, and suppression bounded by rows this stream actually delivered needs no invariant at all.

Duplicate rows inside a single poll are yielded, deliberately. A hostile server can spend bounded extra deploy work by repeating valid rows — bounded by the page and response limits, and idempotent downstream since entity ids are content addresses. A per-poll row cap would either truncate a legitimate deep backlog or fail the poll and resume from the last confirmed timestamp, the same liveness trap as a wall-clock pagination budget. A richer upstream change id would fix it properly.

**A non-array `content` field is rejected.** Every reader guards with `Array.isArray` and falls back to "no content", so an object or string there produced a fully-downloaded entity whose dependencies were never fetched. `null` is rejected too — `@dcl/schemas` declares `content` as a required array, so absence is the only case readable as empty without guessing.

**`createJobQueue({ concurrency })` is required and validated.** It was already required in fact — p-queue falls back to unbounded concurrency only when the key is absent, and the factory always passes it, so omitting it threw p-queue's own `TypeError`. Now it fails with this package's message, as does a bad `timeout`, and `downloadEntityAndContentFiles` validates `contentFilesConcurrency` before spending any request.

**An unknown key in `transferLimits` is rejected.** A misspelled safety bound previously fell back to the permissive default with nothing reporting it. Callers passing extra properties through a spread will now get an error naming the valid keys.

**`createJobQueue({ timeout })` rejects on timeout** instead of resolving as success (p-queue defaults `throwOnTimeout` to false). The catalyst uses this for deployment jobs, so previously-invisible timeouts now surface and retry.

**Pointer-change rows now have structural limits.** Schema-valid rows above the local pointer/auth-chain/string/aggregate ceilings fail the poll before its high-water mark is committed. The 10,000-pointer ceiling is a hardcoded defensive limit in this PR, not yet a configurable cross-repository Catalyst contract. Audits of four current Catalyst databases found a maximum stored deployment of 627 pointers, leaving roughly a 16× margin and no migration impact.

**Retry and reconnection configuration now fails fast.** Non-finite timings and retry exponents below 1 are rejected at construction instead of producing hot loops, stalled jobs, or decreasing backoff.

**Also:** content-download redirects to IANA non-global IPv4 and IPv6 addresses are refused (including mapped forms and DNS-rebinding guards; IANA-designated globally reachable exceptions remain allowed; a private *original* host stays allowed so local development works); `downloadQueue` narrows to `Pick<IJobQueue, 'scheduleJobWithRetries'>`; `@dcl/fetch-component` moved to devDependencies; several previously-accepted config values now throw at construction; some log fields and metric labels changed.

---

## How to review this

**77 commits, +11,897/−761 across 75 files.** Best read as a whole; each commit's message carries the reasoning for that change, including the ones where I reversed an earlier decision in this same branch.

**Verification:** 128 → **609 tests** (19 → 60 suites). The latest full run passed all 609 tests; the last measured coverage was **95.98%** statements and **92.03%** branches. The exact set of runtime exports is pinned by a test, which is this repo's API check: `make build` used to call api-extractor, but it was never declared or installed and no config ever existed, so that step failed on every branch and the check never ran. Every commit was checked to compile independently so `git bisect` works — with two known exceptions, `a5dc01a` and `0a02cc4`, where a shared file's two concerns landed in different commits; `HEAD` is correct and fixing them needs a history rewrite.

**Concentrate here.** Across the review rounds, every confirmed defect in a *fix* landed in the request-destination guards, twice after I'd reported the fix as complete:

| Location | What to check |
|---|---|
| `src/utils.ts` `isNonPublicAddress` / `parseIPv6ToBytes` | Range coverage; byte-based because a textual guard missed the compressed IPv4-mapped form `URL` actually emits (`[::ffff:127.0.0.1]` → `[::ffff:7f00:1]`) |
| `src/utils.ts` `createRedirectSafeLookup` | Pins the original host's public/non-public *classification*, not its address, so round-robin CDNs still work |
| `src/client.ts` pagination + `isUsableTimestamp` | Origin- and path-pinned `next`; the shared timestamp policy |

**And review the tests skeptically, not just the code.** Mine were the weakest link more than once: an SSRF assertion using an address form `URL` can never emit (so a real bypass sat behind a green suite), a storage stub that didn't consume its stream the way real storage does, and the two no-op tests mentioned above. When reading a test, the useful question is whether its input can actually occur.

## Known limitations, deliberately not fixed here

**Same-origin DNS rebinding on the JSON path.** Path pinning and outright redirect refusal constrain it materially, but `IFetchComponent` exposes no DNS `lookup` hook, so any address check here would resolve separately from the request it guards. Closing it fully needs a DNS-pinning fetch component or egress controls on the consumer side — recorded in `fetchJson`.

**No tight worst-case bound on transfer duration.** The rate floor makes holding a slot cost real bandwidth, but at exactly the floor a 1 GiB download still takes ~73 hours. A tighter bound wants a size-proportional budget derived from real catalyst throughput percentiles rather than a constant picked here; a single wall-clock deadline cannot serve both a 1 KiB pointer-changes page and a 1 GiB content file. `transferLimits` at least makes the floor tunable in the meantime.

**Most bounds remain hardcoded.** Only the six that depend on the deployment were surfaced. The new pointer-change structural ceilings are hardcoded as well; making the pointer count a shared configurable Catalyst/snapshots-fetcher contract is deliberately left out until both repositories enforce it together. The rest — redirect count, pagination link length, per-entity file counts, snapshot line length, log caps, JSON response ceiling — express "no legitimate peer exceeds this" rather than a property of your link, so a knob on them would only be a way to switch a guard off.

**`downloadQueue` covers one JSON fetch, not downloads.** Despite the name, the injected queue wraps only `GET /snapshots` (`client.ts`). Content and entity files go through internal `PQueue`s bounded by `contentFilesConcurrency`, so `createJobQueue({ timeout })` on `downloadQueue` does not bound a download, and nothing globally caps concurrent file transfers — the ceiling is your deployer's concurrency × `contentFilesConcurrency`. Renaming or rerouting it is a larger change than this PR should carry.

**Pagination amplification is bounded but still large.** `maxPagesPerPaginatedCall` defaults to the 10,000 this package always used, so one poll can still make that many same-path requests against a server that keeps advertising `next`. It is now tunable rather than lowered for everyone, because a legitimate deep backfill should not start failing on upgrade. There is deliberately no wall-clock budget: pagination progress is not committed until the poll completes, so aborting a long walk discards it and resumes from the last confirmed timestamp, leaving a genuinely far-behind node restarting the same walk forever. A safe budget needs per-page commit first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)












