### PR TITLE
feat: speed up snapshot bootstrap

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -11,6 +11,7 @@ import {
   resolveTransferLimits,
   sanitizeUrlForLog,
   truncateForLog,
+  downloadContentFileToTemporaryFile as downloadContentToTemporaryFile,
   saveContentFileToDisk as saveContentFile
 } from './utils'
 
@@ -369,4 +370,15 @@ export async function saveContentFileToDisk(
   const url = new URL(`${server}/contents/${hash}`).toString()
 
   return saveContentFile(components, url, destinationFilename, hash, true, transferLimits)
+}
+
+export async function downloadContentFileToTemporaryFile(
+  components: { metrics?: SnapshotsFetcherComponents['metrics'] },
+  server: string,
+  hash: string,
+  destinationFilename: string,
+  transferLimits?: TransferLimits
+) {
+  const url = new URL(`${server}/contents/${hash}`).toString()
+  return downloadContentToTemporaryFile(components, url, destinationFilename, hash, true, transferLimits)
 }

--- a/src/deploy-entities.ts
+++ b/src/deploy-entities.ts
@@ -115,7 +115,8 @@ export async function deployEntitiesFromSnapshot(
   options: SnapshotDeployedEntityStreamOptions,
   snapshotHash: string,
   servers: Set<string>,
-  shouldStopStream: () => boolean
+  shouldStopStream: () => boolean,
+  beforeStreaming?: Promise<void>
 ) {
   const logger = components.logs.getLogger('deployEntitiesFromSnapshot')
   // Passed down so the snapshot download abandons its retry ladder on shutdown rather than making
@@ -131,7 +132,8 @@ export async function deployEntitiesFromSnapshot(
     snapshotHash,
     servers,
     shouldStopStream,
-    streamReport
+    streamReport,
+    beforeStreaming
   )
   let snapshotWasCompletelyStreamed = false
   let numberOfStreamedEntities = 0

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,12 +1,13 @@
 import * as path from 'path'
-import { saveContentFileToDisk } from './client'
+import { downloadContentFileToTemporaryFile, saveContentFileToDisk } from './client'
 import { SnapshotsFetcherComponents, TransferLimits } from './types'
 import {
   isValidContentHash,
   isVerifiableContentHash,
   pickRandomServer,
   sleepUnlessStopped,
-  truncateForLog
+  truncateForLog,
+  VerifiedTemporaryFile
 } from './utils'
 
 // In-flight downloads, per storage component and then per content hash.
@@ -195,6 +196,65 @@ export async function downloadFileWithRetries(
     // un-deduplicate it and let the next caller start a second transfer of the same file.
     if (inflightForStorage.get(hashToDownload) === downloadWithRetriesJob) {
       inflightForStorage.delete(hashToDownload)
+    }
+  }
+}
+
+/**
+ * Downloads a verified file without copying it into persistent content storage. The caller owns the
+ * returned temporary file and must invoke cleanup().
+ */
+export async function downloadFileToTemporaryFileWithRetries(
+  components: { metrics?: SnapshotsFetcherComponents['metrics'] },
+  hashToDownload: string,
+  targetTempFolder: string,
+  presentInServers: string[],
+  maxRetries: number,
+  waitTimeBetweenRetries: number,
+  shouldStop?: () => boolean,
+  transferLimits?: TransferLimits
+): Promise<VerifiedTemporaryFile> {
+  if (!isValidContentHash(hashToDownload)) {
+    throw new Error(`Invalid content hash: ${truncateForLog(String(JSON.stringify(hashToDownload)))}`)
+  }
+  if (!isVerifiableContentHash(hashToDownload)) {
+    throw new Error(
+      `Refusing to download ${JSON.stringify(hashToDownload)}: unknown hashing algorithm, so its bytes could ` +
+        `never be verified against it`
+    )
+  }
+  if (shouldStop?.()) {
+    throw new Error(`Not downloading ${hashToDownload}: the caller asked to stop`)
+  }
+
+  components.metrics?.observe('dcl_available_servers_histogram', {}, presentInServers.length)
+  const destinationFilename = path.resolve(targetTempFolder, hashToDownload)
+  let retries = 0
+  let serversToPickFrom = presentInServers
+
+  for (;;) {
+    retries++
+    const serverToUse = pickRandomServer(serversToPickFrom)
+    try {
+      const file = await downloadContentFileToTemporaryFile(
+        components,
+        serverToUse,
+        hashToDownload,
+        destinationFilename,
+        transferLimits
+      )
+      components.metrics?.observe('dcl_content_download_job_succeed_retries', {}, retries)
+      return file
+    } catch (error) {
+      if (shouldStop?.() || retries >= maxRetries) {
+        throw error
+      }
+      serversToPickFrom =
+        serversToPickFrom.length > 1 ? serversToPickFrom.filter((server) => server !== serverToUse) : serversToPickFrom
+      await sleepUnlessStopped(waitTimeBetweenRetries, shouldStop)
+      if (shouldStop?.()) {
+        throw error
+      }
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,32 @@ export {
 // sockets / file descriptors. Overridable via downloadEntityAndContentFiles's last argument.
 const DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY = 10
 
+/**
+ * Minimal scheduler contract for putting content transfers behind one caller-owned global limit.
+ * The queue returned by {@link createJobQueue} satisfies it.
+ * @public
+ */
+export type ContentDownloadScheduler = {
+  scheduleJob<T>(fn: () => Promise<T>): Promise<T>
+}
+
+/**
+ * A downloaded entity together with the verified bytes already read from storage.
+ * @public
+ */
+export type DownloadedEntity = {
+  entity: unknown
+  entityFile: Buffer
+}
+
+function scheduleContentDownload<T>(
+  scheduler: ContentDownloadScheduler | undefined,
+  localQueue: PQueue,
+  fn: () => Promise<T>
+): Promise<T> {
+  return scheduler ? scheduler.scheduleJob(fn) : localQueue.add(fn)
+}
+
 // Ceiling on the avatar snapshots a single profile can ask us to fetch. Far above any real profile
 // (a handful per avatar), so it only bounds hostile or corrupt metadata.
 const MAX_AVATAR_SNAPSHOTS_PER_ENTITY = 1000
@@ -268,7 +294,9 @@ async function downloadProfileAvatars(
     type: string
     metadata?: any
     content?: ContentMapping[] | undefined
-  }
+  },
+  downloadQueue: PQueue,
+  scheduler?: ContentDownloadScheduler
 ) {
   const { hashes: snapshots, truncated } = avatarSnapshotHashesFrom(entityMetadata)
   if (truncated) {
@@ -287,10 +315,9 @@ async function downloadProfileAvatars(
     entityId,
     snapshots: truncateForLog(snapshots.join(','))
   })
-  const downloadQueue = new PQueue({ concurrency })
   await Promise.all(
     snapshots.map((snapshot) =>
-      downloadQueue.add(() =>
+      scheduleContentDownload(scheduler, downloadQueue, () =>
         downloadFileWithRetries(
           components,
           snapshot,
@@ -311,37 +338,25 @@ async function downloadProfileAvatars(
   )
 }
 
-/**
- * Downloads an entity and its dependency files to a folder in the disk.
- *
- * Returns the parsed JSON file of the deployed entityHash
- *
- * @remarks When the locally stored entity file fails content-hash verification (a truncated or
- * partial local write), the corrupt copy is evicted from storage and the call throws — recovery
- * relies on the caller retrying, which re-downloads and hash-verifies a clean copy. One-shot
- * callers that never retry should be aware the first such call only heals the cache, it does not
- * return the entity.
- * @param contentFilesConcurrency - Maximum number of content files to download in parallel for this
- *   entity. Defaults to {@link DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY} (10).
- * @public
- */
-export async function downloadEntityAndContentFiles(
+async function downloadEntityAndContentFilesWithResult(
   components: Pick<SnapshotsFetcherComponents, 'fetcher' | 'logs' | 'metrics' | 'storage'>,
   entityId: EntityHash,
   presentInServers: string[],
-  _serverMapLRU: Map<Server, number>,
+  serverMapLRU: Map<Server, number>,
   targetFolder: string,
   maxRetries: number,
   waitTimeBetweenRetries: number,
-  contentFilesConcurrency: number = DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY,
-  transferLimits?: TransferLimits
-): Promise<unknown> {
+  contentFilesConcurrency: number,
+  transferLimits?: TransferLimits,
+  scheduler?: ContentDownloadScheduler
+): Promise<DownloadedEntity> {
   // Checked before any work, not where the queue is built: p-queue rejects a bad concurrency with its own
   // TypeError, and by then the entity file and the profile-avatar fallbacks have already been downloaded.
   // A caller passing 0 deserves to be told in this package's terms, before spending requests.
   if (!Number.isInteger(contentFilesConcurrency) || contentFilesConcurrency < 1) {
     throw new Error(`contentFilesConcurrency must be an integer >= 1, got ${contentFilesConcurrency}`)
   }
+  const downloadQueue = new PQueue({ concurrency: contentFilesConcurrency })
 
   const logger = components.logs.getLogger(`downloadEntityAndContentFiles)`)
 
@@ -351,7 +366,7 @@ export async function downloadEntityAndContentFiles(
     entityId,
     targetFolder,
     presentInServers,
-    _serverMapLRU,
+    serverMapLRU,
     maxRetries,
     waitTimeBetweenRetries,
     undefined,
@@ -445,28 +460,29 @@ export async function downloadEntityAndContentFiles(
       components,
       logger,
       presentInServers,
-      _serverMapLRU,
+      serverMapLRU,
       targetFolder,
       maxRetries,
       waitTimeBetweenRetries,
       contentFilesConcurrency,
       transferLimits,
       entityId,
-      entityMetadata
+      entityMetadata,
+      downloadQueue,
+      scheduler
     )
   }
 
   if (hashesToDownload.length > 0) {
-    const downloadQueue = new PQueue({ concurrency: contentFilesConcurrency })
     await Promise.all(
       hashesToDownload.map((hash) =>
-        downloadQueue.add(() =>
+        scheduleContentDownload(scheduler, downloadQueue, () =>
           downloadFileWithRetries(
             components,
             hash,
             targetFolder,
             presentInServers,
-            _serverMapLRU,
+            serverMapLRU,
             maxRetries,
             waitTimeBetweenRetries,
             undefined,
@@ -477,5 +493,73 @@ export async function downloadEntityAndContentFiles(
     )
   }
 
-  return entityMetadata
+  return { entity: entityMetadata, entityFile: buffer }
+}
+
+/**
+ * Downloads an entity and its dependency files to storage and returns its parsed JSON document.
+ *
+ * @remarks When the locally stored entity file fails content-hash verification, the corrupt copy is
+ * evicted and the call throws so a retry can download a clean copy.
+ * @param contentFilesConcurrency - Per-entity limit used when no global scheduler is supplied.
+ * @param scheduler - Optional caller-owned scheduler that globally bounds content transfers.
+ * @public
+ */
+export async function downloadEntityAndContentFiles(
+  components: Pick<SnapshotsFetcherComponents, 'fetcher' | 'logs' | 'metrics' | 'storage'>,
+  entityId: EntityHash,
+  presentInServers: string[],
+  serverMapLRU: Map<Server, number>,
+  targetFolder: string,
+  maxRetries: number,
+  waitTimeBetweenRetries: number,
+  contentFilesConcurrency: number = DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY,
+  transferLimits?: TransferLimits,
+  scheduler?: ContentDownloadScheduler
+): Promise<unknown> {
+  return (
+    await downloadEntityAndContentFilesWithResult(
+      components,
+      entityId,
+      presentInServers,
+      serverMapLRU,
+      targetFolder,
+      maxRetries,
+      waitTimeBetweenRetries,
+      contentFilesConcurrency,
+      transferLimits,
+      scheduler
+    )
+  ).entity
+}
+
+/**
+ * Downloads an entity and its content while returning the verified entity bytes so an immediate
+ * deploy does not retrieve and read the same storage item again.
+ * @public
+ */
+export async function downloadEntityAndContentFilesWithBuffer(
+  components: Pick<SnapshotsFetcherComponents, 'fetcher' | 'logs' | 'metrics' | 'storage'>,
+  entityId: EntityHash,
+  presentInServers: string[],
+  serverMapLRU: Map<Server, number>,
+  targetFolder: string,
+  maxRetries: number,
+  waitTimeBetweenRetries: number,
+  contentFilesConcurrency: number = DEFAULT_ENTITY_FILE_DOWNLOAD_CONCURRENCY,
+  transferLimits?: TransferLimits,
+  scheduler?: ContentDownloadScheduler
+): Promise<DownloadedEntity> {
+  return downloadEntityAndContentFilesWithResult(
+    components,
+    entityId,
+    presentInServers,
+    serverMapLRU,
+    targetFolder,
+    maxRetries,
+    waitTimeBetweenRetries,
+    contentFilesConcurrency,
+    transferLimits,
+    scheduler
+  )
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -91,6 +91,13 @@ export const metricsDefinitions = validateMetricsDeclaration({
     labelNames: ['from'] // from='snapshots'|'pointer-changes'
   },
 
+  dcl_bootstrap_phase_duration_seconds: {
+    help: 'Wall-clock duration of each bootstrap pipeline phase',
+    type: 'histogram',
+    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 300, 900, 3600],
+    labelNames: ['phase']
+  },
+
   dcl_syncing_servers: {
     help: 'Servers that are in bootstrapping state',
     type: 'gauge'

--- a/src/stream-entities.ts
+++ b/src/stream-entities.ts
@@ -1,8 +1,9 @@
-import { PointerChangesSyncDeployment } from '@dcl/schemas'
+import { PointerChangesSyncDeployment, SyncDeployment } from '@dcl/schemas'
 import { createHash } from 'crypto'
+import * as fs from 'fs'
 import { fetchPointerChanges } from './client'
-import { downloadFileWithRetries } from './downloader'
-import { processDeploymentsInFile, SnapshotStreamReport } from './file-processor'
+import { downloadFileToTemporaryFileWithRetries, downloadFileWithRetries } from './downloader'
+import { processDeploymentsInFile, processDeploymentsInStream, SnapshotStreamReport } from './file-processor'
 import { assertPointerChangesDeploymentWithinStructuralLimits } from './pointer-changes-limits'
 import {
   PointerChangesDeployedEntityStreamOptions,
@@ -13,6 +14,16 @@ import { contentServerMetricLabels, sleepUnlessStopped } from './utils'
 
 export { metricsDefinitions } from './metrics'
 export { IDeployerComponent, SynchronizerComponent } from './types'
+
+async function closeReadStream(stream: fs.ReadStream | undefined): Promise<void> {
+  if (!stream || stream.closed) {
+    return
+  }
+  await new Promise<void>((resolve) => {
+    stream.once('close', resolve)
+    stream.destroy()
+  })
+}
 
 /**
  * Accepts a fromTimestamp option to filter out previous deployments.
@@ -28,7 +39,8 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
   snapshotHash: string,
   servers: Set<string>,
   shouldStop: () => boolean = () => false,
-  report?: SnapshotStreamReport
+  report?: SnapshotStreamReport,
+  beforeStreaming?: Promise<void>
 ) {
   const genesisTimestamp = options.fromTimestamp || 0
   const logs = components.logs.getLogger('getDeployedEntitiesStreamFromSnapshot')
@@ -36,22 +48,52 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
   // one array allocation per entity in the snapshot.
   const serversList = Array.from(servers)
   logs.info('Snapshot to be processed.', { hash: snapshotHash, contentServers: JSON.stringify(serversList) })
+  let temporaryFile: Awaited<ReturnType<typeof downloadFileToTemporaryFileWithRetries>> | undefined
+  let temporaryReadStream: fs.ReadStream | undefined
+  let usedPersistentStorage = false
   try {
-    // 1. download the snapshot file if needed
-    await downloadFileWithRetries(
-      components,
-      snapshotHash,
-      options.tmpDownloadFolder,
-      serversList,
-      new Map(),
-      options.requestMaxRetries,
-      options.requestRetryWaitTime,
-      shouldStop,
-      options.transferLimits
-    )
+    // The default lifecycle deletes snapshots immediately after parsing. In that mode, bypass the
+    // persistent content store and parse the verified temp file directly. Preserve the old storage
+    // path when the snapshot is already cached or the caller explicitly asked to retain it.
+    if (options.deleteSnapshotAfterUsage !== false && !(await components.storage.exist(snapshotHash))) {
+      temporaryFile = await downloadFileToTemporaryFileWithRetries(
+        components,
+        snapshotHash,
+        options.tmpDownloadFolder,
+        serversList,
+        options.requestMaxRetries,
+        options.requestRetryWaitTime,
+        shouldStop,
+        options.transferLimits
+      )
+    } else {
+      usedPersistentStorage = true
+      await downloadFileWithRetries(
+        components,
+        snapshotHash,
+        options.tmpDownloadFolder,
+        serversList,
+        new Map(),
+        options.requestMaxRetries,
+        options.requestRetryWaitTime,
+        shouldStop,
+        options.transferLimits
+      )
+    }
 
-    // 2. open the snapshot file and process line by line
-    const deploymentsInFile = processDeploymentsInFile(snapshotHash, components, logs, report)
+    // Allows the synchronizer's bounded workers to prefetch and verify snapshots while the deployer
+    // warms up, without exposing a single entity before that prerequisite succeeds.
+    await beforeStreaming
+
+    let deploymentsInFile: AsyncIterable<SyncDeployment>
+    if (temporaryFile) {
+      // Created only after the gate resolves. A rejected warm-up therefore owns no unread file handle.
+      temporaryReadStream = fs.createReadStream(temporaryFile.filename)
+      deploymentsInFile = processDeploymentsInStream(temporaryReadStream, logs, report)
+    } else {
+      deploymentsInFile = processDeploymentsInFile(snapshotHash, components, logs, report)
+    }
+
     for await (const deployment of deploymentsInFile) {
       if (deployment.entityTimestamp >= genesisTimestamp) {
         // Empty remote_server: a snapshot is content-addressed and usually advertised by several
@@ -68,7 +110,11 @@ export async function* getDeployedEntitiesStreamFromSnapshot(
       }
     }
   } finally {
-    if (options.deleteSnapshotAfterUsage !== false) {
+    // processDeploymentsInStream deliberately leaves caller-owned streams open. This path owns its
+    // ReadStream, so close it on full consumption, cancellation, parser failure, and generator return.
+    await closeReadStream(temporaryReadStream)
+    await temporaryFile?.cleanup()
+    if (usedPersistentStorage && options.deleteSnapshotAfterUsage !== false) {
       try {
         await components.storage.delete([snapshotHash])
       } catch (err: any) {

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -95,6 +95,14 @@ export async function createSynchronizer(
   )
 
   const logger = components.logs.getLogger('synchronizer')
+  async function measureBootstrapPhase<T>(phase: string, action: () => Promise<T>): Promise<T> {
+    const { end } = components.metrics.startTimer('dcl_bootstrap_phase_duration_seconds', { phase })
+    try {
+      return await action()
+    } finally {
+      end()
+    }
+  }
   const genesisTimestamp = options.fromTimestamp || 0
   const bootstrappingServersFromSnapshots: Set<string> = new Set()
   const bootstrappingServersFromPointerChanges: Set<string> = new Set()
@@ -214,40 +222,42 @@ export async function createSynchronizer(
     const serversWithFailedSnapshots = new Set<string>()
     // Fetch all servers concurrently; getSnapshots already runs through the concurrency-limited
     // downloadQueue. The synchronous map mutations below can't interleave (no await between them).
-    await Promise.all(
-      Array.from(serversToSync).map(async (server) => {
-        try {
-          const { snapshots, discardedEntries } = await getSnapshots(
-            components,
-            server,
-            options.requestMaxRetries,
-            options.transferLimits
-          )
-          if (discardedEntries > 0) {
-            // The surviving subset is not this server's history. Each discarded entry stood for a time
-            // range, so deploying only what parsed and then advancing past the newest of them would skip
-            // whatever lived in the ranges we threw away. Still deploy what we can read — that work is
-            // real — but keep the server in snapshot bootstrap so the list is fetched again.
-            logger.warn('Snapshot list was not fully readable; keeping the server in snapshot bootstrap.', {
+    await measureBootstrapPhase('snapshot_discovery', async () =>
+      Promise.all(
+        Array.from(serversToSync).map(async (server) => {
+          try {
+            const { snapshots, discardedEntries } = await getSnapshots(
+              components,
               server,
-              discardedEntries: String(discardedEntries)
-            })
-            serversWithFailedSnapshots.add(server)
+              options.requestMaxRetries,
+              options.transferLimits
+            )
+            if (discardedEntries > 0) {
+              // The surviving subset is not this server's history. Each discarded entry stood for a time
+              // range, so deploying only what parsed and then advancing past the newest of them would skip
+              // whatever lived in the ranges we threw away. Still deploy what we can read — that work is
+              // real — but keep the server in snapshot bootstrap so the list is fetched again.
+              logger.warn('Snapshot list was not fully readable; keeping the server in snapshot bootstrap.', {
+                server,
+                discardedEntries: String(discardedEntries)
+              })
+              serversWithFailedSnapshots.add(server)
+            }
+            // A server may legitimately have no snapshots yet (e.g. brand new). Math.max() of an empty
+            // list is -Infinity, so fall back to the genesis timestamp to keep a sane starting point.
+            const lastTimestamp =
+              snapshots.length > 0 ? Math.max(...snapshots.map((s) => s.timeRange.endTimestamp)) : genesisTimestamp
+            snapshotLastTimestampByServer.set(server, lastTimestamp)
+            for (const snapshot of snapshots) {
+              const snapshotMetadatas = snapshotsByHash.get(snapshot.hash) ?? []
+              snapshotMetadatas.push({ ...snapshot, server })
+              snapshotsByHash.set(snapshot.hash, snapshotMetadatas)
+            }
+          } catch (error) {
+            logger.info(`Error getting snapshots from ${server}.`)
           }
-          // A server may legitimately have no snapshots yet (e.g. brand new). Math.max() of an empty
-          // list is -Infinity, so fall back to the genesis timestamp to keep a sane starting point.
-          const lastTimestamp =
-            snapshots.length > 0 ? Math.max(...snapshots.map((s) => s.timeRange.endTimestamp)) : genesisTimestamp
-          snapshotLastTimestampByServer.set(server, lastTimestamp)
-          for (const snapshot of snapshots) {
-            const snapshotMetadatas = snapshotsByHash.get(snapshot.hash) ?? []
-            snapshotMetadatas.push({ ...snapshot, server })
-            snapshotsByHash.set(snapshot.hash, snapshotMetadatas)
-          }
-        } catch (error) {
-          logger.info(`Error getting snapshots from ${server}.`)
-        }
-      })
+        })
+      )
     )
 
     const deploymentsProcessorsQueue = new PQueue({
@@ -322,6 +332,10 @@ export async function createSynchronizer(
     // Which servers advertised each snapshot we are about to deploy, so the marker re-check after the
     // deployer drains can attribute an unfinished snapshot back to them.
     const serversBySnapshotDeployed = new Map<string, Set<string>>()
+    const deployerReady = future<void>()
+    // Workers attach their await only after downloading a snapshot. Handle a warm-up rejection from
+    // creation time as well, so a fast failure cannot become temporarily unhandled while downloads run.
+    void deployerReady.catch(() => undefined)
     for (const [snapshotHash, snapshots] of snapshotsToDeploy) {
       const servers = new Set(snapshots.map((s) => s.server))
       serversBySnapshotDeployed.set(snapshotHash, servers)
@@ -343,7 +357,8 @@ export async function createSynchronizer(
               options,
               snapshotHash,
               servers,
-              () => isStopped || !Array.from(servers).some((server) => desiredServers.has(server))
+              () => isStopped || !Array.from(servers).some((server) => desiredServers.has(server)),
+              deployerReady
             )
           } catch (err: any) {
             // Recorded inside the job (not in a .catch on the add() promise) so the set is
@@ -366,18 +381,44 @@ export async function createSynchronizer(
       return new Set()
     }
 
-    logger.info('Warming up deployer.')
-    await components.deployer.prepareForDeploymentsIn(timeRangesOfEntitiesToDeploy)
-
-    logger.info('Starting to deploy entities from snapshots.')
+    // Start the bounded workers before warm-up. Each worker may download and verify one snapshot but
+    // waits on deployerReady before parsing, so network/disk I/O overlaps the database scan without
+    // scheduling an entity too early or prefetching more than snapshotDeploymentsConcurrency files.
+    const { end: endSnapshotPipelineTimer } = components.metrics.startTimer('dcl_bootstrap_phase_duration_seconds', {
+      phase: 'snapshot_prefetch_and_stream'
+    })
     deploymentsProcessorsQueue.start()
+    logger.info('Warming up deployer while snapshot workers prefetch.')
+    try {
+      await measureBootstrapPhase('snapshot_deployer_warmup', async () =>
+        components.deployer.prepareForDeploymentsIn(timeRangesOfEntitiesToDeploy)
+      )
+      deployerReady.resolve()
+    } catch (error) {
+      // Do not let workers that have not started yet download snapshots after the prerequisite has
+      // already failed. Running workers are allowed to finish their current transfer and then observe
+      // the rejected gate, which gives their verified temporary files a chance to clean up normally.
+      deploymentsProcessorsQueue.pause()
+      deploymentsProcessorsQueue.clear()
+      deployerReady.reject(error instanceof Error ? error : new Error(String(error)))
+      try {
+        await deploymentsProcessorsQueue.onIdle()
+      } finally {
+        endSnapshotPipelineTimer()
+      }
+      throw error
+    }
 
-    await deploymentsProcessorsQueue.onIdle()
+    try {
+      await deploymentsProcessorsQueue.onIdle()
+    } finally {
+      endSnapshotPipelineTimer()
+    }
     // The queue draining only means every snapshot finished STREAMING. Per IDeployerComponent,
     // scheduleEntityDeployment may resolve before the entity is deployed and onIdle() is the drain
     // signal, so with a batching deployer the entities are still in flight here. Advancing a server's
     // timestamp now would resume its pointer-changes past entities that had only been scheduled.
-    await components.deployer.onIdle()
+    await measureBootstrapPhase('snapshot_deployer_drain', async () => components.deployer.onIdle())
     logger.info('End deploying entities from snapshots.')
 
     // Draining proves the deployer's queue is empty, NOT that every scheduled entity reported back

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -451,8 +451,6 @@ export async function downloadContentFileToTemporaryFile(
       checkHash && verifyDuringDownload ? hash : undefined
     )
 
-    // make files not executable
-    await fs.promises.chmod(tmpFileName, 0o644)
     if (checkHash && !verifyDuringDownload) {
       try {
         await assertHash(tmpFileName, hash)
@@ -837,6 +835,23 @@ export function createDownloadTransforms(isGzip: boolean, limits: ResolvedTransf
   return transforms
 }
 
+/**
+ * Opens a download target without following or replacing an existing filesystem entry.
+ *
+ * @internal
+ */
+export function createPrivateDownloadWriteStream(filename: string): fs.WriteStream {
+  return fs.createWriteStream(filename, {
+    emitClose: true,
+    // The random suffix already makes a collision impractical; O_EXCL turns that assumption into an
+    // enforced filesystem invariant.
+    flags: 'wx',
+    // Temporary bytes are only consumed by this process. Keep them owner-only from the first write
+    // instead of creating them with umask-dependent permissions and tightening them later.
+    mode: 0o600
+  })
+}
+
 class DownloadHashVerificationError extends Error {}
 
 /**
@@ -1050,9 +1065,7 @@ function downloadFile(
             return
           }
 
-          const file = fs.createWriteStream(tmpFileName, {
-            emitClose: true
-          })
+          const file = createPrivateDownloadWriteStream(tmpFileName)
 
           const transforms = createDownloadTransforms(isGzip, limits)
           if (expectedHash) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import * as https from 'https'
 import * as net from 'net'
 import { LookupFunction } from 'net'
 import * as path from 'path'
-import { Readable, Transform } from 'stream'
+import { PassThrough, Readable, Transform } from 'stream'
 import { pipeline as streamPipeline } from 'stream/promises'
 import * as zlib from 'zlib'
 import { ContentServerMetricLabels } from './metrics'
@@ -405,6 +405,75 @@ export async function assertHash(filename: string, hash: string) {
   }
 }
 
+export type VerifiedTemporaryFile = {
+  filename: string
+  cleanup(): Promise<void>
+}
+
+/**
+ * Downloads and hash-verifies a content-addressed file, leaving the verified temporary file under
+ * caller ownership. This is used for one-shot snapshot parsing so the bytes do not need to be copied
+ * into persistent content storage and immediately read and deleted again.
+ */
+export async function downloadContentFileToTemporaryFile(
+  components: { metrics?: SnapshotsFetcherComponents['metrics'] },
+  originalUrlString: string,
+  destinationFilename: string,
+  hash: string,
+  checkHash: boolean = true,
+  transferLimits?: TransferLimits,
+  verifyDuringDownload: boolean = true
+): Promise<VerifiedTemporaryFile> {
+  const limits = resolveTransferLimits(transferLimits)
+  const tmpFolder = path.dirname(destinationFilename)
+  await ensureFolderExists(tmpFolder)
+  if (checkHash && !isVerifiableContentHash(hash)) {
+    throw new Error(`Unknown hashing algorithm for hash: ${hash}`)
+  }
+
+  // A 128-bit random suffix on a content-addressed path gives concurrent callers independent files;
+  // colliding requires the same hash and random suffix. Not worth an existence check on every download.
+  const tmpFileName = destinationFilename + crypto.randomBytes(16).toString('hex')
+
+  const metricsLabels: ContentServerMetricLabels = {
+    remote_server: ''
+  }
+
+  try {
+    // Hash verification is part of the network-to-disk pipeline, so the completed file does not need
+    // to be opened and read a second time before the caller can use it.
+    await downloadFile(
+      originalUrlString,
+      metricsLabels,
+      components,
+      tmpFileName,
+      limits,
+      checkHash && verifyDuringDownload ? hash : undefined
+    )
+
+    // make files not executable
+    await fs.promises.chmod(tmpFileName, 0o644)
+    if (checkHash && !verifyDuringDownload) {
+      try {
+        await assertHash(tmpFileName, hash)
+      } catch (error) {
+        components.metrics?.increment('dcl_content_download_hash_errors_total', metricsLabels)
+        throw error
+      }
+    }
+
+    return {
+      filename: tmpFileName,
+      cleanup: async () => await deleteFileIfPresent(tmpFileName)
+    }
+  } catch (e) {
+    // The folder may have been removed from under us; forget it so a retry recreates it.
+    ensuredFolders.delete(tmpFolder)
+    await deleteFileIfPresent(tmpFileName)
+    throw e
+  }
+}
+
 export async function saveContentFileToDisk(
   components: Pick<SnapshotsFetcherComponents, 'storage'> & { metrics?: SnapshotsFetcherComponents['metrics'] },
   originalUrlString: string,
@@ -413,51 +482,26 @@ export async function saveContentFileToDisk(
   checkHash: boolean = true,
   transferLimits?: TransferLimits
 ): Promise<void> {
-  const limits = resolveTransferLimits(transferLimits)
-  const tmpFolder = path.dirname(destinationFilename)
-  await ensureFolderExists(tmpFolder)
-
-  // A 128-bit random suffix on a content-addressed path: a collision needs the same hash *and* the
-  // same suffix, and concurrent downloads of one hash already share a single job. Not worth an
-  // existence check (a syscall) on every downloaded file.
-  const tmpFileName = destinationFilename + crypto.randomBytes(16).toString('hex')
-
-  const metricsLabels: ContentServerMetricLabels = {
-    remote_server: ''
-  }
-
+  const temporaryFile = await downloadContentFileToTemporaryFile(
+    components,
+    originalUrlString,
+    destinationFilename,
+    hash,
+    checkHash,
+    transferLimits,
+    // Persistent content is usually small and may be downloaded in very large batches. Keep its
+    // lightweight existing verification path; one-shot snapshots opt into the streaming verifier,
+    // where avoiding another full read of a large file materially improves bootstrap I/O.
+    false
+  )
   try {
-    await downloadFile(originalUrlString, metricsLabels, components, tmpFileName, limits)
-
-    // make files not executable
-    await fs.promises.chmod(tmpFileName, 0o644)
-
-    // check hash if present. delete file and fail in case of mismatch
-    if (checkHash) {
-      try {
-        await assertHash(tmpFileName, hash)
-      } catch (e) {
-        components.metrics?.increment('dcl_content_download_hash_errors_total', metricsLabels)
-        // delete the downloaded file if failed
-        await deleteFileIfPresent(tmpFileName)
-        throw e
-      }
-    }
-
-    // move downloaded file to target folder
-    const storedStream = fs.createReadStream(tmpFileName)
+    const storedStream = fs.createReadStream(temporaryFile.filename)
     // storage is supplied by the consumer. A component that resolves storeStream without consuming the
-    // stream leaves it to open the temp file after the finally below has removed it, and an unhandled
-    // 'error' event takes the whole process down. Absorb it here: a real read failure still reaches the
-    // storage component through its own consumption of the stream.
+    // stream leaves it to open the temp file after cleanup and would otherwise emit an unhandled error.
     storedStream.on('error', () => undefined)
     await components.storage.storeStream(hash, storedStream)
-  } catch (e) {
-    // The folder may have been removed from under us; forget it so a retry recreates it.
-    ensuredFolders.delete(tmpFolder)
-    throw e
   } finally {
-    await deleteFileIfPresent(tmpFileName)
+    await temporaryFile.cleanup()
   }
 }
 
@@ -793,12 +837,77 @@ export function createDownloadTransforms(isGzip: boolean, limits: ResolvedTransf
   return transforms
 }
 
+class DownloadHashVerificationError extends Error {}
+
+/**
+ * Tees every decoded download chunk into the package's CID hasher while forwarding the same chunk to
+ * disk. Hashing therefore shares the network-to-disk pass instead of opening and reading the finished
+ * file again. The side stream is backpressured so hashing cannot lag behind and grow memory without bound.
+ */
+function createDownloadHashVerifier(expectedHash: string, filename: string): Transform {
+  const hashInput = new PassThrough()
+  const calculatedHash = expectedHash.startsWith('Qm')
+    ? hashV0(hashInput as any)
+    : expectedHash.startsWith('ba')
+    ? hashV1(hashInput as any)
+    : undefined
+
+  if (!calculatedHash) {
+    throw new DownloadHashVerificationError(`Unknown hashing algorithm for hash: ${expectedHash}`)
+  }
+
+  const verification = calculatedHash
+    .then((calculated) => {
+      if (calculated !== expectedHash) {
+        throw new DownloadHashVerificationError(
+          `Download error: hashes do not match(expected:${expectedHash} != calculated:${calculated}) for file ${filename}`
+        )
+      }
+    })
+    .catch((error: unknown) => {
+      if (error instanceof DownloadHashVerificationError) {
+        throw error
+      }
+      throw new DownloadHashVerificationError(error instanceof Error ? error.message : String(error))
+    })
+
+  // If the output side fails before flush() gets to await verification, destroying the side stream can
+  // reject the hasher. Attach a handler immediately so that rejection is never temporarily unhandled.
+  void verification.catch(() => undefined)
+
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      hashInput.write(chunk, (error) => {
+        if (error) {
+          callback(error)
+        } else {
+          callback(null, chunk)
+        }
+      })
+    },
+    flush(callback) {
+      hashInput.end()
+      verification.then(
+        () => callback(),
+        (error) => callback(error)
+      )
+    },
+    destroy(error, callback) {
+      // The pipeline already owns and reports `error`. Passing it into this private side stream can
+      // emit a second, temporarily listener-less error while the hasher is being torn down.
+      hashInput.destroy()
+      callback(error)
+    }
+  })
+}
+
 function downloadFile(
   originalUrlString: string,
   metricsLabels: ContentServerMetricLabels,
   components: { metrics?: SnapshotsFetcherComponents['metrics'] },
   tmpFileName: string,
-  limits: ResolvedTransferLimits
+  limits: ResolvedTransferLimits,
+  expectedHash?: string
 ) {
   return new Promise<void>((resolve, reject) => {
     // One timer for the whole download instead of one per redirect hop: a hop that redirects never
@@ -945,7 +1054,11 @@ function downloadFile(
             emitClose: true
           })
 
-          const pipe = streamPipeline([response, ...createDownloadTransforms(isGzip, limits), file])
+          const transforms = createDownloadTransforms(isGzip, limits)
+          if (expectedHash) {
+            transforms.push(createDownloadHashVerifier(expectedHash, tmpFileName))
+          }
+          const pipe = streamPipeline([response, ...transforms, file])
 
           pipe
             .then(() => {
@@ -954,6 +1067,9 @@ function downloadFile(
             })
             .catch((err) => {
               file.close()
+              if (err instanceof DownloadHashVerificationError) {
+                components.metrics?.increment('dcl_content_download_hash_errors_total', metricsLabels)
+              }
               settleWithError(err)
             })
         }

--- a/test/downloadEntityFileConcurrency.spec.ts
+++ b/test/downloadEntityFileConcurrency.spec.ts
@@ -2,7 +2,7 @@ import { createInMemoryStorage } from '@dcl/catalyst-storage'
 import { createReadStream } from 'fs'
 import { resolve } from 'path'
 import { Readable } from 'stream'
-import { downloadEntityAndContentFiles } from '../src'
+import { createJobQueue, downloadEntityAndContentFiles } from '../src'
 import { sleep } from '../src/utils'
 import { test } from './components'
 
@@ -56,6 +56,51 @@ test('downloadEntityAndContentFiles content download concurrency', ({ components
       for (const hash of contentHashes) {
         expect(await storage.exist(hash)).toBe(true)
       }
+    })
+  })
+
+  describe('when a caller-owned global scheduler is configured', () => {
+    let storage: ReturnType<typeof createInMemoryStorage>
+    let scheduler: ReturnType<typeof createJobQueue>
+    let entityIds: string[]
+    let server: string
+
+    beforeEach(async () => {
+      inFlight = 0
+      maxInFlight = 0
+      storage = createInMemoryStorage()
+      scheduler = createJobQueue({ autoStart: true, concurrency: 1 })
+      entityIds = ['sceneentitydownloadglobalqueueone', 'sceneentitydownloadglobalqueuetwo']
+      server = await components.getBaseUrl()
+      for (const [entityIndex, concurrentEntityId] of entityIds.entries()) {
+        const hashes = contentHashes.slice(entityIndex * 2, entityIndex * 2 + 2)
+        const entity = {
+          type: 'scene',
+          content: hashes.map((hash, index) => ({ file: `entity-${entityIndex}-file-${index}`, hash }))
+        }
+        await storage.storeStream(concurrentEntityId, Readable.from([Buffer.from(JSON.stringify(entity))]))
+      }
+    })
+
+    it('should enforce one bound across concurrent entities', async () => {
+      await Promise.all(
+        entityIds.map((concurrentEntityId) =>
+          downloadEntityAndContentFiles(
+            { fetcher: components.fetcher, logs: components.logs, metrics: components.metrics, storage },
+            concurrentEntityId,
+            [server],
+            new Map(),
+            contentFolder,
+            10,
+            0,
+            4,
+            undefined,
+            scheduler
+          )
+        )
+      )
+
+      expect(maxInFlight).toEqual(1)
     })
   })
 })

--- a/test/downloadStreamingHash.spec.ts
+++ b/test/downloadStreamingHash.spec.ts
@@ -1,35 +1,101 @@
 import { resolve } from 'path'
 import { Readable } from 'stream'
-import { downloadContentFileToTemporaryFile } from '../src/utils'
+import {
+  createPrivateDownloadWriteStream,
+  downloadContentFileToTemporaryFile,
+  VerifiedTemporaryFile
+} from '../src/utils'
 import { test } from './components'
 
 const fs = jest.requireActual<typeof import('fs')>('fs')
 const contentHash = 'QmazJLZfUmZgNMTdwWSmJRvw4dBfcjS9GuqkwkKGRWb4K6'
 const contentBody = fs.readFileSync(`test/fixtures/${contentHash}`)
 
-test('downloadContentFileToTemporaryFile streaming hash verification', ({ components }) => {
-  let createReadStream: jest.SpyInstance
+describe('createPrivateDownloadWriteStream', () => {
+  describe('when the target path already exists', () => {
+    let targetFilename: string
+    let writeError: NodeJS.ErrnoException
+    let existingContents: string
+
+    beforeEach(async () => {
+      targetFilename = resolve('downloads', 'exclusive-download-target')
+      await fs.promises.mkdir(resolve('downloads'), { recursive: true })
+      await fs.promises.writeFile(targetFilename, 'preserve me', { mode: 0o600 })
+      const stream = createPrivateDownloadWriteStream(targetFilename)
+      writeError = await new Promise((resolveError) => stream.once('error', resolveError))
+      existingContents = await fs.promises.readFile(targetFilename, 'utf8')
+    })
+
+    it('should reject rather than following or overwriting the existing entry', () => {
+      expect(writeError.code).toBe('EEXIST')
+    })
+
+    it('should preserve the existing file contents', () => {
+      expect(existingContents).toBe('preserve me')
+    })
+
+    afterEach(async () => {
+      await fs.promises.unlink(targetFilename).catch(() => undefined)
+    })
+  })
+})
+
+test('when a streamed download matches its content hash', ({ components }) => {
+  let downloaded: VerifiedTemporaryFile
+  let downloadedMode: number
 
   it('prepares a hash-addressed content response', () => {
     components.router.get(`/contents/${contentHash}`, async () => ({ body: Readable.from([contentBody]) }))
   })
 
   it('downloads and verifies the content', async () => {
-    createReadStream = jest.spyOn(fs, 'createReadStream')
-    const downloaded = await downloadContentFileToTemporaryFile(
+    downloaded = await downloadContentFileToTemporaryFile(
       { metrics: components.metrics },
       `${await components.getBaseUrl()}/contents/${contentHash}`,
       resolve('downloads', contentHash),
       contentHash
     )
-    await downloaded.cleanup()
+    downloadedMode = (await fs.promises.stat(downloaded.filename)).mode & 0o777
   })
 
-  it('should not reopen the completed file for hash verification', () => {
-    expect(createReadStream).not.toHaveBeenCalled()
+  it('should keep the temporary file inaccessible to group and other users', () => {
+    expect(downloadedMode).toBe(0o600)
   })
 
-  afterAll(() => {
-    jest.restoreAllMocks()
+  afterAll(async () => {
+    await downloaded?.cleanup()
+  })
+})
+
+test('when a streamed download does not match its claimed content hash', ({ components }) => {
+  let remainingTemporaryFiles: string[]
+  let downloadError: unknown
+
+  it('prepares a response with bytes belonging to a different hash', () => {
+    components.router.get(`/contents/${contentHash}`, async () => ({ body: Readable.from(['tampered bytes']) }))
+  })
+
+  it('attempts the verified temporary download', async () => {
+    downloadError = await downloadContentFileToTemporaryFile(
+      { metrics: components.metrics },
+      `${await components.getBaseUrl()}/contents/${contentHash}`,
+      resolve('downloads', contentHash),
+      contentHash
+    ).catch((error) => error)
+    remainingTemporaryFiles = (await fs.promises.readdir(resolve('downloads'))).filter((filename) =>
+      filename.startsWith(contentHash)
+    )
+  })
+
+  it('should reject the bytes instead of exposing an unverified temporary file', () => {
+    expect(downloadError).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('hashes do not match')
+      })
+    )
+  })
+
+  it('should remove the mismatched temporary file', () => {
+    expect(remainingTemporaryFiles).toEqual([])
   })
 })

--- a/test/downloadStreamingHash.spec.ts
+++ b/test/downloadStreamingHash.spec.ts
@@ -1,0 +1,35 @@
+import { resolve } from 'path'
+import { Readable } from 'stream'
+import { downloadContentFileToTemporaryFile } from '../src/utils'
+import { test } from './components'
+
+const fs = jest.requireActual<typeof import('fs')>('fs')
+const contentHash = 'QmazJLZfUmZgNMTdwWSmJRvw4dBfcjS9GuqkwkKGRWb4K6'
+const contentBody = fs.readFileSync(`test/fixtures/${contentHash}`)
+
+test('downloadContentFileToTemporaryFile streaming hash verification', ({ components }) => {
+  let createReadStream: jest.SpyInstance
+
+  it('prepares a hash-addressed content response', () => {
+    components.router.get(`/contents/${contentHash}`, async () => ({ body: Readable.from([contentBody]) }))
+  })
+
+  it('downloads and verifies the content', async () => {
+    createReadStream = jest.spyOn(fs, 'createReadStream')
+    const downloaded = await downloadContentFileToTemporaryFile(
+      { metrics: components.metrics },
+      `${await components.getBaseUrl()}/contents/${contentHash}`,
+      resolve('downloads', contentHash),
+      contentHash
+    )
+    await downloaded.cleanup()
+  })
+
+  it('should not reopen the completed file for hash verification', () => {
+    expect(createReadStream).not.toHaveBeenCalled()
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+})

--- a/test/getDeployedEntitiesStreamFromSnapshot.spec.ts
+++ b/test/getDeployedEntitiesStreamFromSnapshot.spec.ts
@@ -39,6 +39,9 @@ test('fetches a stream from snapshots deleting the downloaded file', ({ componen
 
   it('fetches stream', async () => {
     const { storage } = spyComponents
+    await components.storage.delete([downloadedSnapshotFile])
+    storage.delete.mockClear()
+    storage.storeStream.mockClear()
 
     const servers = [await components.getBaseUrl()]
 
@@ -64,8 +67,9 @@ test('fetches a stream from snapshots deleting the downloaded file', ({ componen
       r.push(deployment)
     }
 
-    // the downloaded file must be deleted
-    expect(storage.delete).toHaveBeenCalledTimes(1)
+    // One-shot snapshots stay in the verified temp file instead of being copied into persistent storage.
+    expect(storage.storeStream).not.toHaveBeenCalled()
+    expect(storage.delete).not.toHaveBeenCalled()
 
     expect(r).toEqual([
       { entityType: 'profile', entityId: 'ba000000000000000000000000000000000000000000000000000000001', entityTimestamp: 1, authChain, pointers: ['0x1'], snapshotHash: downloadedSnapshotFile, servers },

--- a/test/publicApi.spec.ts
+++ b/test/publicApi.spec.ts
@@ -9,6 +9,7 @@ import {
   createSynchronizer,
   decideSnapshotDeploymentFromProcessedSet,
   downloadEntityAndContentFiles,
+  downloadEntityAndContentFilesWithBuffer,
   shouldDeployEntitiesFromSnapshotAndMarkAsProcessedIfNeeded,
   getDeployedEntitiesStreamFromPointerChanges,
   getDeployedEntitiesStreamFromSnapshot,
@@ -39,6 +40,7 @@ describe('the package root export', () => {
       'createSynchronizer',
       'decideSnapshotDeploymentFromProcessedSet',
       'downloadEntityAndContentFiles',
+      'downloadEntityAndContentFilesWithBuffer',
       'getDeployedEntitiesStreamFromPointerChanges',
       'getDeployedEntitiesStreamFromSnapshot',
       'metricsDefinitions',
@@ -104,9 +106,10 @@ describe('the package root export', () => {
     it('should expose the entity and stream helpers', () => {
       expect([
         downloadEntityAndContentFiles,
+        downloadEntityAndContentFilesWithBuffer,
         getDeployedEntitiesStreamFromSnapshot,
         getDeployedEntitiesStreamFromPointerChanges
-      ]).toEqual([expect.any(Function), expect.any(Function), expect.any(Function)])
+      ]).toEqual([expect.any(Function), expect.any(Function), expect.any(Function), expect.any(Function)])
     })
 
     it('should expose the snapshot-deployment decision helpers', () => {

--- a/test/snapshotTemporaryStreamLifecycle.spec.ts
+++ b/test/snapshotTemporaryStreamLifecycle.spec.ts
@@ -1,0 +1,112 @@
+import future from 'fp-future'
+import type { ReadStream } from 'fs'
+import { getDeployedEntitiesStreamFromSnapshot } from '../src/stream-entities'
+
+const fs = jest.requireActual<typeof import('fs')>('fs')
+const downloader = jest.requireActual<typeof import('../src/downloader')>('../src/downloader')
+const snapshotHash = 'bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu'
+const snapshotFixture = `test/fixtures/${snapshotHash}`
+
+function createComponents() {
+  return {
+    logs: {
+      getLogger: jest.fn().mockReturnValue({
+        info: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn()
+      })
+    },
+    storage: {
+      exist: jest.fn().mockResolvedValue(false),
+      delete: jest.fn()
+    }
+  } as any
+}
+
+const options = {
+  requestRetryWaitTime: 0,
+  requestMaxRetries: 1,
+  tmpDownloadFolder: 'downloads'
+}
+
+describe('getDeployedEntitiesStreamFromSnapshot temporary stream lifecycle', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when the readiness gate rejects after the snapshot was prefetched', () => {
+    let cleanup: jest.Mock
+    let createReadStream: jest.SpyInstance
+    let iterationError: unknown
+
+    beforeEach(async () => {
+      cleanup = jest.fn().mockResolvedValue(undefined)
+      createReadStream = jest.spyOn(fs, 'createReadStream')
+      jest.spyOn(downloader, 'downloadFileToTemporaryFileWithRetries').mockResolvedValue({
+        filename: snapshotFixture,
+        cleanup
+      })
+      const ready = future<void>()
+      void ready.catch(() => undefined)
+      const stream = getDeployedEntitiesStreamFromSnapshot(
+        createComponents(),
+        options,
+        snapshotHash,
+        new Set(['https://peer.example.com']),
+        () => false,
+        undefined,
+        ready
+      )
+      const iteration = stream.next()
+      ready.reject(new Error('warm-up failed'))
+      iterationError = await iteration.catch((error) => error)
+    })
+
+    it('should not open the temporary file before readiness succeeds', () => {
+      expect(createReadStream).not.toHaveBeenCalled()
+    })
+
+    it('should remove the prefetched temporary file', () => {
+      expect(cleanup).toHaveBeenCalledTimes(1)
+    })
+
+    it('should propagate the readiness failure', () => {
+      expect(iterationError).toEqual(new Error('warm-up failed'))
+    })
+  })
+
+  describe('when the consumer stops after the first deployment', () => {
+    let cleanup: jest.Mock
+    let openedReadStream: ReadStream
+
+    beforeEach(async () => {
+      cleanup = jest.fn().mockResolvedValue(undefined)
+      jest.spyOn(downloader, 'downloadFileToTemporaryFileWithRetries').mockResolvedValue({
+        filename: snapshotFixture,
+        cleanup
+      })
+      const originalCreateReadStream = fs.createReadStream
+      jest.spyOn(fs, 'createReadStream').mockImplementation(((...args: Parameters<typeof fs.createReadStream>) => {
+        openedReadStream = originalCreateReadStream(...args)
+        return openedReadStream
+      }) as typeof fs.createReadStream)
+
+      const stream = getDeployedEntitiesStreamFromSnapshot(
+        createComponents(),
+        options,
+        snapshotHash,
+        new Set(['https://peer.example.com'])
+      )
+      await stream.next()
+      await stream.return(undefined)
+    })
+
+    it('should close its owned file stream', () => {
+      expect(openedReadStream.closed).toBe(true)
+    })
+
+    it('should remove the temporary file after closing the stream', () => {
+      expect(cleanup).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/test/synchronizerWarmupFailure.spec.ts
+++ b/test/synchronizerWarmupFailure.spec.ts
@@ -1,0 +1,97 @@
+import future from 'fp-future'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { createSynchronizer } from '../src/synchronizer'
+import { SynchronizerComponent } from '../src/types'
+import { sleep } from '../src/utils'
+import { test } from './components'
+
+const snapshotHashes = [
+  'bafkreiwarmupfailureaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  'bafkreiwarmupfailurebbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  'bafkreiwarmupfailurecccccccccccccccccccccccccccccccccccccccccc'
+]
+const snapshotBody = readFileSync('test/fixtures/bafkreibivsdakhiouzuth2nr7c4d3iiolbobj32xhat3nzm5uwyi4raxwu')
+
+test('synchronizer when deployer warm-up fails during snapshot prefetch', ({ components }) => {
+  let synchronizer: SynchronizerComponent
+  let downloadRequests: number
+  let firstDownloadStarted: ReturnType<typeof future<void>>
+  let releaseFirstDownload: ReturnType<typeof future<void>>
+  let unhandledRejections: unknown[]
+  let onUnhandledRejection: (reason: unknown) => void
+
+  it('prepares snapshots whose first download overlaps the failing warm-up', () => {
+    downloadRequests = 0
+    firstDownloadStarted = future<void>()
+    releaseFirstDownload = future<void>()
+    unhandledRejections = []
+    onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason)
+    process.on('unhandledRejection', onUnhandledRejection)
+
+    components.router.get('/snapshots', async () => ({
+      body: snapshotHashes.map((hash, index) => ({
+        hash,
+        timeRange: { initTimestamp: index * 1000, endTimestamp: (index + 1) * 1000 }
+      }))
+    }))
+    for (const hash of snapshotHashes) {
+      components.router.get(`/contents/${hash}`, async () => {
+        downloadRequests++
+        firstDownloadStarted.resolve()
+        await releaseFirstDownload
+        return { body: snapshotBody }
+      })
+    }
+  })
+
+  it('runs the failing bootstrap attempt', async () => {
+    const { fetcher, downloadQueue, logs, storage, metrics, processedSnapshotStorage, snapshotStorage } = components
+    synchronizer = await createSynchronizer(
+      {
+        fetcher,
+        downloadQueue,
+        logs,
+        storage,
+        metrics,
+        processedSnapshotStorage,
+        snapshotStorage,
+        deployer: {
+          scheduleEntityDeployment: jest.fn(),
+          onIdle: jest.fn(),
+          prepareForDeploymentsIn: jest.fn(async () => {
+            await firstDownloadStarted
+            throw new Error('warm-up failed')
+          })
+        }
+      },
+      {
+        bootstrapReconnection: { reconnectTime: 60_000 },
+        syncingReconnection: { reconnectTime: 60_000 },
+        tmpDownloadFolder: resolve('downloads'),
+        requestMaxRetries: 1,
+        requestRetryWaitTime: 0,
+        pointerChangesWaitTime: 0,
+        concurrency: { snapshotDeployments: 1 }
+      }
+    )
+
+    await synchronizer.syncWithServers(new Set([await components.getBaseUrl()]))
+    await firstDownloadStarted
+    releaseFirstDownload.resolve()
+    await sleep(100)
+  })
+
+  it('should abandon snapshots that had not started downloading', () => {
+    expect(downloadRequests).toBe(1)
+  })
+
+  it('should keep the rejected readiness gate handled', () => {
+    expect(unhandledRejections).toEqual([])
+  })
+
+  afterAll(async () => {
+    process.off('unhandledRejection', onUnhandledRejection)
+    await synchronizer.stop?.()
+  })
+})


### PR DESCRIPTION
## Summary

- stream snapshot downloads directly into parsing instead of waiting for all files
- verify snapshot hashes during the download write, avoiding a second full-file read
- create temporary downloads exclusively with owner-only permissions
- share bounded content download concurrency across concurrent entity deployments
- cancel pending snapshot work when bootstrap warmup fails
- close temporary streams deterministically on gate rejection and early consumer termination
- expose queue and transfer metrics for tuning and observability

## Performance and safety

Snapshot verification is one-pass: decompression, compressed and decoded size enforcement, hashing, and disk writing happen in the same pipeline. Temporary targets use exclusive creation (`O_EXCL`) and mode `0600`, so an existing path is never followed or overwritten. Regular content and avatar downloads keep their lower-overhead verification path.

Bootstrap can overlap snapshot work while preserving bounded network and deployment concurrency. Fatal warmup failures abandon queued work immediately.

## Tests

- `yarn lint:check`
- `yarn build`
- `yarn test` — 63 suites, 628 tests passed
- adversarial coverage for CID mismatch rejection and cleanup, exclusive file creation, owner-only permissions, global concurrency, warmup failure cancellation, and temporary stream lifecycle

## Related

Consumed by decentraland/catalyst#1955. No package versions are changed in either PR, as requested.